### PR TITLE
T-09: RLS helper functions for tenant isolation

### DIFF
--- a/supabase/migrations/00003_rls_helpers.sql
+++ b/supabase/migrations/00003_rls_helpers.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- RLS Helper Functions
+-- =============================================================================
+-- These two functions are the standard building blocks for all table-level RLS
+-- policies across this database.  Every application table that has a tenant_id
+-- column should use them as shown in the template at the bottom of this file.
+--
+-- NOTE: The memberships table itself cannot use these helpers (circular
+-- dependency), so its policies use inline EXISTS queries instead.
+-- =============================================================================
+
+-- Returns TRUE if the current authenticated user is a member of the tenant.
+CREATE OR REPLACE FUNCTION is_tenant_member(t_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM memberships
+    WHERE memberships.tenant_id = t_id
+      AND memberships.user_id   = auth.uid()
+  );
+$$;
+
+-- Returns TRUE if the current authenticated user is an editor of the tenant.
+CREATE OR REPLACE FUNCTION is_tenant_editor(t_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM memberships
+    WHERE memberships.tenant_id = t_id
+      AND memberships.user_id   = auth.uid()
+      AND memberships.role      = 'editor'
+  );
+$$;
+
+-- =============================================================================
+-- Rewire tenants SELECT policy to use the helper
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Members can view their tenants" ON tenants;
+
+CREATE POLICY "Members can view their tenants"
+  ON tenants FOR SELECT TO authenticated
+  USING (is_tenant_member(tenants.id));
+
+-- =============================================================================
+-- RLS PATTERN TEMPLATE (copy-paste for each new application table)
+-- =============================================================================
+--
+-- ALTER TABLE <table> ENABLE ROW LEVEL SECURITY;
+--
+-- CREATE POLICY "<table>: members can select"
+--   ON <table> FOR SELECT TO authenticated
+--   USING (is_tenant_member(tenant_id));
+--
+-- CREATE POLICY "<table>: editors can insert"
+--   ON <table> FOR INSERT TO authenticated
+--   WITH CHECK (is_tenant_editor(tenant_id));
+--
+-- CREATE POLICY "<table>: editors can update"
+--   ON <table> FOR UPDATE TO authenticated
+--   USING (is_tenant_editor(tenant_id));
+--
+-- CREATE POLICY "<table>: editors can delete"
+--   ON <table> FOR DELETE TO authenticated
+--   USING (is_tenant_editor(tenant_id));
+--
+-- =============================================================================


### PR DESCRIPTION
## Summary

- Adds `is_tenant_member(t_id UUID)` — returns `TRUE` if the current user has any membership row for the given tenant
- Adds `is_tenant_editor(t_id UUID)` — returns `TRUE` if the current user has `role='editor'` for the given tenant
- Both functions are `SECURITY DEFINER` with a fixed `search_path` to prevent privilege escalation
- Rewires the `tenants` SELECT policy to `is_tenant_member(tenants.id)` instead of the inline `EXISTS`
- Embeds a copy-paste RLS template in the migration for all future application tables

## Test plan

- [ ] `pnpm build` — passes
- [ ] `pnpm test:run` — 38 tests pass
- [ ] `supabase db push` — migration 00003 applied to remote
- [ ] Verify in Supabase dashboard: `is_tenant_member` and `is_tenant_editor` visible under Database → Functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)