### PR TITLE
T-20: Program item data model and server actions

### DIFF
--- a/app/actions/program-items.ts
+++ b/app/actions/program-items.ts
@@ -1,0 +1,258 @@
+'use server';
+
+import { z } from 'zod';
+import { randomUUID } from 'crypto';
+import { createTenantClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { getUserRole, requireEditor } from '@/lib/membership';
+import { generateRecurrenceDates } from '@/lib/day-utils';
+import { ensureDayExists } from '@/app/actions/days';
+import type { ActionResponse } from '@/types/actions';
+import type { ProgramItem } from '@/types/index';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const programItemSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  type: z.enum(['golf', 'event']),
+  dayId: z.string().uuid('Day ID is required'),
+  description: z.string().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  guestCount: z.number().int().min(0).optional(),
+  capacity: z.number().int().min(0).optional(),
+  venueTypeId: z.string().uuid().optional().nullable(),
+  pocId: z.string().uuid().optional().nullable(),
+  tableBreakdown: z.array(z.number().int().min(0)).optional().nullable(),
+  isTourOperator: z.boolean().optional(),
+  notes: z.string().optional(),
+  isRecurring: z.boolean().optional(),
+  recurrenceFrequency: z
+    .enum(['weekly', 'biweekly', 'monthly', 'yearly'])
+    .optional()
+    .nullable(),
+});
+
+export type ProgramItemFormData = z.infer<typeof programItemSchema>;
+
+// ---------------------------------------------------------------------------
+// Table breakdown helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a "3+2+1" string into an integer array [3, 2, 1].
+ * Returns null for empty / null input.
+ */
+export function parseTableBreakdown(input: string | null | undefined): number[] | null {
+  if (!input || input.trim() === '') return null;
+  return input
+    .split('+')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !isNaN(n) && n >= 0);
+}
+
+// ---------------------------------------------------------------------------
+// Internal row builder
+// ---------------------------------------------------------------------------
+
+function toRow(
+  tenantId: string,
+  data: ProgramItemFormData,
+  overrides: Partial<{ day_id: string; recurrence_group_id: string; is_recurring: boolean }>
+) {
+  return {
+    tenant_id: tenantId,
+    day_id: overrides.day_id ?? data.dayId,
+    type: data.type,
+    title: data.title.trim(),
+    description: data.description?.trim() || null,
+    start_time: data.startTime || null,
+    end_time: data.endTime || null,
+    guest_count: data.guestCount ?? null,
+    capacity: data.capacity ?? null,
+    venue_type_id: data.venueTypeId ?? null,
+    poc_id: data.pocId ?? null,
+    table_breakdown: data.tableBreakdown ?? null,
+    is_tour_operator: data.isTourOperator ?? false,
+    notes: data.notes?.trim() || null,
+    is_recurring: overrides.is_recurring ?? data.isRecurring ?? false,
+    recurrence_frequency: data.recurrenceFrequency ?? null,
+    recurrence_group_id: overrides.recurrence_group_id ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export async function createProgramItem(
+  raw: ProgramItemFormData
+): Promise<ActionResponse<ProgramItem>> {
+  const parsed = programItemSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const data = parsed.data;
+  const isRecurring = data.isRecurring && !!data.recurrenceFrequency;
+
+  if (!isRecurring) {
+    const { data: row, error } = await supabase
+      .from('program_item')
+      .insert(toRow(tenantId, data, {}))
+      .select()
+      .single();
+
+    if (error) return { success: false, error: error.message };
+    return { success: true, data: row as ProgramItem };
+  }
+
+  // Recurring path: look up the start date, fan out to all occurrence dates
+  const { data: dayRow, error: dayErr } = await supabase
+    .from('day')
+    .select('date_iso')
+    .eq('id', data.dayId)
+    .single();
+
+  if (dayErr || !dayRow) {
+    return { success: false, error: 'Could not find the day record.' };
+  }
+
+  const startDate = dayRow.date_iso;
+  const futureDates = generateRecurrenceDates(startDate, data.recurrenceFrequency!);
+  const allDates = [startDate, ...futureDates];
+
+  const recurrenceGroupId = randomUUID();
+
+  // Ensure Day rows exist for all future dates
+  await Promise.all(futureDates.map((d) => ensureDayExists(d)));
+
+  // Fetch day IDs for all dates
+  const { data: dayRows, error: daysErr } = await supabase
+    .from('day')
+    .select('id, date_iso')
+    .eq('tenant_id', tenantId)
+    .in('date_iso', allDates);
+
+  if (daysErr || !dayRows) {
+    return { success: false, error: 'Could not resolve day records for recurrence.' };
+  }
+
+  const dateToId = new Map(dayRows.map((d) => [d.date_iso, d.id]));
+  const rows = allDates
+    .map((d) => dateToId.get(d))
+    .filter((id): id is string => !!id)
+    .map((dayId) =>
+      toRow(tenantId, data, {
+        day_id: dayId,
+        recurrence_group_id: recurrenceGroupId,
+        is_recurring: true,
+      })
+    );
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from('program_item')
+    .insert(rows)
+    .select()
+    .eq('day_id', data.dayId)
+    .single();
+
+  if (insertErr) return { success: false, error: insertErr.message };
+  return { success: true, data: inserted as ProgramItem };
+}
+
+export async function updateProgramItem(
+  id: string,
+  raw: ProgramItemFormData
+): Promise<ActionResponse<ProgramItem>> {
+  const parsed = programItemSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const data = parsed.data;
+
+  const { data: row, error } = await supabase
+    .from('program_item')
+    .update({
+      type: data.type,
+      title: data.title.trim(),
+      description: data.description?.trim() || null,
+      start_time: data.startTime || null,
+      end_time: data.endTime || null,
+      guest_count: data.guestCount ?? null,
+      capacity: data.capacity ?? null,
+      venue_type_id: data.venueTypeId ?? null,
+      poc_id: data.pocId ?? null,
+      table_breakdown: data.tableBreakdown ?? null,
+      is_tour_operator: data.isTourOperator ?? false,
+      notes: data.notes?.trim() || null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: row as ProgramItem };
+}
+
+export async function deleteProgramItem(id: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { error } = await supabase
+    .from('program_item')
+    .delete()
+    .eq('id', id)
+    .eq('tenant_id', tenantId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}
+
+export async function deleteRecurrenceGroup(groupId: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { error } = await supabase
+    .from('program_item')
+    .delete()
+    .eq('recurrence_group_id', groupId)
+    .eq('tenant_id', tenantId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}
+
+export async function getProgramItemsForDay(
+  dayId: string
+): Promise<ActionResponse<ProgramItem[]>> {
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('program_item')
+    .select('*, venue_type(*), point_of_contact(*)')
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .order('start_time', { nullsFirst: true });
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as unknown as ProgramItem[] };
+}

--- a/supabase/migrations/00007_create_program_item.sql
+++ b/supabase/migrations/00007_create_program_item.sql
@@ -1,0 +1,42 @@
+CREATE TABLE program_item (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id           UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  day_id              UUID NOT NULL REFERENCES day(id) ON DELETE CASCADE,
+  type                TEXT NOT NULL CHECK (type IN ('golf', 'event')),
+  title               TEXT NOT NULL,
+  description         TEXT,
+  start_time          TEXT,
+  end_time            TEXT,
+  guest_count         INT,
+  capacity            INT,
+  venue_type_id       UUID REFERENCES venue_type(id) ON DELETE SET NULL,
+  poc_id              UUID REFERENCES point_of_contact(id) ON DELETE SET NULL,
+  table_breakdown     JSONB,
+  is_tour_operator    BOOLEAN NOT NULL DEFAULT false,
+  notes               TEXT,
+  is_recurring        BOOLEAN NOT NULL DEFAULT false,
+  recurrence_frequency TEXT CHECK (recurrence_frequency IN ('weekly', 'biweekly', 'monthly', 'yearly')),
+  recurrence_group_id UUID,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX program_item_tenant_day_idx ON program_item (tenant_id, day_id);
+
+ALTER TABLE program_item ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "program_item: members can select"
+  ON program_item FOR SELECT TO authenticated
+  USING (is_tenant_member(tenant_id));
+
+CREATE POLICY "program_item: editors can insert"
+  ON program_item FOR INSERT TO authenticated
+  WITH CHECK (is_tenant_editor(tenant_id));
+
+CREATE POLICY "program_item: editors can update"
+  ON program_item FOR UPDATE TO authenticated
+  USING (is_tenant_editor(tenant_id));
+
+CREATE POLICY "program_item: editors can delete"
+  ON program_item FOR DELETE TO authenticated
+  USING (is_tenant_editor(tenant_id));

--- a/tests/actions/program-items.test.ts
+++ b/tests/actions/program-items.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { programItemSchema, parseTableBreakdown } from '@/app/actions/program-items';
+import { generateRecurrenceDates } from '@/lib/day-utils';
+
+// ---------------------------------------------------------------------------
+// parseTableBreakdown
+// ---------------------------------------------------------------------------
+describe('parseTableBreakdown', () => {
+  it('parses "3+2+1" to [3, 2, 1]', () => {
+    expect(parseTableBreakdown('3+2+1')).toEqual([3, 2, 1]);
+  });
+
+  it('parses a single number', () => {
+    expect(parseTableBreakdown('10')).toEqual([10]);
+  });
+
+  it('handles whitespace around values', () => {
+    expect(parseTableBreakdown('4 + 3 + 2')).toEqual([4, 3, 2]);
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseTableBreakdown('')).toBeNull();
+  });
+
+  it('returns null for null', () => {
+    expect(parseTableBreakdown(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(parseTableBreakdown(undefined)).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    expect(parseTableBreakdown('   ')).toBeNull();
+  });
+
+  it('handles "0" as a valid seat count', () => {
+    expect(parseTableBreakdown('0+4')).toEqual([0, 4]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// programItemSchema validation
+// ---------------------------------------------------------------------------
+describe('programItemSchema', () => {
+  const validGolf = {
+    title: 'Morning Round',
+    type: 'golf' as const,
+    dayId: '123e4567-e89b-12d3-a456-426614174000',
+  };
+
+  it('accepts a minimal valid golf item', () => {
+    expect(programItemSchema.safeParse(validGolf).success).toBe(true);
+  });
+
+  it('accepts a minimal valid event item', () => {
+    const result = programItemSchema.safeParse({ ...validGolf, type: 'event' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty title', () => {
+    const result = programItemSchema.safeParse({ ...validGolf, title: '' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].message).toBe('Title is required');
+  });
+
+  it('rejects missing title', () => {
+    const { title: _, ...noTitle } = validGolf;
+    expect(programItemSchema.safeParse(noTitle).success).toBe(false);
+  });
+
+  it('rejects invalid type', () => {
+    const result = programItemSchema.safeParse({ ...validGolf, type: 'lesson' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing dayId', () => {
+    const { dayId: _, ...noDayId } = validGolf;
+    expect(programItemSchema.safeParse(noDayId).success).toBe(false);
+  });
+
+  it('accepts optional fields', () => {
+    const result = programItemSchema.safeParse({
+      ...validGolf,
+      description: 'Full round',
+      startTime: '09:00',
+      endTime: '13:00',
+      guestCount: 12,
+      capacity: 20,
+      isTourOperator: true,
+      notes: 'Bring rain gear',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a recurring item with frequency', () => {
+    const result = programItemSchema.safeParse({
+      ...validGolf,
+      isRecurring: true,
+      recurrenceFrequency: 'weekly',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid recurrenceFrequency', () => {
+    const result = programItemSchema.safeParse({
+      ...validGolf,
+      isRecurring: true,
+      recurrenceFrequency: 'daily',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative guestCount', () => {
+    const result = programItemSchema.safeParse({ ...validGolf, guestCount: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts tableBreakdown as an array of integers', () => {
+    const result = programItemSchema.safeParse({
+      ...validGolf,
+      tableBreakdown: [3, 2, 1],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recurrence fanout integration
+// ---------------------------------------------------------------------------
+describe('recurrence fanout (generateRecurrenceDates integration)', () => {
+  it('weekly from 2024-06-01 for 4 weeks generates 4 future dates', () => {
+    const futureDates = generateRecurrenceDates('2024-06-01', 'weekly', '2024-06-29');
+    expect(futureDates).toEqual(['2024-06-08', '2024-06-15', '2024-06-22', '2024-06-29']);
+    // Including the start date, 5 items are created
+    expect([' 2024-06-01', ...futureDates]).toHaveLength(5);
+  });
+
+  it('monthly from 2024-01-31 for 3 months generates 3 future dates (clamped)', () => {
+    const futureDates = generateRecurrenceDates('2024-01-31', 'monthly', '2024-05-01');
+    expect(futureDates).toEqual(['2024-02-29', '2024-03-29', '2024-04-29']);
+  });
+
+  it('biweekly from 2024-06-01 for 6 weeks generates 3 future dates', () => {
+    const futureDates = generateRecurrenceDates('2024-06-01', 'biweekly', '2024-07-13');
+    expect(futureDates).toEqual(['2024-06-15', '2024-06-29', '2024-07-13']);
+  });
+
+  it('total occurrences = 1 (start) + future dates', () => {
+    const start = '2024-09-01';
+    const futureDates = generateRecurrenceDates(start, 'weekly', '2024-09-22');
+    const allOccurrences = [start, ...futureDates];
+    expect(allOccurrences).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `supabase/migrations/00007_create_program_item.sql` — `program_item` table with type check, FK to `day` + `venue_type` + `point_of_contact`, recurrence fields, RLS, and index on `(tenant_id, day_id)`
- Adds `app/actions/program-items.ts`:
  - `createProgramItem` — single insert or recurring fanout (upserts all Day rows, batch inserts with shared `recurrence_group_id`)
  - `updateProgramItem` — updates single item
  - `deleteProgramItem` — deletes single item
  - `deleteRecurrenceGroup` — deletes entire series by `recurrence_group_id`
  - `getProgramItemsForDay` — returns items with joined `venue_type` and `point_of_contact`
  - `parseTableBreakdown` — exported pure helper: `"3+2+1"` → `[3, 2, 1]`
- Adds `tests/actions/program-items.test.ts` — 23 tests covering breakdown parsing, Zod schema validation, and recurrence fanout integration

## Migration required
Run `supabase db push` to apply `00007_create_program_item.sql`.

## Test plan
- [ ] `pnpm vitest run tests/actions/program-items.test.ts` — all 23 pass
- [ ] Create a golf item on a day page — appears in the list
- [ ] Create a weekly recurring item — rows created for all future dates within 1 year
- [ ] Delete single vs delete series

🤖 Generated with [Claude Code](https://claude.com/claude-code)