### PR TITLE
T-17: Day data model and ensure-day-exists logic

### DIFF
--- a/app/actions/days.ts
+++ b/app/actions/days.ts
@@ -1,0 +1,69 @@
+'use server';
+
+import { createSupabaseServiceClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { getWeekdayName, datesInRange } from '@/lib/day-utils';
+import type { ActionResponse } from '@/types/actions';
+import type { Day } from '@/types/index';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function buildRow(tenantId: string, dateIso: string) {
+  return {
+    tenant_id: tenantId,
+    date_iso: dateIso,
+    weekday: getWeekdayName(dateIso),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Upserts a Day row for the current tenant + date.
+ * Uses the service role client — day creation is a system operation.
+ */
+export async function ensureDayExists(
+  dateIso: string
+): Promise<ActionResponse<Day>> {
+  const tenantId = await getTenantId();
+  const supabase = createSupabaseServiceClient();
+
+  const { data, error } = await supabase
+    .from('day')
+    .upsert(buildRow(tenantId, dateIso), {
+      onConflict: 'tenant_id,date_iso',
+    })
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as Day };
+}
+
+/**
+ * Upserts Day rows for every date in [startDate, endDate] (inclusive).
+ * Used by the month calendar view. Performs a single batch upsert.
+ */
+export async function ensureDaysRange(
+  startDate: string,
+  endDate: string
+): Promise<ActionResponse<Day[]>> {
+  const tenantId = await getTenantId();
+  const supabase = createSupabaseServiceClient();
+
+  const rows = datesInRange(startDate, endDate).map((d) =>
+    buildRow(tenantId, d)
+  );
+
+  const { data, error } = await supabase
+    .from('day')
+    .upsert(rows, { onConflict: 'tenant_id,date_iso' })
+    .select();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as Day[] };
+}

--- a/lib/day-utils.ts
+++ b/lib/day-utils.ts
@@ -1,6 +1,7 @@
 import {
   format,
   parse,
+  parseISO,
   startOfMonth,
   endOfMonth,
   addWeeks,
@@ -106,6 +107,26 @@ export function generateRecurrenceDates(
   }
 
   return results;
+}
+
+// ---------------------------------------------------------------------------
+// Range helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns an array of every YYYY-MM-DD date in [startDate, endDate] (inclusive).
+ */
+export function datesInRange(startDate: string, endDate: string): Ymd[] {
+  const dates: Ymd[] = [];
+  let current = parseISO(startDate);
+  const end = parseISO(endDate);
+
+  while (current <= end) {
+    dates.push(format(current, 'yyyy-MM-dd') as Ymd);
+    current = addDays(current, 1);
+  }
+
+  return dates;
 }
 
 function nextOccurrence(date: Date, frequency: Frequency): Date {

--- a/supabase/migrations/00006_create_day.sql
+++ b/supabase/migrations/00006_create_day.sql
@@ -1,0 +1,19 @@
+CREATE TABLE day (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id  UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  date_iso   TEXT NOT NULL,
+  weekday    TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX day_tenant_date_unique
+  ON day (tenant_id, date_iso);
+
+ALTER TABLE day ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "day: members can select"
+  ON day FOR SELECT TO authenticated
+  USING (is_tenant_member(tenant_id));
+
+-- Days are auto-created by the system (service role) on visit.
+-- No INSERT/UPDATE/DELETE policies for authenticated users.

--- a/tests/actions/days.test.ts
+++ b/tests/actions/days.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { getWeekdayName, datesInRange } from '@/lib/day-utils';
+
+// ---------------------------------------------------------------------------
+// Weekday computation (used by ensureDayExists / ensureDaysRange)
+// ---------------------------------------------------------------------------
+describe('getWeekdayName', () => {
+  it('returns Monday for 2024-04-01', () => {
+    expect(getWeekdayName('2024-04-01')).toBe('Monday');
+  });
+
+  it('returns Sunday for 2024-03-31', () => {
+    expect(getWeekdayName('2024-03-31')).toBe('Sunday');
+  });
+
+  it('returns Saturday for 2024-06-01', () => {
+    expect(getWeekdayName('2024-06-01')).toBe('Saturday');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// datesInRange (used by ensureDaysRange)
+// ---------------------------------------------------------------------------
+describe('datesInRange', () => {
+  it('returns a single date when start equals end', () => {
+    expect(datesInRange('2024-06-15', '2024-06-15')).toEqual(['2024-06-15']);
+  });
+
+  it('returns all dates in a short range', () => {
+    expect(datesInRange('2024-06-01', '2024-06-05')).toEqual([
+      '2024-06-01',
+      '2024-06-02',
+      '2024-06-03',
+      '2024-06-04',
+      '2024-06-05',
+    ]);
+  });
+
+  it('returns empty array when start is after end', () => {
+    expect(datesInRange('2024-06-10', '2024-06-05')).toEqual([]);
+  });
+
+  it('crosses a month boundary correctly', () => {
+    const result = datesInRange('2024-01-30', '2024-02-02');
+    expect(result).toEqual([
+      '2024-01-30',
+      '2024-01-31',
+      '2024-02-01',
+      '2024-02-02',
+    ]);
+  });
+
+  it('handles a full month range for February in a leap year', () => {
+    const result = datesInRange('2024-02-01', '2024-02-29');
+    expect(result).toHaveLength(29);
+    expect(result[0]).toBe('2024-02-01');
+    expect(result[28]).toBe('2024-02-29');
+  });
+
+  it('handles a full month range for February in a non-leap year', () => {
+    const result = datesInRange('2023-02-01', '2023-02-28');
+    expect(result).toHaveLength(28);
+    expect(result[27]).toBe('2023-02-28');
+  });
+
+  it('crosses a year boundary', () => {
+    const result = datesInRange('2024-12-30', '2025-01-02');
+    expect(result).toEqual([
+      '2024-12-30',
+      '2024-12-31',
+      '2025-01-01',
+      '2025-01-02',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `supabase/migrations/00006_create_day.sql` — `day` table with unique `(tenant_id, date_iso)` constraint; SELECT-only RLS for members; inserts use service role
- Adds `app/actions/days.ts` — `ensureDayExists(dateIso)` and `ensureDaysRange(startDate, endDate)` using service role client for idempotent upserts
- Extracts `datesInRange` into `lib/day-utils.ts` (alongside other pure date utilities) for testability
- Adds `tests/actions/days.test.ts` — 10 tests covering weekday computation and range generation (including leap years, month/year boundaries, empty ranges)

## Migration required
Run `supabase db push` (or apply `00006_create_day.sql`) on the linked project.

## Test plan
- [ ] `pnpm vitest run tests/actions/days.test.ts` — all 10 pass
- [ ] Navigate to a day page (T-18) — Day row is auto-created on first visit
- [ ] Re-visiting the same day is idempotent (no duplicate key errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)