### PR TITLE
T-11: Database types and type generation

### DIFF
--- a/app/actions/courses.ts
+++ b/app/actions/courses.ts
@@ -6,11 +6,9 @@ import {
   createSupabaseServiceClient,
 } from '@/lib/supabase-server';
 import { isValidSlug } from '@/lib/tenant-validation';
+import type { ActionResponse } from '@/types/actions';
 
 type CourseResult = { slug: string; requiresConfirmation: boolean };
-type ActionResponse<T = void> =
-  | { success: true; data: T }
-  | { success: false; error: string };
 
 /**
  * Creates a Supabase user account and a tenant in one shot.

--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -7,16 +7,13 @@ import {
 } from '@/lib/supabase-server';
 import { isValidSlug } from '@/lib/tenant-validation';
 import { getUser } from '@/app/actions/auth';
+import type { ActionResponse } from '@/types/actions';
 
 export type TenantRedisData = {
   id: string;
   name: string;
   slug: string;
 };
-
-type ActionResponse<T = void> =
-  | { success: true; data: T }
-  | { success: false; error: string };
 
 // ---------------------------------------------------------------------------
 // createTenant

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "next start",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "db:types": "supabase gen types typescript --linked > types/supabase.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/types/actions.ts
+++ b/types/actions.ts
@@ -1,0 +1,12 @@
+import type { User } from '@supabase/supabase-js';
+import type { Role } from '@/lib/membership';
+
+export type ActionResponse<T = void> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type AuthState = {
+  user: User | null;
+  role: Role | null;
+  isEditor: boolean;
+};

--- a/types/components.ts
+++ b/types/components.ts
@@ -1,0 +1,23 @@
+import type {
+  ProgramItem,
+  Reservation,
+  HotelBooking,
+  VenueType,
+  PointOfContact,
+} from './index';
+
+export type ProgramItemWithRelations = ProgramItem & {
+  venue_type: VenueType | null;
+  point_of_contact: PointOfContact | null;
+};
+
+export type ReservationWithRelations = Reservation & {
+  hotel_booking: HotelBooking | null;
+  program_item: ProgramItem | null;
+};
+
+export type DayEntry = ProgramItemWithRelations | ReservationWithRelations;
+
+export function isProgramItem(entry: DayEntry): entry is ProgramItemWithRelations {
+  return 'title' in entry;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,111 @@
+// Re-export generated Supabase types
+export type { Database, Tables, TablesInsert, TablesUpdate } from './supabase';
+
+// ── Existing table aliases ───────────────────────────────────────────────────
+
+import type { Tables, TablesInsert, TablesUpdate } from './supabase';
+
+export type Tenant = Tables<'tenants'>;
+export type TenantInsert = TablesInsert<'tenants'>;
+export type TenantUpdate = TablesUpdate<'tenants'>;
+
+export type Membership = Tables<'memberships'>;
+export type MembershipInsert = TablesInsert<'memberships'>;
+export type MembershipUpdate = TablesUpdate<'memberships'>;
+
+// ── Future table aliases (populated when tables are created and db:types is re-run) ──
+// These are stubs that will be replaced with generated row types.
+
+/** @todo Replace with Tables<'days'> once the days table migration exists */
+export type Day = {
+  id: string;
+  tenant_id: string;
+  date: string;
+  created_at: string;
+  updated_at: string;
+};
+export type DayInsert = Omit<Day, 'id' | 'created_at' | 'updated_at'>;
+export type DayUpdate = Partial<DayInsert>;
+
+/** @todo Replace with Tables<'program_items'> once the program_items migration exists */
+export type ProgramItem = {
+  id: string;
+  tenant_id: string;
+  day_id: string;
+  title: string;
+  start_time: string | null;
+  end_time: string | null;
+  venue_type_id: string | null;
+  point_of_contact_id: string | null;
+  recurrence_rule: string | null;
+  created_at: string;
+  updated_at: string;
+};
+export type ProgramItemInsert = Omit<ProgramItem, 'id' | 'created_at' | 'updated_at'>;
+export type ProgramItemUpdate = Partial<ProgramItemInsert>;
+
+/** @todo Replace with Tables<'reservations'> once the reservations migration exists */
+export type Reservation = {
+  id: string;
+  tenant_id: string;
+  day_id: string;
+  guest_name: string;
+  tee_time: string | null;
+  holes: number | null;
+  hotel_booking_id: string | null;
+  program_item_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+export type ReservationInsert = Omit<Reservation, 'id' | 'created_at' | 'updated_at'>;
+export type ReservationUpdate = Partial<ReservationInsert>;
+
+/** @todo Replace with Tables<'hotel_bookings'> */
+export type HotelBooking = {
+  id: string;
+  tenant_id: string;
+  guest_name: string;
+  check_in: string;
+  check_out: string;
+  room_type: string | null;
+  created_at: string;
+  updated_at: string;
+};
+export type HotelBookingInsert = Omit<HotelBooking, 'id' | 'created_at' | 'updated_at'>;
+export type HotelBookingUpdate = Partial<HotelBookingInsert>;
+
+/** @todo Replace with Tables<'breakfast_configurations'> */
+export type BreakfastConfiguration = {
+  id: string;
+  tenant_id: string;
+  day_id: string;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+};
+export type BreakfastConfigurationInsert = Omit<BreakfastConfiguration, 'id' | 'created_at' | 'updated_at'>;
+export type BreakfastConfigurationUpdate = Partial<BreakfastConfigurationInsert>;
+
+/** @todo Replace with Tables<'points_of_contact'> */
+export type PointOfContact = {
+  id: string;
+  tenant_id: string;
+  name: string;
+  role: string | null;
+  phone: string | null;
+  email: string | null;
+  created_at: string;
+  updated_at: string;
+};
+export type PointOfContactInsert = Omit<PointOfContact, 'id' | 'created_at' | 'updated_at'>;
+export type PointOfContactUpdate = Partial<PointOfContactInsert>;
+
+/** @todo Replace with Tables<'venue_types'> */
+export type VenueType = {
+  id: string;
+  tenant_id: string;
+  name: string;
+  created_at: string;
+};
+export type VenueTypeInsert = Omit<VenueType, 'id' | 'created_at'>;
+export type VenueTypeUpdate = Partial<VenueTypeInsert>;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,0 +1,245 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.5"
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      memberships: {
+        Row: {
+          created_at: string
+          id: string
+          role: string
+          tenant_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          role?: string
+          tenant_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          role?: string
+          tenant_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "memberships_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tenants: {
+        Row: {
+          created_at: string
+          id: string
+          logo_url: string | null
+          name: string
+          slug: string
+          timezone: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          logo_url?: string | null
+          name: string
+          slug: string
+          timezone?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          logo_url?: string | null
+          name?: string
+          slug?: string
+          timezone?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      is_tenant_editor: { Args: { t_id: string }; Returns: boolean }
+      is_tenant_member: { Args: { t_id: string }; Returns: boolean }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const


### PR DESCRIPTION
## Summary

- **`types/supabase.ts`** — generated from the remote schema; contains `tenants`, `memberships`, and the two RLS helper functions
- **`types/index.ts`** — `Tenant`, `Membership` (+ `Insert`/`Update` variants) aliased from generated types; stub types for `Day`, `ProgramItem`, `Reservation`, `HotelBooking`, `BreakfastConfiguration`, `PointOfContact`, `VenueType` marked `@todo` — they'll be replaced with real generated types once those table migrations exist and `pnpm db:types` is re-run
- **`types/components.ts`** — `ProgramItemWithRelations`, `ReservationWithRelations`, `DayEntry` union, `isProgramItem()` type guard
- **`types/actions.ts`** — shared `ActionResponse<T>` and `AuthState`; existing inline definitions in `tenants.ts` and `courses.ts` now import from here
- **`package.json`** — `db:types` script: `supabase gen types typescript --linked > types/supabase.ts`

## Test plan

- [ ] `pnpm build` — passes
- [ ] `pnpm test:run` — 38 tests pass
- [ ] `pnpm db:types` — regenerates `types/supabase.ts` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)