### PR TITLE
T-19: Day view client shell, navigation, and summary

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -1,8 +1,81 @@
 'use client';
 
-// Stub — will be implemented in T-19.
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { DayNav } from '@/components/day-nav';
+import { DaySummaryCard } from '@/components/day-summary-card';
+import { Button } from '@/components/ui/button';
 import type { DayViewProps } from './page';
 
-export function DayViewClient(_props: DayViewProps) {
-  return <div />;
+export function DayViewClient({
+  date,
+  today,
+  programItems,
+  reservations,
+  hotelBookings,
+  breakfastConfigs,
+  authState,
+}: DayViewProps) {
+  // Modal state — consumed by T-21 (entries), T-24 (reservations), T-27 (hotel / breakfast)
+  const [_addEntryOpen, setAddEntryOpen] = useState(false);
+  const [_addReservationOpen, setAddReservationOpen] = useState(false);
+  const [_addHotelBookingOpen, setAddHotelBookingOpen] = useState(false);
+
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+      <DayNav date={date} today={today} />
+
+      <DaySummaryCard
+        programItems={programItems}
+        reservations={reservations}
+        hotelBookings={hotelBookings}
+        breakfastConfigs={breakfastConfigs}
+      />
+
+      {/* Golf & Events — entry cards added in T-22 */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="font-semibold">Golf &amp; Events</h2>
+          {authState.isEditor && (
+            <Button size="sm" onClick={() => setAddEntryOpen(true)}>
+              <Plus className="w-4 h-4 mr-1" /> Add entry
+            </Button>
+          )}
+        </div>
+        {programItems.length === 0 && (
+          <p className="text-sm text-muted-foreground">No entries yet.</p>
+        )}
+      </section>
+
+      {/* Tee Time Reservations — reservation cards added in T-24 */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="font-semibold">Tee Time Reservations</h2>
+          {authState.isEditor && (
+            <Button size="sm" onClick={() => setAddReservationOpen(true)}>
+              <Plus className="w-4 h-4 mr-1" /> Add reservation
+            </Button>
+          )}
+        </div>
+        {reservations.length === 0 && (
+          <p className="text-sm text-muted-foreground">No reservations yet.</p>
+        )}
+      </section>
+
+      {/* Hotel Bookings — editor-only, drawer added in T-27 */}
+      {authState.isEditor && (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold">Hotel Bookings</h2>
+            <Button size="sm" onClick={() => setAddHotelBookingOpen(true)}>
+              <Plus className="w-4 h-4 mr-1" /> Add booking
+            </Button>
+          </div>
+          {hotelBookings.length === 0 && (
+            <p className="text-sm text-muted-foreground">No hotel bookings yet.</p>
+          )}
+        </section>
+      )}
+    </div>
+  );
 }

--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -8,7 +8,7 @@ import {
   getProgramItemsForDay,
   getReservationsForDay,
   getHotelBookingsForDate,
-  getBreakfastConfigForDay,
+  getBreakfastConfigsForDay,
 } from './queries';
 import { DayViewClient } from './DayViewClient';
 import type { ProgramItem, Reservation, HotelBooking, BreakfastConfiguration } from '@/types/index';
@@ -16,10 +16,11 @@ import type { AuthState } from '@/types/actions';
 
 export type DayViewProps = {
   date: string;
+  today: string;
   programItems: ProgramItem[];
   reservations: Reservation[];
   hotelBookings: HotelBooking[];
-  breakfastConfig: BreakfastConfiguration | null;
+  breakfastConfigs: BreakfastConfiguration[];
   authState: AuthState;
 };
 
@@ -59,22 +60,23 @@ export default async function DayPage({
   const day = dayResult.data;
 
   // Load all day data + auth state in parallel
-  const [programItems, reservations, hotelBookings, breakfastConfig, authState] =
+  const [programItems, reservations, hotelBookings, breakfastConfigs, authState] =
     await Promise.all([
       getProgramItemsForDay(tenant.id, day.id),
       getReservationsForDay(tenant.id, day.id),
       getHotelBookingsForDate(tenant.id, date),
-      getBreakfastConfigForDay(tenant.id, day.id),
+      getBreakfastConfigsForDay(tenant.id, date),
       getAuthState(),
     ]);
 
   return (
     <DayViewClient
       date={date}
+      today={today}
       programItems={programItems}
       reservations={reservations}
       hotelBookings={hotelBookings}
-      breakfastConfig={breakfastConfig}
+      breakfastConfigs={breakfastConfigs}
       authState={authState}
     />
   );

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -48,16 +48,16 @@ export async function getHotelBookingsForDate(
   return (data ?? []) as unknown as HotelBooking[];
 }
 
-export async function getBreakfastConfigForDay(
+export async function getBreakfastConfigsForDay(
   tenantId: string,
-  dayId: string
-): Promise<BreakfastConfiguration | null> {
+  dateIso: string
+): Promise<BreakfastConfiguration[]> {
   const supabase = await createSupabaseServerClient();
   const { data } = await supabase
     .from('breakfast_configurations')
     .select('*')
     .eq('tenant_id', tenantId)
-    .eq('day_id', dayId)
-    .maybeSingle();
-  return (data ?? null) as unknown as BreakfastConfiguration | null;
+    .eq('breakfast_date', dateIso)
+    .order('created_at');
+  return (data ?? []) as unknown as BreakfastConfiguration[];
 }

--- a/components/day-nav.tsx
+++ b/components/day-nav.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { addDays, parseISO, format } from 'date-fns';
+import { ChevronLeft, ChevronRight, CalendarIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+
+type Props = {
+  date: string;
+  today: string;
+};
+
+export function DayNav({ date, today }: Props) {
+  const router = useRouter();
+  const [calOpen, setCalOpen] = useState(false);
+
+  const currentDate = parseISO(date);
+  const todayDate = parseISO(today);
+  const maxDate = addDays(todayDate, 365);
+
+  const prevYmd = format(addDays(currentDate, -1), 'yyyy-MM-dd');
+  const nextYmd = format(addDays(currentDate, 1), 'yyyy-MM-dd');
+  const maxYmd = format(maxDate, 'yyyy-MM-dd');
+
+  function navigate(d: string) {
+    router.push(`/day/${d}`);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => navigate(prevYmd)}
+        disabled={prevYmd < today}
+        aria-label="Previous day"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      <Popover open={calOpen} onOpenChange={setCalOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" className="min-w-44 justify-start gap-2 font-normal">
+            <CalendarIcon className="h-4 w-4 text-muted-foreground" />
+            {format(currentDate, 'EEE, d MMM yyyy')}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="single"
+            selected={currentDate}
+            onSelect={(d) => {
+              if (d) {
+                navigate(format(d, 'yyyy-MM-dd'));
+                setCalOpen(false);
+              }
+            }}
+            disabled={(d) => {
+              const ymd = format(d, 'yyyy-MM-dd');
+              return ymd < today || ymd > maxYmd;
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => navigate(nextYmd)}
+        disabled={nextYmd > maxYmd}
+        aria-label="Next day"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+
+      {date !== today && (
+        <Button variant="outline" size="sm" onClick={() => navigate(today)}>
+          Today
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/components/day-summary-card.tsx
+++ b/components/day-summary-card.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent } from '@/components/ui/card';
+import type { ProgramItem, Reservation, HotelBooking, BreakfastConfiguration } from '@/types/index';
+
+type Props = {
+  programItems: ProgramItem[];
+  reservations: Reservation[];
+  hotelBookings: HotelBooking[];
+  breakfastConfigs: BreakfastConfiguration[];
+};
+
+export function DaySummaryCard({ programItems, reservations, hotelBookings, breakfastConfigs }: Props) {
+  const totalHotelGuests = hotelBookings.reduce((sum, b) => sum + b.guest_count, 0);
+  const totalBreakfastGuests = breakfastConfigs.reduce((sum, b) => sum + b.total_guests, 0);
+  const totalProgramGuests = programItems.reduce((sum, p) => sum + (p.guest_count ?? 0), 0);
+
+  const bookingMap = new Map(hotelBookings.map((b) => [b.id, b.guest_name]));
+
+  return (
+    <Card>
+      <CardContent className="py-4">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <SummaryItem label="Hotel guests" value={totalHotelGuests} />
+          <SummaryItem label="Breakfasts" value={totalBreakfastGuests} />
+          <SummaryItem label="Golf / events" value={totalProgramGuests} />
+          <SummaryItem label="Tee time bookings" value={reservations.length} />
+        </div>
+
+        {breakfastConfigs.length > 0 && (
+          <div className="mt-4 border-t pt-3 space-y-1">
+            <p className="text-xs font-medium text-muted-foreground mb-2">Breakfast breakdown</p>
+            {breakfastConfigs.map((bc) => (
+              <div key={bc.id} className="flex justify-between text-sm">
+                <span>{bookingMap.get(bc.hotel_booking_id) ?? 'Unknown'}</span>
+                <span className="tabular-nums text-muted-foreground">{bc.total_guests}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SummaryItem({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <p className="text-2xl font-semibold tabular-nums">{value}</p>
+      <p className="text-xs text-muted-foreground mt-0.5">{label}</p>
+    </div>
+  );
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -16,35 +16,43 @@ export type MembershipUpdate = TablesUpdate<'memberships'>;
 // ── Future table aliases (populated when tables are created and db:types is re-run) ──
 // These are stubs that will be replaced with generated row types.
 
-/** @todo Replace with Tables<'days'> once the days table migration exists */
+/** @todo Replace with Tables<'day'> once db:types is re-run after T-17 migration */
 export type Day = {
   id: string;
   tenant_id: string;
-  date: string;
+  date_iso: string;
+  weekday: string;
   created_at: string;
-  updated_at: string;
 };
-export type DayInsert = Omit<Day, 'id' | 'created_at' | 'updated_at'>;
-export type DayUpdate = Partial<DayInsert>;
+export type DayInsert = Omit<Day, 'id' | 'created_at'>;
 
-/** @todo Replace with Tables<'program_items'> once the program_items migration exists */
+/** @todo Replace with Tables<'program_item'> once the program_item migration exists (T-20) */
 export type ProgramItem = {
   id: string;
   tenant_id: string;
   day_id: string;
+  type: 'golf' | 'event';
   title: string;
+  description: string | null;
   start_time: string | null;
   end_time: string | null;
+  guest_count: number | null;
+  capacity: number | null;
   venue_type_id: string | null;
-  point_of_contact_id: string | null;
-  recurrence_rule: string | null;
+  poc_id: string | null;
+  table_breakdown: number[] | null;
+  is_tour_operator: boolean;
+  notes: string | null;
+  is_recurring: boolean;
+  recurrence_frequency: string | null;
+  recurrence_group_id: string | null;
   created_at: string;
   updated_at: string;
 };
 export type ProgramItemInsert = Omit<ProgramItem, 'id' | 'created_at' | 'updated_at'>;
 export type ProgramItemUpdate = Partial<ProgramItemInsert>;
 
-/** @todo Replace with Tables<'reservations'> once the reservations migration exists */
+/** @todo Replace with Tables<'reservation'> once the reservation migration exists (T-23) */
 export type Reservation = {
   id: string;
   tenant_id: string;
@@ -60,25 +68,31 @@ export type Reservation = {
 export type ReservationInsert = Omit<Reservation, 'id' | 'created_at' | 'updated_at'>;
 export type ReservationUpdate = Partial<ReservationInsert>;
 
-/** @todo Replace with Tables<'hotel_bookings'> */
+/** @todo Replace with Tables<'hotel_booking'> once the hotel_booking migration exists (T-25) */
 export type HotelBooking = {
   id: string;
   tenant_id: string;
   guest_name: string;
+  guest_count: number;
   check_in: string;
   check_out: string;
-  room_type: string | null;
+  is_tour_operator: boolean;
+  notes: string | null;
   created_at: string;
   updated_at: string;
 };
 export type HotelBookingInsert = Omit<HotelBooking, 'id' | 'created_at' | 'updated_at'>;
 export type HotelBookingUpdate = Partial<HotelBookingInsert>;
 
-/** @todo Replace with Tables<'breakfast_configurations'> */
+/** @todo Replace with Tables<'breakfast_configuration'> once the migration exists (T-26) */
 export type BreakfastConfiguration = {
   id: string;
   tenant_id: string;
-  day_id: string;
+  hotel_booking_id: string;
+  breakfast_date: string;
+  table_breakdown: number[] | null;
+  total_guests: number;
+  start_time: string | null;
   notes: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- Replaces the T-18 stub with a full `DayViewClient` — manages modal state (entries, reservations, hotel bookings), renders DayNav + DaySummaryCard + three placeholder sections (Golf & Events, Tee Time Reservations, Hotel Bookings)
- Adds `components/day-nav.tsx` — prev/next day buttons, Calendar popover date picker, "Today" button; all navigation bounded to today…today+365 days
- Adds `components/day-summary-card.tsx` — compact Card showing hotel guests, breakfasts, golf/event guests, tee time count, with per-booking breakfast breakdown below
- Fixes stub types in `types/index.ts` to match the actual DB schemas from T-20/25/26 (adds `guest_count`, `type`, `hotel_booking_id`, `breakfast_date`, `total_guests`, etc.)
- Updates `queries.ts` and `page.tsx` for plural breakfast configs (`getBreakfastConfigsForDay`, `breakfast_date` filter) and to pass `today` down to `DayViewClient`

## Test plan
- [ ] Navigate to `{tenant}/day/{today}` — page renders with nav, summary card (all zeros), three empty sections
- [ ] Prev button is disabled on today; Next button active; Today button hidden when already on today
- [ ] Calendar picker restricts selection to today through today+365
- [ ] Hotel Bookings section is hidden when signed in as a viewer
- [ ] Editor sees all three sections with "Add" buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)