### PR TITLE
T-05: Tenant data model — Redis routing + Supabase storage

### DIFF
--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -1,0 +1,193 @@
+'use server';
+
+import { redis } from '@/lib/redis';
+import {
+  createSupabaseServerClient,
+  createSupabaseServiceClient,
+} from '@/lib/supabase-server';
+import { isValidSlug } from '@/lib/tenant-validation';
+
+export type TenantRedisData = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+type ActionResponse<T = void> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+// ---------------------------------------------------------------------------
+// createTenant
+// ---------------------------------------------------------------------------
+export async function createTenant(data: {
+  name: string;
+  slug: string;
+}): Promise<ActionResponse<TenantRedisData>> {
+  if (!isValidSlug(data.slug)) {
+    return {
+      success: false,
+      error:
+        'Slug must be 3–63 characters, lowercase alphanumeric and hyphens only, and must not start or end with a hyphen.',
+    };
+  }
+
+  // Check Redis first (fast path)
+  const existingInRedis = await redis.get(`subdomain:${data.slug}`);
+  if (existingInRedis) {
+    return { success: false, error: 'This subdomain is already taken.' };
+  }
+
+  // Check Supabase (source of truth)
+  const serviceClient = createSupabaseServiceClient();
+  const { data: existing } = await serviceClient
+    .from('tenants')
+    .select('id')
+    .eq('slug', data.slug)
+    .maybeSingle();
+
+  if (existing) {
+    return { success: false, error: 'This subdomain is already taken.' };
+  }
+
+  // Insert into Supabase
+  const { data: tenant, error } = await serviceClient
+    .from('tenants')
+    .insert({ name: data.name, slug: data.slug })
+    .select('id, name, slug')
+    .single();
+
+  if (error || !tenant) {
+    return { success: false, error: 'Failed to create tenant.' };
+  }
+
+  // Store in Redis
+  const redisData: TenantRedisData = {
+    id: tenant.id,
+    name: tenant.name,
+    slug: tenant.slug,
+  };
+  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData));
+
+  // TODO (T-08): Create initial membership row for the creating user with role 'editor'.
+  // Requires the memberships table introduced in T-08.
+
+  return { success: true, data: redisData };
+}
+
+// ---------------------------------------------------------------------------
+// getTenantBySlug
+// ---------------------------------------------------------------------------
+export async function getTenantBySlug(
+  slug: string
+): Promise<ActionResponse<TenantRedisData>> {
+  // Redis fast path
+  const cached = await redis.get(`subdomain:${slug}`);
+  if (cached) {
+    return { success: true, data: JSON.parse(cached) as TenantRedisData };
+  }
+
+  // Fallback to Supabase
+  const serviceClient = createSupabaseServiceClient();
+  const { data: tenant } = await serviceClient
+    .from('tenants')
+    .select('id, name, slug')
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (!tenant) {
+    return { success: false, error: 'Tenant not found.' };
+  }
+
+  // Backfill Redis
+  const redisData: TenantRedisData = {
+    id: tenant.id,
+    name: tenant.name,
+    slug: tenant.slug,
+  };
+  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData));
+
+  return { success: true, data: redisData };
+}
+
+// ---------------------------------------------------------------------------
+// updateTenant
+// ---------------------------------------------------------------------------
+export async function updateTenant(
+  id: string,
+  data: { name?: string; slug?: string; logo_url?: string; timezone?: string }
+): Promise<ActionResponse<TenantRedisData>> {
+  const serviceClient = createSupabaseServiceClient();
+
+  if (data.slug !== undefined && !isValidSlug(data.slug)) {
+    return {
+      success: false,
+      error: 'Invalid slug format.',
+    };
+  }
+
+  // Get current record so we can clean up Redis if slug changes
+  const { data: current } = await serviceClient
+    .from('tenants')
+    .select('id, name, slug')
+    .eq('id', id)
+    .single();
+
+  if (!current) {
+    return { success: false, error: 'Tenant not found.' };
+  }
+
+  const { data: updated, error } = await serviceClient
+    .from('tenants')
+    .update({ ...data, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select('id, name, slug')
+    .single();
+
+  if (error || !updated) {
+    return { success: false, error: 'Failed to update tenant.' };
+  }
+
+  // If slug changed, remove old Redis key
+  if (data.slug && data.slug !== current.slug) {
+    await redis.del(`subdomain:${current.slug}`);
+  }
+
+  // Upsert Redis with latest data
+  const redisData: TenantRedisData = {
+    id: updated.id,
+    name: updated.name,
+    slug: updated.slug,
+  };
+  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData));
+
+  return { success: true, data: redisData };
+}
+
+// ---------------------------------------------------------------------------
+// deleteTenant
+// ---------------------------------------------------------------------------
+export async function deleteTenant(id: string): Promise<ActionResponse> {
+  const serviceClient = createSupabaseServiceClient();
+
+  // Fetch slug before deleting so we can remove the Redis key
+  const { data: tenant } = await serviceClient
+    .from('tenants')
+    .select('slug')
+    .eq('id', id)
+    .single();
+
+  if (!tenant) {
+    return { success: false, error: 'Tenant not found.' };
+  }
+
+  const { error } = await serviceClient.from('tenants').delete().eq('id', id);
+
+  if (error) {
+    return { success: false, error: 'Failed to delete tenant.' };
+  }
+
+  await redis.del(`subdomain:${tenant.slug}`);
+
+  return { success: true, data: undefined };
+}

