### PR TITLE
T-22: Entry card component

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -5,8 +5,9 @@ import { Plus } from 'lucide-react';
 import { DayNav } from '@/components/day-nav';
 import { DaySummaryCard } from '@/components/day-summary-card';
 import { AddEntryModal } from '@/components/add-entry-modal';
+import { EntryCard } from '@/components/entry-card';
 import { Button } from '@/components/ui/button';
-import type { ProgramItem } from '@/types/index';
+import type { ProgramItem, ProgramItemWithRelations } from '@/types/index';
 import type { DayViewProps } from './page';
 
 export function DayViewClient({
@@ -21,12 +22,14 @@ export function DayViewClient({
   venueTypes,
   authState,
 }: DayViewProps) {
-  const [programItems, setProgramItems] = useState(initialProgramItems);
+  const [programItems, setProgramItems] = useState(
+    initialProgramItems as ProgramItemWithRelations[]
+  );
 
   // Entry modal state
   const [entryModalOpen, setEntryModalOpen] = useState(false);
   const [entryType, setEntryType] = useState<'golf' | 'event'>('golf');
-  const [editEntry, setEditEntry] = useState<ProgramItem | null>(null);
+  const [editEntry, setEditEntry] = useState<ProgramItemWithRelations | null>(null);
 
   // Placeholder modal state for T-24 / T-27
   const [_addReservationOpen, setAddReservationOpen] = useState(false);
@@ -38,7 +41,7 @@ export function DayViewClient({
     setEntryModalOpen(true);
   }
 
-  function openEditEntry(item: ProgramItem) {
+  function openEditEntry(item: ProgramItemWithRelations) {
     setEntryType(item.type);
     setEditEntry(item);
     setEntryModalOpen(true);
@@ -49,13 +52,24 @@ export function DayViewClient({
       const idx = prev.findIndex((p) => p.id === item.id);
       if (idx >= 0) {
         const next = [...prev];
-        next[idx] = item;
+        next[idx] = item as ProgramItemWithRelations;
         return next;
       }
-      return [...prev, item].sort((a, b) =>
+      return [...prev, item as ProgramItemWithRelations].sort((a, b) =>
         (a.start_time ?? '').localeCompare(b.start_time ?? '')
       );
     });
+  }
+
+  function handleEntryDeleted(id: string, mode: 'single' | 'all') {
+    if (mode === 'all') {
+      const groupId = programItems.find((p) => p.id === id)?.recurrence_group_id;
+      setProgramItems((prev) =>
+        groupId ? prev.filter((p) => p.recurrence_group_id !== groupId) : prev.filter((p) => p.id !== id)
+      );
+    } else {
+      setProgramItems((prev) => prev.filter((p) => p.id !== id));
+    }
   }
 
   return (
@@ -69,7 +83,7 @@ export function DayViewClient({
         breakfastConfigs={breakfastConfigs}
       />
 
-      {/* Golf & Events — entry cards added in T-22 */}
+      {/* Golf & Events */}
       <section className="space-y-3">
         <div className="flex items-center justify-between">
           <h2 className="font-semibold">Golf &amp; Events</h2>
@@ -84,12 +98,25 @@ export function DayViewClient({
             </div>
           )}
         </div>
-        {programItems.length === 0 && (
+
+        {programItems.length === 0 ? (
           <p className="text-sm text-muted-foreground">No entries yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {programItems.map((item) => (
+              <EntryCard
+                key={item.id}
+                item={item}
+                isEditor={authState.isEditor}
+                onEdit={openEditEntry}
+                onDeleted={handleEntryDeleted}
+              />
+            ))}
+          </div>
         )}
       </section>
 
-      {/* Tee Time Reservations — reservation cards added in T-24 */}
+      {/* Tee Time Reservations — cards added in T-24 */}
       <section className="space-y-3">
         <div className="flex items-center justify-between">
           <h2 className="font-semibold">Tee Time Reservations</h2>

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -10,7 +10,7 @@ export async function getProgramItemsForDay(
 ): Promise<ProgramItem[]> {
   const supabase = await createSupabaseServerClient();
   const { data } = await supabase
-    .from('program_items')
+    .from('program_item')
     .select('*, point_of_contact(*), venue_type(*)')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)

--- a/components/entry-card.tsx
+++ b/components/entry-card.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Pencil, Trash2, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import { deleteProgramItem, deleteRecurrenceGroup } from '@/app/actions/program-items';
+import type { ProgramItemWithRelations } from '@/types/index';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+type Props = {
+  item: ProgramItemWithRelations;
+  isEditor: boolean;
+  onEdit: (item: ProgramItemWithRelations) => void;
+  onDeleted: (id: string, mode: 'single' | 'all') => void;
+};
+
+export function EntryCard({ item, isEditor, onEdit, onDeleted }: Props) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, startDeleteTransition] = useTransition();
+  const isRecurring = !!item.recurrence_group_id;
+
+  function handleDelete(mode: 'single' | 'all') {
+    startDeleteTransition(async () => {
+      const result =
+        mode === 'all' && item.recurrence_group_id
+          ? await deleteRecurrenceGroup(item.recurrence_group_id)
+          : await deleteProgramItem(item.id);
+
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success(mode === 'all' ? 'All occurrences deleted.' : 'Entry deleted.');
+      setDeleteOpen(false);
+      onDeleted(item.id, mode);
+    });
+  }
+
+  return (
+    <>
+      <Card>
+        <CardContent className="py-3 px-4">
+          <div className="flex items-start justify-between gap-3">
+            {/* Left: details */}
+            <div className="flex-1 min-w-0 space-y-1.5">
+              {/* Badges row */}
+              <div className="flex flex-wrap items-center gap-1.5">
+                <TypeBadge type={item.type} />
+                {item.is_tour_operator && (
+                  <Badge variant="outline" className="text-amber-600 border-amber-300">
+                    Tour operator
+                  </Badge>
+                )}
+                {isRecurring && (
+                  <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                    <RefreshCw className="h-3 w-3" /> Recurring
+                  </span>
+                )}
+              </div>
+
+              {/* Title */}
+              <p className="font-medium leading-snug truncate">{item.title}</p>
+
+              {/* Time range */}
+              {(item.start_time || item.end_time) && (
+                <p className="text-sm text-muted-foreground">
+                  {formatTimeRange(item.start_time, item.end_time)}
+                </p>
+              )}
+
+              {/* Guest count / capacity */}
+              {(item.guest_count != null || item.capacity != null) && (
+                <p className="text-sm text-muted-foreground">
+                  {formatGuests(item.guest_count, item.capacity)}
+                </p>
+              )}
+
+              {/* Venue type */}
+              {item.venue_type && (
+                <p className="text-sm text-muted-foreground">
+                  {item.venue_type.name}
+                </p>
+              )}
+
+              {/* Point of contact */}
+              {item.point_of_contact && (
+                <p className="text-sm text-muted-foreground">
+                  {item.point_of_contact.name}
+                </p>
+              )}
+
+              {/* Table breakdown */}
+              {item.table_breakdown && item.table_breakdown.length > 0 && (
+                <p className="text-sm text-muted-foreground">
+                  {formatTableBreakdown(item.table_breakdown)}
+                </p>
+              )}
+
+              {/* Notes */}
+              {item.notes && (
+                <p className="text-sm text-muted-foreground italic">{item.notes}</p>
+              )}
+            </div>
+
+            {/* Right: actions */}
+            {isEditor && (
+              <div className="flex gap-1 shrink-0">
+                <Button variant="ghost" size="icon" onClick={() => onEdit(item)}>
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Delete dialog */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete entry?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {isRecurring
+                ? 'This is a recurring entry. Choose what to delete.'
+                : <>This will permanently delete <strong>{item.title}</strong>.</>}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className={isRecurring ? 'flex-col sm:flex-row gap-2' : undefined}>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            {isRecurring ? (
+              <>
+                <AlertDialogAction
+                  onClick={() => handleDelete('single')}
+                  disabled={isDeleting}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                >
+                  {isDeleting ? 'Deleting…' : 'Delete this occurrence'}
+                </AlertDialogAction>
+                <AlertDialogAction
+                  onClick={() => handleDelete('all')}
+                  disabled={isDeleting}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                >
+                  {isDeleting ? 'Deleting…' : 'Delete all occurrences'}
+                </AlertDialogAction>
+              </>
+            ) : (
+              <AlertDialogAction
+                onClick={() => handleDelete('single')}
+                disabled={isDeleting}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {isDeleting ? 'Deleting…' : 'Delete'}
+              </AlertDialogAction>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components / helpers
+// ---------------------------------------------------------------------------
+
+function TypeBadge({ type }: { type: 'golf' | 'event' }) {
+  if (type === 'golf') {
+    return (
+      <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 hover:bg-emerald-100">
+        Golf
+      </Badge>
+    );
+  }
+  return (
+    <Badge className="bg-blue-100 text-blue-700 border-blue-200 hover:bg-blue-100">
+      Event
+    </Badge>
+  );
+}
+
+function formatTimeRange(start: string | null, end: string | null): string {
+  if (start && end) return `${start} – ${end}`;
+  if (start) return `From ${start}`;
+  if (end) return `Until ${end}`;
+  return '';
+}
+
+function formatGuests(count: number | null, capacity: number | null): string {
+  if (count != null && capacity != null) return `${count} / ${capacity} guests`;
+  if (count != null) return `${count} guests`;
+  if (capacity != null) return `Capacity: ${capacity}`;
+  return '';
+}
+
+function formatTableBreakdown(breakdown: number[]): string {
+  return breakdown
+    .map((seats, i) => `Table ${i + 1} (${seats})`)
+    .join(' | ');
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -107,3 +107,9 @@ export type PointOfContactUpdate = TablesUpdate<'point_of_contact'>;
 export type VenueType = Tables<'venue_type'>;
 export type VenueTypeInsert = TablesInsert<'venue_type'>;
 export type VenueTypeUpdate = TablesUpdate<'venue_type'>;
+
+/** ProgramItem with joined venue_type and point_of_contact relations */
+export type ProgramItemWithRelations = ProgramItem & {
+  venue_type: VenueType | null;
+  point_of_contact: PointOfContact | null;
+};


### PR DESCRIPTION
## Summary
- Adds `components/entry-card.tsx` — Card showing type badge (Golf=emerald, Event=blue), title, time range, guest count/capacity, venue type, POC, table breakdown formatted as "Table 1 (3) | Table 2 (2) | Table 3 (1)", tour operator badge, and notes; edit/delete actions for editors
- Recurring items show a RefreshCw indicator; delete dialog offers two actions — "Delete this occurrence" and "Delete all occurrences"
- Wires cards into `DayViewClient`; edit button opens `AddEntryModal` with `editItem` pre-filled; delete calls `deleteProgramItem` or `deleteRecurrenceGroup` and updates local state
- Adds `ProgramItemWithRelations` type to `types/index.ts`
- Fixes wrong table name `program_items` → `program_item` in `queries.ts`

## Test plan
- [ ] Day page shows EntryCards for existing program items
- [ ] Golf card has emerald badge; event card has blue badge
- [ ] Edit button opens modal pre-filled with item data; save updates the card in place
- [ ] Delete non-recurring → single confirmation → item removed
- [ ] Delete recurring → two-option dialog → "Delete this occurrence" removes one; "Delete all" removes all with same `recurrence_group_id`
- [ ] Editor actions hidden for viewer role

🤖 Generated with [Claude Code](https://claude.com/claude-code)