### PR TITLE
T-15: Venue Type CRUD

### DIFF
--- a/app/actions/venue-type.ts
+++ b/app/actions/venue-type.ts
@@ -1,0 +1,133 @@
+'use server';
+
+import { z } from 'zod';
+import { createTenantClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { getUserRole, requireEditor } from '@/lib/membership';
+import type { ActionResponse } from '@/types/actions';
+import type { VenueType } from '@/types/index';
+
+// ---------------------------------------------------------------------------
+// Validation schema
+// ---------------------------------------------------------------------------
+export const venueTypeSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  code: z.string().optional().or(z.literal('')),
+});
+
+export type VenueTypeFormData = z.infer<typeof venueTypeSchema>;
+
+function normaliseEmpty(s: string | undefined | null): string | null {
+  return s && s.trim() !== '' ? s.trim() : null;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export async function getAllVenueTypes(): Promise<ActionResponse<VenueType[]>> {
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('venue_type')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .order('name');
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as VenueType[] };
+}
+
+export async function createVenueType(
+  raw: VenueTypeFormData
+): Promise<ActionResponse<VenueType>> {
+  const parsed = venueTypeSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('venue_type')
+    .insert({
+      tenant_id: tenantId,
+      name: parsed.data.name.trim(),
+      code: normaliseEmpty(parsed.data.code),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    const isDupe = error.code === '23505';
+    return {
+      success: false,
+      error: isDupe
+        ? 'A venue type with that name or code already exists.'
+        : error.message,
+    };
+  }
+
+  return { success: true, data: data as VenueType };
+}
+
+export async function updateVenueType(
+  id: string,
+  raw: VenueTypeFormData
+): Promise<ActionResponse<VenueType>> {
+  const parsed = venueTypeSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('venue_type')
+    .update({
+      name: parsed.data.name.trim(),
+      code: normaliseEmpty(parsed.data.code),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .select()
+    .single();
+
+  if (error) {
+    const isDupe = error.code === '23505';
+    return {
+      success: false,
+      error: isDupe
+        ? 'A venue type with that name or code already exists.'
+        : error.message,
+    };
+  }
+
+  return { success: true, data: data as VenueType };
+}
+
+export async function deleteVenueType(id: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+
+  // TODO (T-16+): check if referenced by any program_item before deleting
+
+  const { error } = await supabase
+    .from('venue_type')
+    .delete()
+    .eq('id', id)
+    .eq('tenant_id', tenantId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}

--- a/components/venue-type-management.tsx
+++ b/components/venue-type-management.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Pencil, Trash2, Plus } from 'lucide-react';
+import {
+  getAllVenueTypes,
+  createVenueType,
+  updateVenueType,
+  deleteVenueType,
+  venueTypeSchema,
+  type VenueTypeFormData,
+} from '@/app/actions/venue-type';
+import type { VenueType } from '@/types/index';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+function VenueTypeDialog({
+  open,
+  onOpenChange,
+  initial,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  initial: VenueType | null;
+  onSaved: (vt: VenueType) => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<VenueTypeFormData>({
+    resolver: zodResolver(venueTypeSchema),
+    defaultValues: { name: '', code: '' },
+  });
+
+  useEffect(() => {
+    reset(
+      initial
+        ? { name: initial.name, code: initial.code ?? '' }
+        : { name: '', code: '' }
+    );
+  }, [initial, open, reset]);
+
+  function onSubmit(data: VenueTypeFormData) {
+    startTransition(async () => {
+      const result = initial
+        ? await updateVenueType(initial.id, data)
+        : await createVenueType(data);
+
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success(initial ? 'Venue type updated.' : 'Venue type added.');
+      onSaved(result.data);
+      onOpenChange(false);
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{initial ? 'Edit venue type' : 'Add venue type'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="vt-name">Name *</Label>
+            <Input id="vt-name" {...register('name')} />
+            {errors.name && (
+              <p className="text-sm text-destructive">{errors.name.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="vt-code">Code</Label>
+            <Input id="vt-code" {...register('code')} placeholder="e.g. REST" />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function VenueTypeManagement() {
+  const [venueTypes, setVenueTypes] = useState<VenueType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<VenueType | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<VenueType | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, startDeleteTransition] = useTransition();
+
+  useEffect(() => {
+    getAllVenueTypes().then((result) => {
+      if (result.success) setVenueTypes(result.data);
+      setLoading(false);
+    });
+  }, []);
+
+  function handleSaved(vt: VenueType) {
+    setVenueTypes((prev) => {
+      const idx = prev.findIndex((v) => v.id === vt.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = vt;
+        return next;
+      }
+      return [...prev, vt].sort((a, b) => a.name.localeCompare(b.name));
+    });
+  }
+
+  function confirmDelete() {
+    if (!deleteTarget) return;
+    startDeleteTransition(async () => {
+      const result = await deleteVenueType(deleteTarget.id);
+      if (!result.success) {
+        setDeleteError(result.error);
+        return;
+      }
+      setVenueTypes((prev) => prev.filter((v) => v.id !== deleteTarget.id));
+      toast.success('Venue type deleted.');
+      setDeleteTarget(null);
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Venue Types</h2>
+        <Button
+          size="sm"
+          onClick={() => { setEditing(null); setDialogOpen(true); }}
+        >
+          <Plus className="w-4 h-4 mr-1" /> Add venue type
+        </Button>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : venueTypes.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No venue types yet.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Code</TableHead>
+              <TableHead className="w-24" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {venueTypes.map((vt) => (
+              <TableRow key={vt.id}>
+                <TableCell className="font-medium">{vt.name}</TableCell>
+                <TableCell>{vt.code ?? '—'}</TableCell>
+                <TableCell>
+                  <div className="flex gap-1 justify-end">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => { setEditing(vt); setDialogOpen(true); }}
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => { setDeleteTarget(vt); setDeleteError(null); }}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <VenueTypeDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        initial={editing}
+        onSaved={handleSaved}
+      />
+
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(v) => { if (!v) setDeleteTarget(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete venue type?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteError ? (
+                <span className="text-destructive">{deleteError}</span>
+              ) : (
+                <>This will permanently delete <strong>{deleteTarget?.name}</strong>.</>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            {!deleteError && (
+              <AlertDialogAction
+                onClick={confirmDelete}
+                disabled={isDeleting}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {isDeleting ? 'Deleting…' : 'Delete'}
+              </AlertDialogAction>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/supabase/migrations/00005_create_venue_type.sql
+++ b/supabase/migrations/00005_create_venue_type.sql
@@ -1,0 +1,34 @@
+CREATE TABLE venue_type (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id  UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  name       TEXT NOT NULL,
+  code       TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Per-tenant uniqueness (case-insensitive)
+CREATE UNIQUE INDEX venue_type_tenant_name_unique
+  ON venue_type (tenant_id, lower(name));
+
+CREATE UNIQUE INDEX venue_type_tenant_code_unique
+  ON venue_type (tenant_id, lower(code))
+  WHERE code IS NOT NULL AND code <> '';
+
+ALTER TABLE venue_type ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "venue_type: members can select"
+  ON venue_type FOR SELECT TO authenticated
+  USING (is_tenant_member(tenant_id));
+
+CREATE POLICY "venue_type: editors can insert"
+  ON venue_type FOR INSERT TO authenticated
+  WITH CHECK (is_tenant_editor(tenant_id));
+
+CREATE POLICY "venue_type: editors can update"
+  ON venue_type FOR UPDATE TO authenticated
+  USING (is_tenant_editor(tenant_id));
+
+CREATE POLICY "venue_type: editors can delete"
+  ON venue_type FOR DELETE TO authenticated
+  USING (is_tenant_editor(tenant_id));

--- a/tests/actions/venue-type.test.ts
+++ b/tests/actions/venue-type.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { venueTypeSchema } from '@/app/actions/venue-type';
+
+describe('venueTypeSchema', () => {
+  it('accepts a valid name and code', () => {
+    const result = venueTypeSchema.safeParse({ name: 'Main Restaurant', code: 'REST' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts name only (code optional)', () => {
+    const result = venueTypeSchema.safeParse({ name: 'Terrace' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty string for code (treated as absent)', () => {
+    const result = venueTypeSchema.safeParse({ name: 'Clubhouse', code: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    const result = venueTypeSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].message).toBe('Name is required');
+  });
+
+  it('rejects missing name', () => {
+    const result = venueTypeSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts name with special characters', () => {
+    const result = venueTypeSchema.safeParse({ name: "19th Hole Bar & Grill" });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a code with spaces', () => {
+    const result = venueTypeSchema.safeParse({ name: 'Pro Shop', code: 'PRO SHOP' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -90,12 +90,6 @@ export type PointOfContact = Tables<'point_of_contact'>;
 export type PointOfContactInsert = TablesInsert<'point_of_contact'>;
 export type PointOfContactUpdate = TablesUpdate<'point_of_contact'>;
 
-/** @todo Replace with Tables<'venue_types'> */
-export type VenueType = {
-  id: string;
-  tenant_id: string;
-  name: string;
-  created_at: string;
-};
-export type VenueTypeInsert = Omit<VenueType, 'id' | 'created_at'>;
-export type VenueTypeUpdate = Partial<VenueTypeInsert>;
+export type VenueType = Tables<'venue_type'>;
+export type VenueTypeInsert = TablesInsert<'venue_type'>;
+export type VenueTypeUpdate = TablesUpdate<'venue_type'>;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -139,6 +139,41 @@ export type Database = {
         }
         Relationships: []
       }
+      venue_type: {
+        Row: {
+          code: string | null
+          created_at: string
+          id: string
+          name: string
+          tenant_id: string
+          updated_at: string
+        }
+        Insert: {
+          code?: string | null
+          created_at?: string
+          id?: string
+          name: string
+          tenant_id: string
+          updated_at?: string
+        }
+        Update: {
+          code?: string | null
+          created_at?: string
+          id?: string
+          name?: string
+          tenant_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "venue_type_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       [_ in never]: never


### PR DESCRIPTION
## Summary

Venue types categorise where golf events take place (e.g. "Main Restaurant", "Terrace", "Clubhouse"). Follows the same pattern as T-14 POC CRUD.

- **Migration 00005**: `venue_type` table; unique index on `lower(name)` per tenant, partial unique index on `lower(code)` (only where non-empty); RLS using `is_tenant_member`/`is_tenant_editor`
- **`app/actions/venue-type.ts`**: `getAllVenueTypes`, `createVenueType`, `updateVenueType`, `deleteVenueType` — Zod validation, duplicate surfaced from DB constraint `23505`, editor guard on writes; delete has `TODO` for programme item reference check
- **`components/venue-type-management.tsx`**: table, add/edit dialog, delete confirmation alert dialog, sonner toasts
- **Types**: `VenueType` in `types/index.ts` now uses `Tables<'venue_type'>`; `types/supabase.ts` regenerated

## Test plan

- [ ] `pnpm test:run` — 90 tests pass (7 new)
- [ ] `pnpm build` — clean build
- [ ] Migration 00005 applied to remote
- [ ] Add a venue type, edit it, verify duplicate name is rejected, delete it

🤖 Generated with [Claude Code](https://claude.com/claude-code)