### PR TITLE
T-18: Day page route and server data loading

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+// Stub — will be implemented in T-19.
+import type { DayViewProps } from './page';
+
+export function DayViewClient(_props: DayViewProps) {
+  return <div />;
+}

--- a/app/[tenant]/day/[date]/loading.tsx
+++ b/app/[tenant]/day/[date]/loading.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function DayLoading() {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+      {/* Date nav */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-9 w-9 rounded-md" />
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-9 w-9 rounded-md" />
+        <Skeleton className="h-9 w-20 rounded-md ml-auto" />
+      </div>
+
+      {/* Summary card */}
+      <Skeleton className="h-28 w-full rounded-xl" />
+
+      {/* Program items section */}
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-36" />
+        <Skeleton className="h-20 w-full rounded-lg" />
+        <Skeleton className="h-20 w-full rounded-lg" />
+      </div>
+
+      {/* Reservations section */}
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -1,0 +1,81 @@
+import { redirect } from 'next/navigation';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getTenantFromHeaders } from '@/lib/tenant';
+import { getAuthState } from '@/app/actions/auth';
+import { ensureDayExists } from '@/app/actions/days';
+import { isPastDate, isDateWithinOneYear, getTenantToday } from '@/lib/day-utils';
+import {
+  getProgramItemsForDay,
+  getReservationsForDay,
+  getHotelBookingsForDate,
+  getBreakfastConfigForDay,
+} from './queries';
+import { DayViewClient } from './DayViewClient';
+import type { ProgramItem, Reservation, HotelBooking, BreakfastConfiguration } from '@/types/index';
+import type { AuthState } from '@/types/actions';
+
+export type DayViewProps = {
+  date: string;
+  programItems: ProgramItem[];
+  reservations: Reservation[];
+  hotelBookings: HotelBooking[];
+  breakfastConfig: BreakfastConfiguration | null;
+  authState: AuthState;
+};
+
+const YMD_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export default async function DayPage({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const tenant = await getTenantFromHeaders();
+
+  // Fetch tenant timezone
+  const supabase = await createSupabaseServerClient();
+  const { data: tenantRow } = await supabase
+    .from('tenants')
+    .select('timezone')
+    .eq('id', tenant.id)
+    .single();
+  const timezone = tenantRow?.timezone ?? 'UTC';
+
+  const today = getTenantToday(timezone);
+
+  // Validate date — redirect to today on any invalid input
+  if (
+    !YMD_REGEX.test(date) ||
+    isPastDate(date, timezone) ||
+    !isDateWithinOneYear(date, timezone)
+  ) {
+    redirect(`/day/${today}`);
+  }
+
+  // Ensure Day row exists (idempotent)
+  const dayResult = await ensureDayExists(date);
+  if (!dayResult.success) redirect(`/day/${today}`);
+  const day = dayResult.data;
+
+  // Load all day data + auth state in parallel
+  const [programItems, reservations, hotelBookings, breakfastConfig, authState] =
+    await Promise.all([
+      getProgramItemsForDay(tenant.id, day.id),
+      getReservationsForDay(tenant.id, day.id),
+      getHotelBookingsForDate(tenant.id, date),
+      getBreakfastConfigForDay(tenant.id, day.id),
+      getAuthState(),
+    ]);
+
+  return (
+    <DayViewClient
+      date={date}
+      programItems={programItems}
+      reservations={reservations}
+      hotelBookings={hotelBookings}
+      breakfastConfig={breakfastConfig}
+      authState={authState}
+    />
+  );
+}

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -1,0 +1,63 @@
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import type { ProgramItem, Reservation, HotelBooking, BreakfastConfiguration } from '@/types/index';
+
+// These queries target tables created in T-20, T-23, T-25, T-26.
+// Until those migrations are applied they return empty arrays gracefully.
+
+export async function getProgramItemsForDay(
+  tenantId: string,
+  dayId: string
+): Promise<ProgramItem[]> {
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('program_items')
+    .select('*, point_of_contact(*), venue_type(*)')
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .order('start_time', { nullsFirst: true });
+  return (data ?? []) as unknown as ProgramItem[];
+}
+
+export async function getReservationsForDay(
+  tenantId: string,
+  dayId: string
+): Promise<Reservation[]> {
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('reservations')
+    .select('*, hotel_bookings(*)')
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .order('tee_time', { nullsFirst: true });
+  return (data ?? []) as unknown as Reservation[];
+}
+
+export async function getHotelBookingsForDate(
+  tenantId: string,
+  dateIso: string
+): Promise<HotelBooking[]> {
+  const supabase = await createSupabaseServerClient();
+  // Bookings where check_in <= dateIso < check_out (guest is on property)
+  const { data } = await supabase
+    .from('hotel_bookings')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .lte('check_in', dateIso)
+    .gt('check_out', dateIso)
+    .order('guest_name');
+  return (data ?? []) as unknown as HotelBooking[];
+}
+
+export async function getBreakfastConfigForDay(
+  tenantId: string,
+  dayId: string
+): Promise<BreakfastConfiguration | null> {
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('breakfast_configurations')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .maybeSingle();
+  return (data ?? null) as unknown as BreakfastConfiguration | null;
+}


### PR DESCRIPTION
## Summary
- Adds `app/[tenant]/day/[date]/page.tsx` — server component that validates the date param (YYYY-MM-DD, not past, within 1 year), redirects invalid dates to today, calls `ensureDayExists`, then loads all day data in parallel via `Promise.all`
- Adds `app/[tenant]/day/[date]/queries.ts` — reusable query functions for program items (with POC + venue type), reservations (with hotel bookings), hotel bookings overlapping the date, and breakfast config; return empty arrays gracefully until T-20/23/25/26 tables are applied
- Adds `app/[tenant]/day/[date]/DayViewClient.tsx` — stub client component (filled in T-19)
- Adds `app/[tenant]/day/[date]/loading.tsx` — skeleton matching the day view layout (nav, summary card, two content sections)

## Test plan
- [ ] Navigate to `{tenant}/day/2026-04-05` — page loads, Day row created in DB
- [ ] Navigate to `{tenant}/day/2024-01-01` (past) — redirects to today
- [ ] Navigate to `{tenant}/day/invalid` — redirects to today
- [ ] Navigate to `{tenant}/day/2030-01-01` (>1 year) — redirects to today
- [ ] Revisit same date — no duplicate key errors (idempotent upsert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)