### PR TITLE
T-16: Admin settings page

### DIFF
--- a/app/[tenant]/admin/settings/client.tsx
+++ b/app/[tenant]/admin/settings/client.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { PocManagement } from '@/components/poc-management';
+import { VenueTypeManagement } from '@/components/venue-type-management';
+
+const TABS = ['poc', 'venue-types'] as const;
+type Tab = (typeof TABS)[number];
+
+function isValidTab(v: string | null): v is Tab {
+  return TABS.includes(v as Tab);
+}
+
+export function SettingsClient() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const raw = searchParams.get('tab');
+  const activeTab: Tab = isValidTab(raw) ? raw : 'poc';
+
+  function handleTabChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', value);
+    router.replace(`?${params.toString()}`);
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8">
+      <h1 className="text-2xl font-semibold mb-6">Settings</h1>
+
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <TabsList className="mb-6">
+          <TabsTrigger value="poc">Points of Contact</TabsTrigger>
+          <TabsTrigger value="venue-types">Venue Types</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="poc">
+          <PocManagement />
+        </TabsContent>
+
+        <TabsContent value="venue-types">
+          <VenueTypeManagement />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/app/[tenant]/admin/settings/page.tsx
+++ b/app/[tenant]/admin/settings/page.tsx
@@ -1,0 +1,10 @@
+import { getTenantFromHeaders } from '@/lib/tenant';
+import { requireEditor } from '@/lib/membership';
+import { SettingsClient } from './client';
+
+export default async function SettingsPage() {
+  const tenant = await getTenantFromHeaders();
+  await requireEditor(tenant.id);
+
+  return <SettingsClient />;
+}


### PR DESCRIPTION
## Summary
- Adds `app/[tenant]/admin/settings/page.tsx` — server component that calls `requireEditor` then renders the client
- Adds `app/[tenant]/admin/settings/client.tsx` — tabbed UI using shadcn `Tabs`, with tab state persisted in the `?tab=` URL search param
- Two tabs: **Points of Contact** (renders `PocManagement`) and **Venue Types** (renders `VenueTypeManagement`)

## Test plan
- [ ] Navigate to `{tenant}/admin/settings` as an editor — page loads on the POC tab by default
- [ ] Switch to Venue Types tab — URL updates to `?tab=venue-types`, tab persists on reload
- [ ] CRUD operations work on both tabs (covered by T-14/T-15)
- [ ] Non-editor user visiting the route is redirected to `/`
- [ ] Unauthenticated user is redirected to `/auth/sign-in`

🤖 Generated with [Claude Code](https://claude.com/claude-code)