--- a/lib/tenant-validation.test.ts
+++ b/lib/tenant-validation.test.ts
@@ -1,0 +1,60 @@
+import { isValidSlug } from '@/lib/tenant-validation';
+
+describe('isValidSlug', () => {
+  describe('valid slugs', () => {
+    it('accepts a simple lowercase slug', () => {
+      expect(isValidSlug('pierpont')).toBe(true);
+    });
+
+    it('accepts a slug with hyphens', () => {
+      expect(isValidSlug('my-golf-club')).toBe(true);
+    });
+
+    it('accepts a slug with numbers', () => {
+      expect(isValidSlug('club123')).toBe(true);
+    });
+
+    it('accepts exactly 3 characters', () => {
+      expect(isValidSlug('abc')).toBe(true);
+    });
+
+    it('accepts exactly 63 characters', () => {
+      expect(isValidSlug('a'.repeat(63))).toBe(true);
+    });
+  });
+
+  describe('invalid slugs', () => {
+    it('rejects slugs shorter than 3 characters', () => {
+      expect(isValidSlug('ab')).toBe(false);
+    });
+
+    it('rejects slugs longer than 63 characters', () => {
+      expect(isValidSlug('a'.repeat(64))).toBe(false);
+    });
+
+    it('rejects uppercase letters', () => {
+      expect(isValidSlug('MyClub')).toBe(false);
+    });
+
+    it('rejects slugs starting with a hyphen', () => {
+      expect(isValidSlug('-myclub')).toBe(false);
+    });
+
+    it('rejects slugs ending with a hyphen', () => {
+      expect(isValidSlug('myclub-')).toBe(false);
+    });
+
+    it('rejects slugs with spaces', () => {
+      expect(isValidSlug('my club')).toBe(false);
+    });
+
+    it('rejects slugs with special characters', () => {
+      expect(isValidSlug('my_club')).toBe(false);
+      expect(isValidSlug('my.club')).toBe(false);
+    });
+
+    it('rejects an empty string', () => {
+      expect(isValidSlug('')).toBe(false);
+    });
+  });
+});

--- a/lib/tenant-validation.ts
+++ b/lib/tenant-validation.ts
@@ -1,0 +1,11 @@
+/**
+ * Validates a tenant slug.
+ * Rules: lowercase alphanumeric and hyphens, 3–63 characters,
+ * must not start or end with a hyphen.
+ */
+export function isValidSlug(slug: string): boolean {
+  if (slug.length < 3 || slug.length > 63) return false;
+  if (!/^[a-z0-9-]+$/.test(slug)) return false;
+  if (slug.startsWith('-') || slug.endsWith('-')) return false;
+  return true;
+}

--- a/supabase/migrations/00001_create_tenants_table.sql
+++ b/supabase/migrations/00001_create_tenants_table.sql
@@ -3,6 +3,8 @@ CREATE TABLE tenants (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   name        TEXT NOT NULL,
   slug        TEXT NOT NULL UNIQUE,
+  logo_url    TEXT,
+  timezone    TEXT NOT NULL DEFAULT 'Europe/Brussels',
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
## Summary
- Updates migration `00001` to add `logo_url` (nullable) and `timezone` (default `Europe/Brussels`) columns
- Adds `lib/tenant-validation.ts` — `isValidSlug()`: lowercase alphanumeric + hyphens, 3–63 chars, no leading/trailing hyphens
- Adds `lib/tenant-validation.test.ts` — 13 tests covering valid slugs, boundary lengths, uppercase, bad chars, hyphen placement
- Adds `app/actions/tenants.ts` with four Server Actions:
  - **`createTenant`** — validates slug, checks uniqueness in Redis then Supabase, inserts to both. Membership row creation is a `TODO` flagged for T-08 (memberships table doesn't exist yet)
  - **`getTenantBySlug`** — Redis fast path → Supabase fallback → backfills Redis on miss
  - **`updateTenant`** — updates Supabase, rotates Redis key if slug changed
  - **`deleteTenant`** — fetches slug first, deletes from Supabase, then removes Redis key
- Redis key pattern changed from `{ emoji, createdAt }` to `{ id, name, slug }`

## Test plan
- [ ] `pnpm test:run` passes (13/13 slug validation tests)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)