### PR TITLE
T-12: Date utilities with timezone support

### DIFF
--- a/lib/day-utils.ts
+++ b/lib/day-utils.ts
@@ -1,0 +1,122 @@
+import {
+  format,
+  parse,
+  startOfMonth,
+  endOfMonth,
+  addWeeks,
+  addMonths,
+  addYears,
+  isAfter,
+  isBefore,
+  addDays,
+} from 'date-fns';
+import { toZonedTime, fromZonedTime } from 'date-fns-tz';
+
+/**
+ * Branded YYYY-MM-DD string. Use formatYmd() to create one.
+ */
+export type Ymd = string & { readonly __ymd: unique symbol };
+
+// ---------------------------------------------------------------------------
+// Core helpers
+// ---------------------------------------------------------------------------
+
+/** Returns the current date in the given timezone as a YYYY-MM-DD string. */
+export function getTenantToday(timezone: string): Ymd {
+  return format(toZonedTime(new Date(), timezone), 'yyyy-MM-dd') as Ymd;
+}
+
+/** Formats a UTC Date to YYYY-MM-DD in the local (JS) calendar day. */
+export function formatYmd(date: Date): Ymd {
+  return format(date, 'yyyy-MM-dd') as Ymd;
+}
+
+/** Parses a YYYY-MM-DD string to a Date at midnight UTC. */
+export function parseYmd(ymd: string): Date {
+  return parse(ymd, 'yyyy-MM-dd', new Date(0));
+}
+
+// ---------------------------------------------------------------------------
+// Month range
+// ---------------------------------------------------------------------------
+
+/** Returns the first and last day of the given month as YYYY-MM-DD strings. */
+export function getMonthDateRange(
+  year: number,
+  month: number // 1-indexed
+): { start: Ymd; end: Ymd } {
+  const ref = new Date(year, month - 1, 1);
+  return {
+    start: formatYmd(startOfMonth(ref)),
+    end: formatYmd(endOfMonth(ref)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Guardrails
+// ---------------------------------------------------------------------------
+
+/** Returns true if the given YYYY-MM-DD is strictly before today in the tenant's timezone. */
+export function isPastDate(ymd: string, timezone: string): boolean {
+  const today = getTenantToday(timezone);
+  return ymd < today;
+}
+
+/** Returns true if the given YYYY-MM-DD is within one year from today in the tenant's timezone. */
+export function isDateWithinOneYear(ymd: string, timezone: string): boolean {
+  const today = getTenantToday(timezone);
+  const oneYearLater = formatYmd(addYears(parseYmd(today), 1));
+  return ymd >= today && ymd <= oneYearLater;
+}
+
+// ---------------------------------------------------------------------------
+// Display
+// ---------------------------------------------------------------------------
+
+/** Returns the full weekday name for a YYYY-MM-DD string (e.g. "Monday"). */
+export function getWeekdayName(ymd: string, locale = 'en-GB'): string {
+  return parseYmd(ymd).toLocaleDateString(locale, { weekday: 'long' });
+}
+
+// ---------------------------------------------------------------------------
+// Recurrence
+// ---------------------------------------------------------------------------
+
+type Frequency = 'weekly' | 'biweekly' | 'monthly' | 'yearly';
+
+/**
+ * Generates all occurrence dates for a recurrence rule starting from startDate,
+ * up to maxDate (exclusive). Defaults to one year from startDate.
+ * Returns YYYY-MM-DD strings, not including startDate itself.
+ */
+export function generateRecurrenceDates(
+  startDate: string,
+  frequency: Frequency,
+  maxDate?: string
+): Ymd[] {
+  const start = parseYmd(startDate);
+  const limit = maxDate ? parseYmd(maxDate) : addYears(start, 1);
+  const results: Ymd[] = [];
+
+  let current = nextOccurrence(start, frequency);
+
+  while (!isAfter(current, limit)) {
+    results.push(formatYmd(current));
+    current = nextOccurrence(current, frequency);
+  }
+
+  return results;
+}
+
+function nextOccurrence(date: Date, frequency: Frequency): Date {
+  switch (frequency) {
+    case 'weekly':
+      return addWeeks(date, 1);
+    case 'biweekly':
+      return addWeeks(date, 2);
+    case 'monthly':
+      return addMonths(date, 1);
+    case 'yearly':
+      return addYears(date, 1);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "embla-carousel-react": "^8.6.0",
     "frimousse": "^0.2.0",
     "ioredis": "^5.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.1.0)
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.1.0)
@@ -1758,6 +1761,11 @@ packages:
 
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -4057,6 +4065,10 @@ snapshots:
       - '@noble/hashes'
 
   date-fns-jalali@4.1.0-0: {}
+
+  date-fns-tz@3.2.0(date-fns@4.1.0):
+    dependencies:
+      date-fns: 4.1.0
 
   date-fns@4.1.0: {}
 

--- a/tests/lib/day-utils.test.ts
+++ b/tests/lib/day-utils.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  getTenantToday,
+  formatYmd,
+  parseYmd,
+  getMonthDateRange,
+  isPastDate,
+  isDateWithinOneYear,
+  getWeekdayName,
+  generateRecurrenceDates,
+} from '@/lib/day-utils';
+
+const TZ_BRUSSELS = 'Europe/Brussels';
+const TZ_NYC = 'America/New_York';
+
+afterEach(() => vi.useRealTimers());
+
+// ---------------------------------------------------------------------------
+// getTenantToday
+// ---------------------------------------------------------------------------
+describe('getTenantToday', () => {
+  it('returns today in the given timezone', () => {
+    vi.useFakeTimers();
+    // 2024-03-15T23:30:00Z — still March 15 in Brussels (UTC+1), March 15 in NYC (UTC-4)
+    vi.setSystemTime(new Date('2024-03-15T23:30:00Z'));
+    expect(getTenantToday(TZ_BRUSSELS)).toBe('2024-03-16'); // Brussels is UTC+1 → already Mar 16
+    expect(getTenantToday(TZ_NYC)).toBe('2024-03-15');       // NYC is UTC-4 → still Mar 15
+  });
+
+  it('handles DST spring-forward in Brussels (last Sunday of March)', () => {
+    vi.useFakeTimers();
+    // 2024-03-31T00:30:00Z — Brussels has just sprung forward to UTC+2, so local time is 02:30
+    vi.setSystemTime(new Date('2024-03-31T00:30:00Z'));
+    expect(getTenantToday(TZ_BRUSSELS)).toBe('2024-03-31');
+  });
+
+  it('handles DST fall-back in Brussels (last Sunday of October)', () => {
+    vi.useFakeTimers();
+    // 2024-10-27T00:30:00Z — Brussels clocks go back, still Oct 27 local
+    vi.setSystemTime(new Date('2024-10-27T00:30:00Z'));
+    expect(getTenantToday(TZ_BRUSSELS)).toBe('2024-10-27');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatYmd / parseYmd
+// ---------------------------------------------------------------------------
+describe('formatYmd', () => {
+  it('formats a date to YYYY-MM-DD', () => {
+    expect(formatYmd(new Date(2024, 0, 5))).toBe('2024-01-05');
+    expect(formatYmd(new Date(2024, 11, 31))).toBe('2024-12-31');
+  });
+
+  it('handles leap year Feb 29', () => {
+    expect(formatYmd(new Date(2024, 1, 29))).toBe('2024-02-29');
+  });
+});
+
+describe('parseYmd', () => {
+  it('parses YYYY-MM-DD and round-trips with formatYmd', () => {
+    expect(formatYmd(parseYmd('2024-06-15'))).toBe('2024-06-15');
+    expect(formatYmd(parseYmd('2024-02-29'))).toBe('2024-02-29');
+    expect(formatYmd(parseYmd('2024-12-31'))).toBe('2024-12-31');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMonthDateRange
+// ---------------------------------------------------------------------------
+describe('getMonthDateRange', () => {
+  it('returns correct range for a standard month', () => {
+    const { start, end } = getMonthDateRange(2024, 6); // June
+    expect(start).toBe('2024-06-01');
+    expect(end).toBe('2024-06-30');
+  });
+
+  it('returns correct range for January', () => {
+    const { start, end } = getMonthDateRange(2024, 1);
+    expect(start).toBe('2024-01-01');
+    expect(end).toBe('2024-01-31');
+  });
+
+  it('returns correct range for December', () => {
+    const { start, end } = getMonthDateRange(2024, 12);
+    expect(start).toBe('2024-12-01');
+    expect(end).toBe('2024-12-31');
+  });
+
+  it('handles February in a leap year', () => {
+    const { start, end } = getMonthDateRange(2024, 2);
+    expect(start).toBe('2024-02-01');
+    expect(end).toBe('2024-02-29');
+  });
+
+  it('handles February in a non-leap year', () => {
+    const { start, end } = getMonthDateRange(2023, 2);
+    expect(start).toBe('2023-02-01');
+    expect(end).toBe('2023-02-28');
+  });
+
+  it('handles year boundary — month 1 and 12', () => {
+    expect(getMonthDateRange(2025, 1).start).toBe('2025-01-01');
+    expect(getMonthDateRange(2025, 12).end).toBe('2025-12-31');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPastDate
+// ---------------------------------------------------------------------------
+describe('isPastDate', () => {
+  it('returns true for yesterday', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    expect(isPastDate('2024-06-14', TZ_BRUSSELS)).toBe(true);
+  });
+
+  it('returns false for today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    expect(isPastDate('2024-06-15', TZ_BRUSSELS)).toBe(false);
+  });
+
+  it('returns false for tomorrow', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    expect(isPastDate('2024-06-16', TZ_BRUSSELS)).toBe(false);
+  });
+
+  it('is timezone-aware: 23:30 UTC is next day in Brussels (UTC+1)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T23:30:00Z'));
+    // Local Brussels time is June 16 — so June 15 is now past
+    expect(isPastDate('2024-06-15', TZ_BRUSSELS)).toBe(true);
+    // But in NYC (UTC-4) it's still June 15 — not past
+    expect(isPastDate('2024-06-15', TZ_NYC)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDateWithinOneYear
+// ---------------------------------------------------------------------------
+describe('isDateWithinOneYear', () => {
+  it('returns true for today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    expect(isDateWithinOneYear('2024-06-15', TZ_BRUSSELS)).toBe(true);
+  });
+
+  it('returns true for one year from today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    expect(isDateWithinOneYear('2025-06-15', TZ_BRUSSELS)).toBe(true);
+  });
+
+  it('returns false for yesterday', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    expect(isDateWithinOneYear('2024-06-14', TZ_BRUSSELS)).toBe(false);
+  });
+
+  it('returns false for more than one year ahead', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    expect(isDateWithinOneYear('2025-06-16', TZ_BRUSSELS)).toBe(false);
+  });
+
+  it('handles leap year boundary correctly', () => {
+    vi.useFakeTimers();
+    // Today is Feb 29 2024 (leap day)
+    vi.setSystemTime(new Date('2024-02-29T12:00:00Z'));
+    // One year later: date-fns addYears goes to Feb 28 2025 (non-leap)
+    expect(isDateWithinOneYear('2025-02-28', TZ_BRUSSELS)).toBe(true);
+    expect(isDateWithinOneYear('2025-03-01', TZ_BRUSSELS)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getWeekdayName
+// ---------------------------------------------------------------------------
+describe('getWeekdayName', () => {
+  it('returns the correct weekday name', () => {
+    expect(getWeekdayName('2024-06-17')).toBe('Monday');
+    expect(getWeekdayName('2024-06-21')).toBe('Friday');
+    expect(getWeekdayName('2024-06-23')).toBe('Sunday');
+  });
+
+  it('works for a leap day', () => {
+    expect(getWeekdayName('2024-02-29')).toBe('Thursday');
+  });
+
+  it('works for year boundary', () => {
+    expect(getWeekdayName('2024-12-31')).toBe('Tuesday');
+    expect(getWeekdayName('2025-01-01')).toBe('Wednesday');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateRecurrenceDates
+// ---------------------------------------------------------------------------
+describe('generateRecurrenceDates', () => {
+  it('generates weekly dates', () => {
+    const dates = generateRecurrenceDates('2024-01-01', 'weekly', '2024-01-22');
+    expect(dates).toEqual(['2024-01-08', '2024-01-15', '2024-01-22']);
+  });
+
+  it('generates biweekly dates', () => {
+    const dates = generateRecurrenceDates('2024-01-01', 'biweekly', '2024-02-01');
+    expect(dates).toEqual(['2024-01-15', '2024-01-29']);
+  });
+
+  it('generates monthly dates', () => {
+    const dates = generateRecurrenceDates('2024-01-31', 'monthly', '2024-05-01');
+    // Jan 31 → Feb 29 (clamped, leap year), then addMonths from Feb 29 → Mar 29, Apr 29
+    expect(dates).toEqual(['2024-02-29', '2024-03-29', '2024-04-29']);
+  });
+
+  it('generates yearly dates', () => {
+    const dates = generateRecurrenceDates('2022-03-15', 'yearly', '2025-01-01');
+    expect(dates).toEqual(['2023-03-15', '2024-03-15']);
+  });
+
+  it('defaults maxDate to one year from startDate', () => {
+    const dates = generateRecurrenceDates('2024-01-01', 'yearly');
+    expect(dates).toEqual(['2025-01-01']);
+  });
+
+  it('returns empty array when maxDate is before first occurrence', () => {
+    const dates = generateRecurrenceDates('2024-01-01', 'weekly', '2024-01-07');
+    expect(dates).toEqual([]);
+  });
+
+  it('handles DST month boundary for monthly recurrence', () => {
+    // March 31 → April 30 crosses the DST transition in Europe
+    const dates = generateRecurrenceDates('2024-03-31', 'monthly', '2024-05-01');
+    expect(dates).toEqual(['2024-04-30']);
+  });
+
+  it('handles leap year for yearly recurrence from Feb 29', () => {
+    // Feb 29 2024 → Feb 28 2025 (non-leap year)
+    const dates = generateRecurrenceDates('2024-02-29', 'yearly', '2026-01-01');
+    expect(dates).toEqual(['2025-02-28']);
+  });
+});


### PR DESCRIPTION
## Summary

`lib/day-utils.ts` — all date logic used throughout the app goes through these functions. No hardcoded timezone anywhere.

| Export | Purpose |
|--------|---------|
| `Ymd` | Branded `string` type for YYYY-MM-DD dates |
| `getTenantToday(tz)` | Current date in tenant's timezone |
| `formatYmd(date)` | Date → YYYY-MM-DD |
| `parseYmd(ymd)` | YYYY-MM-DD → Date |
| `getMonthDateRange(y, m)` | First and last day of a month |
| `isPastDate(ymd, tz)` | True if before today in given timezone |
| `isDateWithinOneYear(ymd, tz)` | Guardrail: today ≤ date ≤ today+1yr |
| `getWeekdayName(ymd, locale?)` | e.g. `"Monday"` |
| `generateRecurrenceDates(start, freq, max?)` | weekly / biweekly / monthly / yearly |

## Test plan

- [ ] `pnpm test:run` — 70 tests pass (32 new)
- [ ] `pnpm build` — clean build
- [ ] DST spring-forward: `2024-03-31T00:30Z` → Brussels already March 31 ✓
- [ ] DST fall-back: `2024-10-27T00:30Z` → Brussels still October 27 ✓
- [ ] Leap year Feb 29: `addMonths` clamps correctly ✓
- [ ] Yearly recurrence from Feb 29 2024 → Feb 28 2025 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)