### PR TITLE
T-06: Subdomain routing middleware

### DIFF
--- a/lib/subdomain.test.ts
+++ b/lib/subdomain.test.ts
@@ -1,0 +1,51 @@
+import { extractSubdomain } from '@/lib/subdomain';
+
+const ROOT = 'example.com';
+
+describe('extractSubdomain', () => {
+  describe('local development', () => {
+    it('extracts subdomain from tenant.localhost', () => {
+      expect(extractSubdomain('pierpont.localhost', 'localhost:3000')).toBe('pierpont');
+    });
+
+    it('returns null for bare localhost', () => {
+      expect(extractSubdomain('localhost', 'localhost:3000')).toBeNull();
+    });
+
+    it('strips port from root domain before comparing', () => {
+      expect(extractSubdomain('club.localhost', 'localhost:3000')).toBe('club');
+    });
+  });
+
+  describe('Vercel preview deployments', () => {
+    it('extracts tenant from tenant---branch.vercel.app', () => {
+      expect(extractSubdomain('pierpont---main.vercel.app', ROOT)).toBe('pierpont');
+    });
+
+    it('extracts tenant when branch name contains hyphens', () => {
+      expect(extractSubdomain('pierpont---feature-auth.vercel.app', ROOT)).toBe('pierpont');
+    });
+  });
+
+  describe('production', () => {
+    it('extracts subdomain from tenant.example.com', () => {
+      expect(extractSubdomain('pierpont.example.com', ROOT)).toBe('pierpont');
+    });
+
+    it('returns null for the root domain', () => {
+      expect(extractSubdomain('example.com', ROOT)).toBeNull();
+    });
+
+    it('returns null for www', () => {
+      expect(extractSubdomain('www.example.com', ROOT)).toBeNull();
+    });
+
+    it('strips port from hostname before comparing', () => {
+      expect(extractSubdomain('pierpont.example.com:3000', ROOT)).toBe('pierpont');
+    });
+
+    it('returns null when hostname equals root domain with port', () => {
+      expect(extractSubdomain('example.com:3000', 'example.com:3000')).toBeNull();
+    });
+  });
+});

--- a/lib/subdomain.ts
+++ b/lib/subdomain.ts
@@ -1,0 +1,36 @@
+/**
+ * Extracts the subdomain from a hostname string.
+ * Returns null if the hostname is the root domain (or www), meaning no tenant.
+ * Handles three environments:
+ *   - Local dev:        tenant.localhost
+ *   - Vercel preview:  tenant---branch.vercel.app
+ *   - Production:      tenant.yourdomain.com
+ */
+export function extractSubdomain(hostname: string, rootDomain: string): string | null {
+  // Strip port if present
+  const host = hostname.split(':')[0];
+  const root = rootDomain.split(':')[0];
+
+  // Local dev: [subdomain].localhost
+  if (host.endsWith('.localhost')) {
+    const sub = host.slice(0, host.length - '.localhost'.length);
+    return sub || null;
+  }
+
+  // Vercel preview: [subdomain]---branch-name.vercel.app
+  if (host.includes('---') && host.endsWith('.vercel.app')) {
+    const sub = host.split('---')[0];
+    return sub || null;
+  }
+
+  // Production: [subdomain].[rootDomain]
+  if (
+    host !== root &&
+    host !== `www.${root}` &&
+    host.endsWith(`.${root}`)
+  ) {
+    return host.slice(0, host.length - root.length - 1);
+  }
+
+  return null;
+}

