### PR TITLE
T-14: Point of Contact CRUD

### DIFF
--- a/app/actions/poc.ts
+++ b/app/actions/poc.ts
@@ -1,0 +1,148 @@
+'use server';
+
+import { z } from 'zod';
+import { createTenantClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { getUserRole, requireEditor } from '@/lib/membership';
+import type { ActionResponse } from '@/types/actions';
+import type { PointOfContact } from '@/types/index';
+
+// ---------------------------------------------------------------------------
+// Validation schema (shared with client for form validation)
+// ---------------------------------------------------------------------------
+export const pocSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z
+    .string()
+    .email('Invalid email address')
+    .optional()
+    .or(z.literal('')),
+  phone: z.string().optional().or(z.literal('')),
+});
+
+export type PocFormData = z.infer<typeof pocSchema>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normaliseEmpty(s: string | undefined | null): string | null {
+  return s && s.trim() !== '' ? s.trim() : null;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export async function getAllPOCs(): Promise<ActionResponse<PointOfContact[]>> {
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('point_of_contact')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .order('name');
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as PointOfContact[] };
+}
+
+export async function createPOC(
+  raw: PocFormData
+): Promise<ActionResponse<PointOfContact>> {
+  const parsed = pocSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('point_of_contact')
+    .insert({
+      tenant_id: tenantId,
+      name: parsed.data.name.trim(),
+      email: normaliseEmpty(parsed.data.email),
+      phone: normaliseEmpty(parsed.data.phone),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    const isDupe = error.code === '23505';
+    return {
+      success: false,
+      error: isDupe
+        ? 'A contact with that name, email, or phone already exists.'
+        : error.message,
+    };
+  }
+
+  return { success: true, data: data as PointOfContact };
+}
+
+export async function updatePOC(
+  id: string,
+  raw: PocFormData
+): Promise<ActionResponse<PointOfContact>> {
+  const parsed = pocSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('point_of_contact')
+    .update({
+      name: parsed.data.name.trim(),
+      email: normaliseEmpty(parsed.data.email),
+      phone: normaliseEmpty(parsed.data.phone),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .select()
+    .single();
+
+  if (error) {
+    const isDupe = error.code === '23505';
+    return {
+      success: false,
+      error: isDupe
+        ? 'A contact with that name, email, or phone already exists.'
+        : error.message,
+    };
+  }
+
+  return { success: true, data: data as PointOfContact };
+}
+
+export async function deletePOC(id: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+
+  // TODO (T-16+): check if referenced by any program_item before deleting
+  // const { count } = await supabase.from('program_items')
+  //   .select('id', { count: 'exact', head: true })
+  //   .eq('point_of_contact_id', id);
+  // if (count && count > 0) return { success: false, error: 'Contact is in use by a programme item.' };
+
+  const { error } = await supabase
+    .from('point_of_contact')
+    .delete()
+    .eq('id', id)
+    .eq('tenant_id', tenantId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}

--- a/components/poc-management.tsx
+++ b/components/poc-management.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Pencil, Trash2, Plus } from 'lucide-react';
+import {
+  getAllPOCs,
+  createPOC,
+  updatePOC,
+  deletePOC,
+  pocSchema,
+  type PocFormData,
+} from '@/app/actions/poc';
+import type { PointOfContact } from '@/types/index';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+// ---------------------------------------------------------------------------
+// Form dialog
+// ---------------------------------------------------------------------------
+
+function PocDialog({
+  open,
+  onOpenChange,
+  initial,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  initial: PointOfContact | null;
+  onSaved: (poc: PointOfContact) => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<PocFormData>({
+    resolver: zodResolver(pocSchema),
+    defaultValues: { name: '', email: '', phone: '' },
+  });
+
+  useEffect(() => {
+    reset(
+      initial
+        ? { name: initial.name, email: initial.email ?? '', phone: initial.phone ?? '' }
+        : { name: '', email: '', phone: '' }
+    );
+  }, [initial, open, reset]);
+
+  function onSubmit(data: PocFormData) {
+    startTransition(async () => {
+      const result = initial
+        ? await updatePOC(initial.id, data)
+        : await createPOC(data);
+
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success(initial ? 'Contact updated.' : 'Contact added.');
+      onSaved(result.data);
+      onOpenChange(false);
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{initial ? 'Edit contact' : 'Add contact'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="poc-name">Name *</Label>
+            <Input id="poc-name" {...register('name')} />
+            {errors.name && (
+              <p className="text-sm text-destructive">{errors.name.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="poc-email">Email</Label>
+            <Input id="poc-email" type="email" {...register('email')} />
+            {errors.email && (
+              <p className="text-sm text-destructive">{errors.email.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="poc-phone">Phone</Label>
+            <Input id="poc-phone" {...register('phone')} />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function PocManagement() {
+  const [pocs, setPocs] = useState<PointOfContact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<PointOfContact | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<PointOfContact | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, startDeleteTransition] = useTransition();
+
+  useEffect(() => {
+    getAllPOCs().then((result) => {
+      if (result.success) setPocs(result.data);
+      setLoading(false);
+    });
+  }, []);
+
+  function handleSaved(poc: PointOfContact) {
+    setPocs((prev) => {
+      const idx = prev.findIndex((p) => p.id === poc.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = poc;
+        return next;
+      }
+      return [...prev, poc].sort((a, b) => a.name.localeCompare(b.name));
+    });
+  }
+
+  function handleDelete(poc: PointOfContact) {
+    setDeleteTarget(poc);
+    setDeleteError(null);
+  }
+
+  function confirmDelete() {
+    if (!deleteTarget) return;
+    startDeleteTransition(async () => {
+      const result = await deletePOC(deleteTarget.id);
+      if (!result.success) {
+        setDeleteError(result.error);
+        return;
+      }
+      setPocs((prev) => prev.filter((p) => p.id !== deleteTarget.id));
+      toast.success('Contact deleted.');
+      setDeleteTarget(null);
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Points of Contact</h2>
+        <Button
+          size="sm"
+          onClick={() => { setEditing(null); setDialogOpen(true); }}
+        >
+          <Plus className="w-4 h-4 mr-1" /> Add contact
+        </Button>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : pocs.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No contacts yet.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Phone</TableHead>
+              <TableHead className="w-24" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {pocs.map((poc) => (
+              <TableRow key={poc.id}>
+                <TableCell className="font-medium">{poc.name}</TableCell>
+                <TableCell>{poc.email ?? '—'}</TableCell>
+                <TableCell>{poc.phone ?? '—'}</TableCell>
+                <TableCell>
+                  <div className="flex gap-1 justify-end">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => { setEditing(poc); setDialogOpen(true); }}
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleDelete(poc)}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <PocDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        initial={editing}
+        onSaved={handleSaved}
+      />
+
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(v) => { if (!v) setDeleteTarget(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete contact?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteError ? (
+                <span className="text-destructive">{deleteError}</span>
+              ) : (
+                <>
+                  This will permanently delete{' '}
+                  <strong>{deleteTarget?.name}</strong>.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            {!deleteError && (
+              <AlertDialogAction
+                onClick={confirmDelete}
+                disabled={isDeleting}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {isDeleting ? 'Deleting…' : 'Delete'}
+              </AlertDialogAction>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/supabase/migrations/00004_create_point_of_contact.sql
+++ b/supabase/migrations/00004_create_point_of_contact.sql
@@ -1,0 +1,40 @@
+CREATE TABLE point_of_contact (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id  UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  name       TEXT NOT NULL,
+  email      TEXT,
+  phone      TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Per-tenant uniqueness (case-insensitive)
+CREATE UNIQUE INDEX poc_tenant_name_unique
+  ON point_of_contact (tenant_id, lower(name))
+  WHERE name IS NOT NULL;
+
+CREATE UNIQUE INDEX poc_tenant_email_unique
+  ON point_of_contact (tenant_id, lower(email))
+  WHERE email IS NOT NULL AND email <> '';
+
+CREATE UNIQUE INDEX poc_tenant_phone_unique
+  ON point_of_contact (tenant_id, phone)
+  WHERE phone IS NOT NULL AND phone <> '';
+
+ALTER TABLE point_of_contact ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "poc: members can select"
+  ON point_of_contact FOR SELECT TO authenticated
+  USING (is_tenant_member(tenant_id));
+
+CREATE POLICY "poc: editors can insert"
+  ON point_of_contact FOR INSERT TO authenticated
+  WITH CHECK (is_tenant_editor(tenant_id));
+
+CREATE POLICY "poc: editors can update"
+  ON point_of_contact FOR UPDATE TO authenticated
+  USING (is_tenant_editor(tenant_id));
+
+CREATE POLICY "poc: editors can delete"
+  ON point_of_contact FOR DELETE TO authenticated
+  USING (is_tenant_editor(tenant_id));

--- a/tests/actions/poc.test.ts
+++ b/tests/actions/poc.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { pocSchema } from '@/app/actions/poc';
+
+describe('pocSchema', () => {
+  it('accepts a valid full record', () => {
+    const result = pocSchema.safeParse({
+      name: 'Alice Dupont',
+      email: 'alice@example.com',
+      phone: '+32 470 00 00 00',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts name-only (email and phone optional)', () => {
+    const result = pocSchema.safeParse({ name: 'Bob' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty string for email (treated as absent)', () => {
+    const result = pocSchema.safeParse({ name: 'Bob', email: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty string for phone', () => {
+    const result = pocSchema.safeParse({ name: 'Bob', phone: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    const result = pocSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].message).toBe('Name is required');
+  });
+
+  it('rejects missing name', () => {
+    const result = pocSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid email format', () => {
+    const result = pocSchema.safeParse({ name: 'Bob', email: 'not-an-email' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].message).toBe('Invalid email address');
+  });
+
+  it('rejects email with missing TLD', () => {
+    const result = pocSchema.safeParse({ name: 'Bob', email: 'bob@nodot' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid email with subdomain', () => {
+    const result = pocSchema.safeParse({
+      name: 'Bob',
+      email: 'bob@mail.example.co.uk',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -86,19 +86,9 @@ export type BreakfastConfiguration = {
 export type BreakfastConfigurationInsert = Omit<BreakfastConfiguration, 'id' | 'created_at' | 'updated_at'>;
 export type BreakfastConfigurationUpdate = Partial<BreakfastConfigurationInsert>;
 
-/** @todo Replace with Tables<'points_of_contact'> */
-export type PointOfContact = {
-  id: string;
-  tenant_id: string;
-  name: string;
-  role: string | null;
-  phone: string | null;
-  email: string | null;
-  created_at: string;
-  updated_at: string;
-};
-export type PointOfContactInsert = Omit<PointOfContact, 'id' | 'created_at' | 'updated_at'>;
-export type PointOfContactUpdate = Partial<PointOfContactInsert>;
+export type PointOfContact = Tables<'point_of_contact'>;
+export type PointOfContactInsert = TablesInsert<'point_of_contact'>;
+export type PointOfContactUpdate = TablesUpdate<'point_of_contact'>;
 
 /** @todo Replace with Tables<'venue_types'> */
 export type VenueType = {

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -71,6 +71,44 @@ export type Database = {
           },
         ]
       }
+      point_of_contact: {
+        Row: {
+          created_at: string
+          email: string | null
+          id: string
+          name: string
+          phone: string | null
+          tenant_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          email?: string | null
+          id?: string
+          name: string
+          phone?: string | null
+          tenant_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          email?: string | null
+          id?: string
+          name?: string
+          phone?: string | null
+          tenant_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "point_of_contact_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       tenants: {
         Row: {
           created_at: string


### PR DESCRIPTION
## Summary

- **Migration 00004**: `point_of_contact` table with per-tenant case-insensitive unique indexes on name and email, and plain unique on phone; RLS using the `is_tenant_member`/`is_tenant_editor` helpers from T-09
- **`app/actions/poc.ts`**: `getAllPOCs`, `createPOC`, `updatePOC`, `deletePOC` — Zod validation, duplicate errors surfaced from DB constraint violations (code `23505`), editor guard on writes; delete has a `TODO` for the programme item reference check (blocked until that table exists)
- **`components/poc-management.tsx`**: full client component — table listing, add/edit dialog (react-hook-form + Zod), delete confirmation alert dialog, sonner toasts
- **Types**: `types/supabase.ts` regenerated; `PointOfContact` in `types/index.ts` now uses `Tables<'point_of_contact'>`
- **Fix found**: Zod v4 uses `error.issues` not `error.errors` — applied throughout

## Test plan

- [ ] `pnpm test:run` — 83 tests pass (9 new for `pocSchema`)
- [ ] `pnpm build` — clean build
- [ ] Migration applied to remote via `supabase db push`
- [ ] At `test.localhost:3000`: add a POC, edit it, verify duplicate name is rejected, delete it

🤖 Generated with [Claude Code](https://claude.com/claude-code)