### PR TITLE
T-23: Reservation data model and server actions

### DIFF
--- a/app/actions/reservations.ts
+++ b/app/actions/reservations.ts
@@ -1,0 +1,119 @@
+'use server';
+
+import { createTenantClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { getUserRole, requireEditor } from '@/lib/membership';
+import { reservationSchema } from '@/lib/reservation-schema';
+import type { ReservationFormData } from '@/lib/reservation-schema';
+import type { ActionResponse } from '@/types/actions';
+import type { Reservation } from '@/types/index';
+
+export async function createReservation(
+  raw: ReservationFormData
+): Promise<ActionResponse<Reservation>> {
+  const parsed = reservationSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const d = parsed.data;
+
+  const { data, error } = await supabase
+    .from('reservation')
+    .insert({
+      tenant_id: tenantId,
+      day_id: d.dayId,
+      guest_name: d.guestName || null,
+      guest_email: d.guestEmail || null,
+      guest_phone: d.guestPhone || null,
+      guest_count: d.guestCount ?? null,
+      start_time: d.startTime || null,
+      end_time: d.endTime || null,
+      notes: d.notes || null,
+      hotel_booking_id: d.hotelBookingId ?? null,
+      program_item_id: d.programItemId ?? null,
+      table_index: d.tableIndex ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as Reservation };
+}
+
+export async function updateReservation(
+  id: string,
+  raw: ReservationFormData
+): Promise<ActionResponse<Reservation>> {
+  const parsed = reservationSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const d = parsed.data;
+
+  const { data, error } = await supabase
+    .from('reservation')
+    .update({
+      guest_name: d.guestName || null,
+      guest_email: d.guestEmail || null,
+      guest_phone: d.guestPhone || null,
+      guest_count: d.guestCount ?? null,
+      start_time: d.startTime || null,
+      end_time: d.endTime || null,
+      notes: d.notes || null,
+      hotel_booking_id: d.hotelBookingId ?? null,
+      program_item_id: d.programItemId ?? null,
+      table_index: d.tableIndex ?? null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as Reservation };
+}
+
+export async function deleteReservation(id: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { error } = await supabase
+    .from('reservation')
+    .delete()
+    .eq('id', id)
+    .eq('tenant_id', tenantId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}
+
+export async function getReservationsForDay(
+  dayId: string
+): Promise<ActionResponse<Reservation[]>> {
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('reservation')
+    .select('*, hotel_booking(*), program_item(*)')
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .order('start_time', { nullsFirst: true });
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as unknown as Reservation[] };
+}

--- a/lib/reservation-schema.ts
+++ b/lib/reservation-schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const reservationSchema = z.object({
+  dayId: z.string().uuid('Day ID is required'),
+  guestName: z.string().optional(),
+  guestEmail: z.string().email('Invalid email address').optional().or(z.literal('')),
+  guestPhone: z.string().optional(),
+  guestCount: z.number().int().min(1).optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  notes: z.string().optional(),
+  hotelBookingId: z.string().uuid().optional().nullable(),
+  programItemId: z.string().uuid().optional().nullable(),
+  tableIndex: z.number().int().min(0).optional().nullable(),
+});
+
+export type ReservationFormData = z.infer<typeof reservationSchema>;

--- a/supabase/migrations/00008_create_reservation.sql
+++ b/supabase/migrations/00008_create_reservation.sql
@@ -1,0 +1,38 @@
+CREATE TABLE reservation (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id        UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  day_id           UUID NOT NULL REFERENCES day(id) ON DELETE CASCADE,
+  guest_name       TEXT,
+  guest_email      TEXT,
+  guest_phone      TEXT,
+  guest_count      INT,
+  start_time       TEXT,
+  end_time         TEXT,
+  notes            TEXT,
+  -- hotel_booking_id FK added in 00009_create_hotel_booking.sql
+  hotel_booking_id UUID,
+  program_item_id  UUID REFERENCES program_item(id) ON DELETE SET NULL,
+  table_index      INT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX reservation_tenant_day_idx ON reservation (tenant_id, day_id);
+
+ALTER TABLE reservation ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "reservation: members can select"
+  ON reservation FOR SELECT TO authenticated
+  USING (is_tenant_member(tenant_id));
+
+CREATE POLICY "reservation: editors can insert"
+  ON reservation FOR INSERT TO authenticated
+  WITH CHECK (is_tenant_editor(tenant_id));
+
+CREATE POLICY "reservation: editors can update"
+  ON reservation FOR UPDATE TO authenticated
+  USING (is_tenant_editor(tenant_id));
+
+CREATE POLICY "reservation: editors can delete"
+  ON reservation FOR DELETE TO authenticated
+  USING (is_tenant_editor(tenant_id));

--- a/tests/actions/reservations.test.ts
+++ b/tests/actions/reservations.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { reservationSchema } from '@/lib/reservation-schema';
+
+const VALID_DAY_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+describe('reservationSchema', () => {
+  it('accepts a minimal reservation with only dayId', () => {
+    const result = reservationSchema.safeParse({ dayId: VALID_DAY_ID });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a full reservation', () => {
+    const result = reservationSchema.safeParse({
+      dayId: VALID_DAY_ID,
+      guestName: 'Jane Smith',
+      guestEmail: 'jane@example.com',
+      guestPhone: '+32 123 456 789',
+      guestCount: 4,
+      startTime: '19:00',
+      endTime: '21:00',
+      notes: 'Window seat requested',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing dayId', () => {
+    const result = reservationSchema.safeParse({ guestName: 'Test' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid email', () => {
+    const result = reservationSchema.safeParse({
+      dayId: VALID_DAY_ID,
+      guestEmail: 'not-an-email',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].message).toBe('Invalid email address');
+  });
+
+  it('accepts empty string for email (treated as absent)', () => {
+    const result = reservationSchema.safeParse({
+      dayId: VALID_DAY_ID,
+      guestEmail: '',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects guestCount less than 1', () => {
+    const result = reservationSchema.safeParse({
+      dayId: VALID_DAY_ID,
+      guestCount: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts optional hotel and program item links', () => {
+    const result = reservationSchema.safeParse({
+      dayId: VALID_DAY_ID,
+      hotelBookingId: '123e4567-e89b-12d3-a456-426614174001',
+      programItemId: '123e4567-e89b-12d3-a456-426614174002',
+      tableIndex: 2,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts null for optional link fields', () => {
+    const result = reservationSchema.safeParse({
+      dayId: VALID_DAY_ID,
+      hotelBookingId: null,
+      programItemId: null,
+      tableIndex: null,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -52,16 +52,21 @@ export type ProgramItem = {
 export type ProgramItemInsert = Omit<ProgramItem, 'id' | 'created_at' | 'updated_at'>;
 export type ProgramItemUpdate = Partial<ProgramItemInsert>;
 
-/** @todo Replace with Tables<'reservation'> once the reservation migration exists (T-23) */
+/** @todo Replace with Tables<'reservation'> once db:types is re-run after T-23 migration */
 export type Reservation = {
   id: string;
   tenant_id: string;
   day_id: string;
-  guest_name: string;
-  tee_time: string | null;
-  holes: number | null;
+  guest_name: string | null;
+  guest_email: string | null;
+  guest_phone: string | null;
+  guest_count: number | null;
+  start_time: string | null;
+  end_time: string | null;
+  notes: string | null;
   hotel_booking_id: string | null;
   program_item_id: string | null;
+  table_index: number | null;
   created_at: string;
   updated_at: string;
 };


### PR DESCRIPTION
## Summary
- Adds `supabase/migrations/00008_create_reservation.sql` — `reservation` table with guest contact fields, times, notes, optional links to `program_item` and `hotel_booking`; index on `(tenant_id, day_id)`; RLS with standard policies
- `hotel_booking_id` is a plain UUID column (no FK yet) — the FK constraint will be added in `00009_create_hotel_booking.sql` (T-25) once that table exists
- Adds `lib/reservation-schema.ts` — Zod schema (outside `'use server'` boundary)
- Adds `app/actions/reservations.ts` — `createReservation`, `updateReservation`, `deleteReservation`, `getReservationsForDay` (with joined `hotel_booking` + `program_item`)
- Updates `Reservation` stub type in `types/index.ts` to match actual schema (replaces old `tee_time`/`holes` fields with `guest_count`, `start_time`, `end_time`, `guest_email`, `guest_phone`, `table_index`)
- Adds 8 schema validation tests

## Migration required
Run `supabase db push` to apply `00008_create_reservation.sql`.

## Test plan
- [ ] `pnpm vitest run tests/actions/reservations.test.ts` — all 8 pass
- [ ] Create a reservation via the T-24 UI — appears in the day view

🤖 Generated with [Claude Code](https://claude.com/claude-code)