--- a/lib/tenant.ts
+++ b/lib/tenant.ts
@@ -1,0 +1,33 @@
+import { headers } from 'next/headers';
+
+export type TenantContext = {
+  id: string;
+  slug: string;
+};
+
+/**
+ * Reads the tenant context injected by middleware into request headers.
+ * Throws if called outside of a tenant subdomain context.
+ */
+export async function getTenantFromHeaders(): Promise<TenantContext> {
+  const headersList = await headers();
+  const id = headersList.get('x-tenant-id');
+  const slug = headersList.get('x-tenant-slug');
+
+  if (!id || !slug) {
+    throw new Error(
+      'getTenantFromHeaders() called outside of a tenant context. ' +
+        'This function is only available in routes served under a tenant subdomain.'
+    );
+  }
+
+  return { id, slug };
+}
+
+/**
+ * Convenience shorthand — returns just the tenant ID.
+ */
+export async function getTenantId(): Promise<string> {
+  const { id } = await getTenantFromHeaders();
+  return id;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,73 +1,60 @@
-import { type NextRequest, NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { extractSubdomain } from '@/lib/subdomain';
 import { rootDomain } from '@/lib/utils';
+import type { TenantRedisData } from '@/app/actions/tenants';
 
-function extractSubdomain(request: NextRequest): string | null {
-  const url = request.url;
-  const host = request.headers.get('host') || '';
-  const hostname = host.split(':')[0];
-
-  // Local development environment
-  if (url.includes('localhost') || url.includes('127.0.0.1')) {
-    // Try to extract subdomain from the full URL
-    const fullUrlMatch = url.match(/http:\/\/([^.]+)\.localhost/);
-    if (fullUrlMatch && fullUrlMatch[1]) {
-      return fullUrlMatch[1];
-    }
-
-    // Fallback to host header approach
-    if (hostname.includes('.localhost')) {
-      return hostname.split('.')[0];
-    }
-
-    return null;
-  }
-
-  // Production environment
-  const rootDomainFormatted = rootDomain.split(':')[0];
-
-  // Handle preview deployment URLs (tenant---branch-name.vercel.app)
-  if (hostname.includes('---') && hostname.endsWith('.vercel.app')) {
-    const parts = hostname.split('---');
-    return parts.length > 0 ? parts[0] : null;
-  }
-
-  // Regular subdomain detection
-  const isSubdomain =
-    hostname !== rootDomainFormatted &&
-    hostname !== `www.${rootDomainFormatted}` &&
-    hostname.endsWith(`.${rootDomainFormatted}`);
-
-  return isSubdomain ? hostname.replace(`.${rootDomainFormatted}`, '') : null;
-}
+// Node.js runtime is required because ioredis uses TCP sockets,
+// which are not available in the Edge runtime.
+export const runtime = 'nodejs';
 
 export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
-  const subdomain = extractSubdomain(request);
+  const host = request.headers.get('host') || '';
+  const subdomain = extractSubdomain(host, rootDomain);
 
-  if (subdomain) {
-    // Block access to admin page from subdomains
-    if (pathname.startsWith('/admin')) {
-      return NextResponse.redirect(new URL('/', request.url));
-    }
-
-    // For the root path on a subdomain, rewrite to the subdomain page
-    if (pathname === '/') {
-      return NextResponse.rewrite(new URL(`/s/${subdomain}`, request.url));
-    }
+  // No subdomain — root domain, pass through to platform pages.
+  if (!subdomain) {
+    return NextResponse.next();
   }
 
-  // On the root domain, allow normal access
-  return NextResponse.next();
+  // www — redirect to root domain.
+  if (subdomain === 'www') {
+    const url = request.nextUrl.clone();
+    url.host = rootDomain;
+    return NextResponse.redirect(url);
+  }
+
+  // Look up tenant in Redis.
+  const cached = await redis.get(`subdomain:${subdomain}`);
+  if (!cached) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const tenant = JSON.parse(cached) as TenantRedisData;
+
+  // Inject tenant context into headers and rewrite to the tenant route group.
+  // e.g. pierpont.example.com/day/2026-04-03
+  //   → example.com/{slug}/day/2026-04-03  (handled by app/[tenant]/...)
+  const { pathname } = request.nextUrl;
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-tenant-id', tenant.id);
+  requestHeaders.set('x-tenant-slug', tenant.slug);
+
+  return NextResponse.rewrite(
+    new URL(`/${tenant.slug}${pathname}`, request.url),
+    { request: { headers: requestHeaders } }
+  );
 }
 
 export const config = {
   matcher: [
     /*
-     * Match all paths except for:
-     * 1. /api routes
-     * 2. /_next (Next.js internals)
-     * 3. all root files inside /public (e.g. /favicon.ico)
+     * Match all paths except:
+     * - /api routes
+     * - /_next (Next.js internals)
+     * - Static files (favicon.ico, images, etc.)
      */
-    '/((?!api|_next|[\\w-]+\\.\\w+).*)'
-  ]
+    '/((?!api|_next|[\\w-]+\\.\\w+).*)',
+  ],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,24 +1,13 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   experimental: {
-    // Enable experimental features if needed
+    // Required to use ioredis (Node.js TCP sockets) inside middleware.
+    // Without this, middleware runs on the Edge runtime which doesn't support
+    // Node.js APIs. The type definition lags the runtime — suppress the error.
+    // @ts-expect-error nodeMiddleware is not yet in ExperimentalConfig types
+    nodeMiddleware: true,
   },
-  // Ensure proper handling of Vercel Analytics and Speed Insights
-  // headers: async () => {
-  //   return [
-  //     {
-  //       source: '/_vercel/speed-insights/script.js',
-  //       headers: [
-  //         {
-  //           key: 'Cache-Control',
-  //           value: 'public, max-age=31536000, immutable',
-  //         },
-  //       ],
-  //     },
-  //   ];
-  // },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Enables `experimental.nodeMiddleware: true` in `next.config.ts` — required because `ioredis` uses TCP sockets which aren't available in the Edge runtime. Next.js accepts the flag at runtime ("✓ nodeMiddleware") but its TypeScript type hasn't caught up; suppressed with `@ts-expect-error`
- Extracts subdomain parsing to `lib/subdomain.ts` as a pure `extractSubdomain(hostname, rootDomain)` function — handles localhost, Vercel preview (`tenant---branch.vercel.app`), and production
- Rewrites `middleware.ts`:
  - No subdomain → pass through (root domain / platform pages)
  - `www` → redirect to root domain
  - Known subdomain → Redis lookup, inject `x-tenant-id` + `x-tenant-slug` headers, rewrite to `/{slug}{pathname}` (the `app/[tenant]/...` route group created in T-07+)
  - Unknown subdomain → `404`
- Adds `lib/tenant.ts` — `getTenantFromHeaders()` and `getTenantId()` for reading the injected headers in Server Components

## Test plan
- [ ] `pnpm test:run` passes (28/28 — includes 10 new subdomain extraction tests)
- [ ] `pnpm build` passes
- [ ] Visiting a registered tenant subdomain locally rewrites correctly
- [ ] Visiting an unknown subdomain returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)