### PR TITLE
T-07: Supabase Auth — sign up, sign in, sign out

### DIFF
--- a/app/[tenant]/auth/sign-in/page.tsx
+++ b/app/[tenant]/auth/sign-in/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useActionState } from 'react';
+import Link from 'next/link';
+import { signIn } from '@/app/actions/auth';
+import { Logo } from '@/components/logo';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export default function SignInPage() {
+  const [state, action, isPending] = useActionState(signIn, null);
+
+  return (
+    <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="flex justify-center">
+          <Logo className="text-2xl" />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <h1 className="text-xl font-semibold tracking-tight text-center">
+              Sign in
+            </h1>
+          </CardHeader>
+
+          <form action={action}>
+            <CardContent className="space-y-4">
+              {state?.error && (
+                <p className="text-sm text-destructive">{state.error}</p>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                />
+              </div>
+            </CardContent>
+
+            <CardFooter className="flex flex-col gap-3">
+              <Button type="submit" className="w-full" disabled={isPending}>
+                {isPending ? 'Signing in…' : 'Sign in'}
+              </Button>
+              <p className="text-sm text-muted-foreground text-center">
+                Don&apos;t have an account?{' '}
+                <Link href="/auth/sign-up" className="underline underline-offset-4">
+                  Sign up
+                </Link>
+              </p>
+            </CardFooter>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/[tenant]/auth/sign-up/page.tsx
+++ b/app/[tenant]/auth/sign-up/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useActionState } from 'react';
+import Link from 'next/link';
+import { signUp } from '@/app/actions/auth';
+import { Logo } from '@/components/logo';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export default function SignUpPage() {
+  const [state, action, isPending] = useActionState(signUp, null);
+
+  if (state?.success) {
+    return (
+      <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center p-4">
+        <div className="w-full max-w-sm space-y-6">
+          <div className="flex justify-center">
+            <Logo className="text-2xl" />
+          </div>
+          <Card>
+            <CardContent className="pt-6 text-center space-y-2">
+              <p className="font-medium">Check your email</p>
+              <p className="text-sm text-muted-foreground">
+                We sent you a confirmation link. Click it to activate your account.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="flex justify-center">
+          <Logo className="text-2xl" />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <h1 className="text-xl font-semibold tracking-tight text-center">
+              Create an account
+            </h1>
+          </CardHeader>
+
+          <form action={action}>
+            <CardContent className="space-y-4">
+              {state?.error && (
+                <p className="text-sm text-destructive">{state.error}</p>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="new-password"
+                  required
+                />
+              </div>
+            </CardContent>
+
+            <CardFooter className="flex flex-col gap-3">
+              <Button type="submit" className="w-full" disabled={isPending}>
+                {isPending ? 'Creating account…' : 'Create account'}
+              </Button>
+              <p className="text-sm text-muted-foreground text-center">
+                Already have an account?{' '}
+                <Link href="/auth/sign-in" className="underline underline-offset-4">
+                  Sign in
+                </Link>
+              </p>
+            </CardFooter>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -1,0 +1,21 @@
+import { Logo } from '@/components/logo';
+import { UserMenu } from '@/components/user-menu';
+import { getUser } from '@/app/actions/auth';
+
+export default async function TenantLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await getUser();
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="border-b px-6 h-14 flex items-center justify-between">
+        <Logo />
+        {user && <UserMenu user={user} />}
+      </header>
+      <main className="flex-1">{children}</main>
+    </div>
+  );
+}

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -1,0 +1,13 @@
+import { getTenantFromHeaders } from '@/lib/tenant';
+
+export default async function TenantHomePage() {
+  const { slug } = await getTenantFromHeaders();
+
+  return (
+    <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center">
+      <p className="text-muted-foreground">
+        Welcome to <span className="font-medium text-foreground">{slug}</span>. Coming soon.
+      </p>
+    </div>
+  );
+}

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -1,0 +1,54 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+
+export async function signIn(_prevState: unknown, formData: FormData) {
+  const email = formData.get('email') as string;
+  const password = formData.get('password') as string;
+
+  const supabase = await createSupabaseServerClient();
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  redirect('/');
+}
+
+export async function signUp(_prevState: unknown, formData: FormData) {
+  const email = formData.get('email') as string;
+  const password = formData.get('password') as string;
+
+  const supabase = await createSupabaseServerClient();
+  const { error } = await supabase.auth.signUp({ email, password });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function signOut() {
+  const supabase = await createSupabaseServerClient();
+  await supabase.auth.signOut();
+  redirect('/auth/sign-in');
+}
+
+export async function getUser() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user;
+}
+
+export async function requireUser() {
+  const user = await getUser();
+  if (!user) {
+    redirect('/auth/sign-in');
+  }
+  return user;
+}

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import type { User } from '@supabase/supabase-js';
+import { signOut } from '@/app/actions/auth';
+import { Button } from '@/components/ui/button';
+
+interface UserMenuProps {
+  user: User;
+}
+
+export function UserMenu({ user }: UserMenuProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-muted-foreground">{user.email}</span>
+      <form action={signOut}>
+        <Button type="submit" variant="outline" size="sm">
+          Sign out
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,31 +1,71 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
 import { redis } from '@/lib/redis';
 import { extractSubdomain } from '@/lib/subdomain';
 import { rootDomain } from '@/lib/utils';
 import type { TenantRedisData } from '@/app/actions/tenants';
 
-// Node.js runtime is required because ioredis uses TCP sockets,
-// which are not available in the Edge runtime.
+// Node.js runtime required for ioredis (TCP sockets).
 export const runtime = 'nodejs';
 
 export async function middleware(request: NextRequest) {
   const host = request.headers.get('host') || '';
+  const { pathname } = request.nextUrl;
+
+  // -------------------------------------------------------------------------
+  // 1. Refresh Supabase auth session on every request.
+  //    We collect any cookies Supabase wants to set and apply them to the
+  //    final response (which may be a rewrite, redirect, or next).
+  // -------------------------------------------------------------------------
+  type AuthCookie = { name: string; value: string; options: Parameters<NextResponse['cookies']['set']>[2] };
+  const authCookies: AuthCookie[] = [];
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => request.cookies.getAll(),
+        setAll: (cookies) => {
+          cookies.forEach((c) => authCookies.push(c as AuthCookie));
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  function applyAuthCookies(response: NextResponse): NextResponse {
+    authCookies.forEach(({ name, value, options }) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      response.cookies.set(name, value, options as any)
+    );
+    return response;
+  }
+
+  // -------------------------------------------------------------------------
+  // 2. Subdomain detection.
+  // -------------------------------------------------------------------------
   const subdomain = extractSubdomain(host, rootDomain);
 
-  // No subdomain — root domain, pass through to platform pages.
+  // Root domain — pass through to platform pages.
   if (!subdomain) {
-    return NextResponse.next();
+    return applyAuthCookies(NextResponse.next());
   }
 
   // www — redirect to root domain.
   if (subdomain === 'www') {
     const url = request.nextUrl.clone();
     url.host = rootDomain;
-    return NextResponse.redirect(url);
+    return applyAuthCookies(NextResponse.redirect(url));
   }
 
-  // Look up tenant in Redis.
+  // -------------------------------------------------------------------------
+  // 3. Tenant resolution via Redis.
+  // -------------------------------------------------------------------------
   const cached = await redis.get(`subdomain:${subdomain}`);
   if (!cached) {
     return new NextResponse('Not found', { status: 404 });
@@ -33,17 +73,35 @@ export async function middleware(request: NextRequest) {
 
   const tenant = JSON.parse(cached) as TenantRedisData;
 
-  // Inject tenant context into headers and rewrite to the tenant route group.
-  // e.g. pierpont.example.com/day/2026-04-03
-  //   → example.com/{slug}/day/2026-04-03  (handled by app/[tenant]/...)
-  const { pathname } = request.nextUrl;
+  // -------------------------------------------------------------------------
+  // 4. Auth guard for tenant routes.
+  //    Public paths (no login required): /auth/*, /day/*
+  // -------------------------------------------------------------------------
+  const isPublicPath =
+    pathname === '/auth/sign-in' ||
+    pathname === '/auth/sign-up' ||
+    pathname.startsWith('/auth/') ||
+    pathname.startsWith('/day/');
+
+  if (!user && !isPublicPath) {
+    const signInUrl = new URL('/auth/sign-in', request.url);
+    return applyAuthCookies(NextResponse.redirect(signInUrl));
+  }
+
+  // -------------------------------------------------------------------------
+  // 5. Inject tenant headers and rewrite to the tenant route group.
+  //    e.g. pierpont.example.com/dashboard → example.com/pierpont/dashboard
+  //    handled by app/[tenant]/dashboard/page.tsx
+  // -------------------------------------------------------------------------
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-tenant-id', tenant.id);
   requestHeaders.set('x-tenant-slug', tenant.slug);
 
-  return NextResponse.rewrite(
-    new URL(`/${tenant.slug}${pathname}`, request.url),
-    { request: { headers: requestHeaders } }
+  return applyAuthCookies(
+    NextResponse.rewrite(
+      new URL(`/${tenant.slug}${pathname}`, request.url),
+      { request: { headers: requestHeaders } }
+    )
   );
 }
 

--- a/scripts/seed-test-tenant.mjs
+++ b/scripts/seed-test-tenant.mjs
@@ -1,0 +1,53 @@
+/**
+ * Seeds a "test" tenant into both Supabase and Redis.
+ * Run once: node scripts/seed-test-tenant.mjs
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Load .env.local manually
+const envFile = readFileSync(resolve(process.cwd(), '.env.local'), 'utf8');
+for (const line of envFile.split('\n')) {
+  const match = line.match(/^([^#=]+)=(.*)$/);
+  if (match) {
+    const key = match[1].trim();
+    const value = match[2].trim().replace(/^"|"$/g, '');
+    process.env[key] = value;
+  }
+}
+
+const TENANT_ID   = '11111111-1111-1111-1111-111111111111';
+const TENANT_NAME = 'Test Golf Club';
+const TENANT_SLUG = 'test';
+
+// ── Supabase ──────────────────────────────────────────────────────────────
+const { createClient } = await import('@supabase/supabase-js');
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { autoRefreshToken: false, persistSession: false } }
+);
+
+const { error } = await supabase.from('tenants').upsert(
+  { id: TENANT_ID, name: TENANT_NAME, slug: TENANT_SLUG, timezone: 'Europe/Brussels' },
+  { onConflict: 'slug' }
+);
+
+if (error) {
+  console.error('Supabase insert failed:', error.message);
+  process.exit(1);
+}
+console.log('✓ Tenant inserted into Supabase');
+
+// ── Redis ─────────────────────────────────────────────────────────────────
+const { default: Redis } = await import('ioredis');
+const redis = new Redis(process.env.REDIS_URL);
+
+await redis.set(
+  `subdomain:${TENANT_SLUG}`,
+  JSON.stringify({ id: TENANT_ID, name: TENANT_NAME, slug: TENANT_SLUG })
+);
+console.log('✓ Tenant inserted into Redis');
+
+await redis.quit();
+console.log('\nDone. Visit test.localhost:3000 (dev) or test.<your-domain> (prod).');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,13 @@
+-- Seed: test tenant
+-- Slug: test  →  accessible at test.localhost:3000 in dev
+--                or test.[your-production-domain] in prod
+-- Fixed UUID so Redis and Supabase stay in sync across environments.
+
+INSERT INTO tenants (id, name, slug, timezone)
+VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'Test Golf Club',
+  'test',
+  'Europe/Brussels'
+)
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## Summary
- **`app/actions/auth.ts`** — five Server Actions: `signIn` (redirects on success, returns error state on failure), `signUp` (returns success flag), `signOut` (redirects to sign-in), `getUser` (returns user or null), `requireUser` (redirects if unauthenticated)
- **`app/[tenant]/layout.tsx`** — tenant shell layout: header with Logo + UserMenu for authenticated users
- **`app/[tenant]/page.tsx`** — minimal tenant home placeholder showing the slug
- **`app/[tenant]/auth/sign-in/page.tsx`** — sign-in form with inline error display, `useActionState`
- **`app/[tenant]/auth/sign-up/page.tsx`** — sign-up form that transitions to a "check your email" confirmation on success
- **`components/user-menu.tsx`** — email display + sign-out button (server action via `<form action={signOut}>`)
- **`middleware.ts`** updated — Supabase session is refreshed on every request; auth cookies are collected and merged onto the final response (rewrite/redirect/next); unauthenticated users on non-public tenant paths are redirected to `/auth/sign-in`; public paths: `/auth/*` and `/day/*`

## This is the first ticket with visible output
Visiting any registered tenant subdomain will now show real pages — sign-in, sign-up, and (once logged in) the tenant home placeholder.

## Test plan
- [ ] `pnpm build` passes — routes `/[tenant]`, `/[tenant]/auth/sign-in`, `/[tenant]/auth/sign-up` all appear
- [ ] `pnpm test:run` passes (28/28)
- [ ] Visiting a tenant subdomain unauthenticated redirects to `/auth/sign-in`
- [ ] Sign-up flow shows "check your email" on success
- [ ] Sign-in with valid credentials redirects to tenant home
- [ ] Sign-out redirects to sign-in
- [ ] User email appears in header after sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)