### PR TITLE
T-13: Tenant-scoped Supabase helpers

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -1,21 +1,28 @@
 import { Logo } from '@/components/logo';
 import { UserMenu } from '@/components/user-menu';
 import { getUser } from '@/app/actions/auth';
+import { getTenantFromHeaders } from '@/lib/tenant';
+import { TenantProvider } from '@/lib/tenant-context';
 
 export default async function TenantLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const user = await getUser();
+  const [user, tenant] = await Promise.all([
+    getUser(),
+    getTenantFromHeaders(),
+  ]);
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="border-b px-6 h-14 flex items-center justify-between">
-        <Logo />
-        {user && <UserMenu user={user} />}
-      </header>
-      <main className="flex-1">{children}</main>
-    </div>
+    <TenantProvider tenantId={tenant.id} tenantSlug={tenant.slug}>
+      <div className="min-h-screen flex flex-col">
+        <header className="border-b px-6 h-14 flex items-center justify-between">
+          <Logo />
+          {user && <UserMenu user={user} />}
+        </header>
+        <main className="flex-1">{children}</main>
+      </div>
+    </TenantProvider>
   );
 }

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,0 +1,30 @@
+import { createTenantClient } from '@/lib/supabase-server';
+
+/**
+ * Returns a Supabase query builder scoped to the current tenant.
+ * Already has .eq('tenant_id', tenantId) applied as a belt-and-suspenders
+ * layer on top of RLS. Chain additional filters and call .select() as needed.
+ *
+ * Usage:
+ *   const q = await tenantQuery('program_items');
+ *   const { data } = await q.eq('day_id', dayId).order('start_time');
+ */
+export async function tenantQuery(table: string) {
+  const { supabase, tenantId } = await createTenantClient();
+  return supabase.from(table).select('*').eq('tenant_id', tenantId);
+}
+
+/**
+ * Inserts a row into the given table, automatically injecting tenant_id.
+ * Uses the authenticated user's session so RLS policies still apply.
+ *
+ * Usage:
+ *   const { data, error } = await tenantInsert('program_items', { title: 'Welcome', ... });
+ */
+export async function tenantInsert<T extends Record<string, unknown>>(
+  table: string,
+  data: T
+) {
+  const { supabase, tenantId } = await createTenantClient();
+  return supabase.from(table).insert({ ...data, tenant_id: tenantId });
+}

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { createClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
+import { getTenantId } from '@/lib/tenant';
 
 export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
@@ -26,6 +27,19 @@ export async function createSupabaseServerClient() {
       },
     }
   );
+}
+
+/**
+ * Returns a Supabase server client together with the current tenant ID.
+ * One-stop convenience for server actions and route handlers that need both.
+ * RLS is the primary isolation mechanism; tenantId is needed for INSERT columns.
+ */
+export async function createTenantClient() {
+  const [supabase, tenantId] = await Promise.all([
+    createSupabaseServerClient(),
+    getTenantId(),
+  ]);
+  return { supabase, tenantId };
 }
 
 export function createSupabaseServiceClient() {

--- a/lib/tenant-context.tsx
+++ b/lib/tenant-context.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+type TenantContextValue = {
+  tenantId: string;
+  tenantSlug: string;
+};
+
+const TenantContext = createContext<TenantContextValue | null>(null);
+
+export function TenantProvider({
+  tenantId,
+  tenantSlug,
+  children,
+}: TenantContextValue & { children: ReactNode }) {
+  return (
+    <TenantContext.Provider value={{ tenantId, tenantSlug }}>
+      {children}
+    </TenantContext.Provider>
+  );
+}
+
+/**
+ * Returns the current tenant's ID and slug.
+ * Must be used inside a component rendered within app/[tenant]/ routes.
+ */
+export function useTenant(): TenantContextValue {
+  const ctx = useContext(TenantContext);
+  if (!ctx) {
+    throw new Error('useTenant() must be used within a TenantProvider');
+  }
+  return ctx;
+}
+
+/**
+ * Returns just the tenant ID for client components that need it for queries.
+ */
+export function getTenantIdClient(): string {
+  return useTenant().tenantId;
+}

--- a/tests/lib/queries.test.ts
+++ b/tests/lib/queries.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/supabase-server', () => ({
+  createTenantClient: vi.fn(),
+}));
+
+import { createTenantClient } from '@/lib/supabase-server';
+import { tenantInsert, tenantQuery } from '@/lib/queries';
+
+const TENANT_ID = 'tenant-123';
+
+function makeChain(insertResult = { data: null, error: null }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.from = vi.fn().mockReturnValue(chain);
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.insert = vi.fn().mockResolvedValue(insertResult);
+  return chain;
+}
+
+describe('tenantInsert', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('injects tenant_id into the insert payload', async () => {
+    const chain = makeChain();
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: chain as never,
+      tenantId: TENANT_ID,
+    });
+
+    await tenantInsert('program_items', { title: 'Welcome', day_id: 'day-1' });
+
+    expect(chain.insert).toHaveBeenCalledWith({
+      title: 'Welcome',
+      day_id: 'day-1',
+      tenant_id: TENANT_ID,
+    });
+  });
+
+  it('does not overwrite an existing tenant_id in the payload', async () => {
+    const chain = makeChain();
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: chain as never,
+      tenantId: TENANT_ID,
+    });
+
+    // Even if caller passes a different tenant_id, it gets overwritten
+    await tenantInsert('program_items', {
+      title: 'Test',
+      tenant_id: 'some-other-id',
+    });
+
+    expect(chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ tenant_id: TENANT_ID })
+    );
+  });
+
+  it('calls from() with the correct table name', async () => {
+    const chain = makeChain();
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: chain as never,
+      tenantId: TENANT_ID,
+    });
+
+    await tenantInsert('reservations', { guest_name: 'Alice' });
+
+    expect(chain.from).toHaveBeenCalledWith('reservations');
+  });
+});
+
+describe('tenantQuery', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('scopes the query to the current tenant', async () => {
+    const chain = makeChain();
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: chain as never,
+      tenantId: TENANT_ID,
+    });
+
+    await tenantQuery('reservations');
+
+    expect(chain.from).toHaveBeenCalledWith('reservations');
+    expect(chain.eq).toHaveBeenCalledWith('tenant_id', TENANT_ID);
+  });
+});


### PR DESCRIPTION
## Summary

Establishes the standard patterns all future server actions and client components will use to query data within a tenant.

**Server side:**
- `createTenantClient()` — gets Supabase client + `tenantId` in one async call
- `tenantQuery(table)` — returns a query builder already filtered by `tenant_id` (extra layer on top of RLS)
- `tenantInsert(table, data)` — automatically injects `tenant_id` into every INSERT; callers never need to remember it

**Client side:**
- `TenantProvider` — rendered in `app/[tenant]/layout.tsx`; reads `tenantId`/`tenantSlug` from middleware headers (server component) and makes them available to the React tree
- `useTenant()` — hook for client components to access both values
- `getTenantIdClient()` — shorthand returning just the ID

## Test plan

- [ ] `pnpm test:run` — 74 tests pass (4 new for `tenantInsert`/`tenantQuery`)
- [ ] `pnpm build` — clean build
- [ ] Verify `useTenant()` returns the correct tenant at `test.localhost:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)