### PR TITLE
T-24: Reservation UI — add/edit modal, reservation card, wired into day view

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -6,8 +6,15 @@ import { DayNav } from '@/components/day-nav';
 import { DaySummaryCard } from '@/components/day-summary-card';
 import { AddEntryModal } from '@/components/add-entry-modal';
 import { EntryCard } from '@/components/entry-card';
+import { AddReservationModal } from '@/components/add-reservation-modal';
+import { ReservationCard } from '@/components/reservation-card';
 import { Button } from '@/components/ui/button';
-import type { ProgramItem, ProgramItemWithRelations } from '@/types/index';
+import type {
+  ProgramItem,
+  ProgramItemWithRelations,
+  Reservation,
+  ReservationWithRelations,
+} from '@/types/index';
 import type { DayViewProps } from './page';
 
 export function DayViewClient({
@@ -15,7 +22,7 @@ export function DayViewClient({
   dayId,
   today,
   programItems: initialProgramItems,
-  reservations,
+  reservations: initialReservations,
   hotelBookings,
   breakfastConfigs,
   pocs,
@@ -25,15 +32,23 @@ export function DayViewClient({
   const [programItems, setProgramItems] = useState(
     initialProgramItems as ProgramItemWithRelations[]
   );
+  const [reservations, setReservations] = useState(
+    initialReservations as ReservationWithRelations[]
+  );
 
   // Entry modal state
   const [entryModalOpen, setEntryModalOpen] = useState(false);
   const [entryType, setEntryType] = useState<'golf' | 'event'>('golf');
   const [editEntry, setEditEntry] = useState<ProgramItemWithRelations | null>(null);
 
-  // Placeholder modal state for T-24 / T-27
-  const [_addReservationOpen, setAddReservationOpen] = useState(false);
+  // Reservation modal state
+  const [reservationModalOpen, setReservationModalOpen] = useState(false);
+  const [editReservation, setEditReservation] = useState<ReservationWithRelations | null>(null);
+
+  // Placeholder for T-27
   const [_addHotelBookingOpen, setAddHotelBookingOpen] = useState(false);
+
+  // ---------- Entry handlers ----------
 
   function openAddEntry(type: 'golf' | 'event') {
     setEntryType(type);
@@ -65,11 +80,43 @@ export function DayViewClient({
     if (mode === 'all') {
       const groupId = programItems.find((p) => p.id === id)?.recurrence_group_id;
       setProgramItems((prev) =>
-        groupId ? prev.filter((p) => p.recurrence_group_id !== groupId) : prev.filter((p) => p.id !== id)
+        groupId
+          ? prev.filter((p) => p.recurrence_group_id !== groupId)
+          : prev.filter((p) => p.id !== id)
       );
     } else {
       setProgramItems((prev) => prev.filter((p) => p.id !== id));
     }
+  }
+
+  // ---------- Reservation handlers ----------
+
+  function openAddReservation() {
+    setEditReservation(null);
+    setReservationModalOpen(true);
+  }
+
+  function openEditReservation(item: ReservationWithRelations) {
+    setEditReservation(item);
+    setReservationModalOpen(true);
+  }
+
+  function handleReservationSaved(item: Reservation) {
+    setReservations((prev) => {
+      const idx = prev.findIndex((r) => r.id === item.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = item as ReservationWithRelations;
+        return next;
+      }
+      return [...prev, item as ReservationWithRelations].sort((a, b) =>
+        (a.start_time ?? '').localeCompare(b.start_time ?? '')
+      );
+    });
+  }
+
+  function handleReservationDeleted(id: string) {
+    setReservations((prev) => prev.filter((r) => r.id !== id));
   }
 
   return (
@@ -98,7 +145,6 @@ export function DayViewClient({
             </div>
           )}
         </div>
-
         {programItems.length === 0 ? (
           <p className="text-sm text-muted-foreground">No entries yet.</p>
         ) : (
@@ -116,18 +162,30 @@ export function DayViewClient({
         )}
       </section>
 
-      {/* Tee Time Reservations — cards added in T-24 */}
+      {/* Tee Time Reservations */}
       <section className="space-y-3">
         <div className="flex items-center justify-between">
           <h2 className="font-semibold">Tee Time Reservations</h2>
           {authState.isEditor && (
-            <Button size="sm" onClick={() => setAddReservationOpen(true)}>
+            <Button size="sm" onClick={openAddReservation}>
               <Plus className="w-4 h-4 mr-1" /> Add reservation
             </Button>
           )}
         </div>
-        {reservations.length === 0 && (
+        {reservations.length === 0 ? (
           <p className="text-sm text-muted-foreground">No reservations yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {reservations.map((item) => (
+              <ReservationCard
+                key={item.id}
+                item={item}
+                isEditor={authState.isEditor}
+                onEdit={openEditReservation}
+                onDeleted={handleReservationDeleted}
+              />
+            ))}
+          </div>
         )}
       </section>
 
@@ -156,6 +214,16 @@ export function DayViewClient({
         venueTypes={venueTypes}
         editItem={editEntry}
         onSuccess={handleEntrySaved}
+      />
+
+      <AddReservationModal
+        isOpen={reservationModalOpen}
+        onClose={() => setReservationModalOpen(false)}
+        dayId={dayId}
+        hotelBookings={hotelBookings}
+        programItems={programItems}
+        editItem={editReservation}
+        onSuccess={handleReservationSaved}
       />
     </div>
   );

--- a/components/add-reservation-modal.tsx
+++ b/components/add-reservation-modal.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { createReservation, updateReservation } from '@/app/actions/reservations';
+import type { Reservation, HotelBooking, ProgramItem } from '@/types/index';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+// ---------------------------------------------------------------------------
+// Local form schema
+// ---------------------------------------------------------------------------
+
+const formSchema = z.object({
+  guestName: z.string().optional(),
+  guestEmail: z.string().email('Invalid email address').optional().or(z.literal('')),
+  guestPhone: z.string().optional(),
+  guestCount: z.string().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  notes: z.string().optional(),
+  hotelBookingId: z.string().optional(),
+  programItemId: z.string().optional(),
+  tableIndex: z.string().optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+const NONE = '__none__';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  dayId: string;
+  hotelBookings: HotelBooking[];
+  programItems: ProgramItem[];
+  editItem?: Reservation | null;
+  onSuccess: (item: Reservation) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AddReservationModal({
+  isOpen,
+  onClose,
+  dayId,
+  hotelBookings,
+  programItems,
+  editItem,
+  onSuccess,
+}: Props) {
+  const [isPending, startTransition] = useTransition();
+  const isEditing = !!editItem;
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: defaultValues(editItem),
+  });
+
+  useEffect(() => {
+    reset(defaultValues(editItem));
+  }, [isOpen, editItem, reset]);
+
+  const watchProgramItemId = watch('programItemId');
+  const selectedItem = programItems.find((p) => p.id === watchProgramItemId);
+  const hasBreakdown = selectedItem?.table_breakdown && selectedItem.table_breakdown.length > 0;
+
+  // Reset table index when program item changes
+  useEffect(() => {
+    setValue('tableIndex', '');
+  }, [watchProgramItemId, setValue]);
+
+  function onSubmit(data: FormData) {
+    startTransition(async () => {
+      const payload = {
+        dayId,
+        guestName: data.guestName || undefined,
+        guestEmail: data.guestEmail || undefined,
+        guestPhone: data.guestPhone || undefined,
+        guestCount: data.guestCount ? parseInt(data.guestCount, 10) : undefined,
+        startTime: data.startTime || undefined,
+        endTime: data.endTime || undefined,
+        notes: data.notes || undefined,
+        hotelBookingId: data.hotelBookingId && data.hotelBookingId !== NONE
+          ? data.hotelBookingId : null,
+        programItemId: data.programItemId && data.programItemId !== NONE
+          ? data.programItemId : null,
+        tableIndex: data.tableIndex ? parseInt(data.tableIndex, 10) : null,
+      };
+
+      const result = isEditing
+        ? await updateReservation(editItem!.id, payload)
+        : await createReservation(payload);
+
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success(isEditing ? 'Reservation updated.' : 'Reservation added.');
+      onSuccess(result.data);
+      onClose();
+    });
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? 'Edit reservation' : 'Add reservation'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* Guest name */}
+          <div className="space-y-1">
+            <Label htmlFor="res-name">Guest name</Label>
+            <Input id="res-name" {...register('guestName')} />
+          </div>
+
+          {/* Contact */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="res-email">Email</Label>
+              <Input id="res-email" type="email" {...register('guestEmail')} />
+              {errors.guestEmail && (
+                <p className="text-sm text-destructive">{errors.guestEmail.message}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="res-phone">Phone</Label>
+              <Input id="res-phone" {...register('guestPhone')} />
+            </div>
+          </div>
+
+          {/* Guest count */}
+          <div className="space-y-1">
+            <Label htmlFor="res-count">Guest count</Label>
+            <Input id="res-count" type="number" min={1} {...register('guestCount')} />
+          </div>
+
+          {/* Times */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="res-start">Start time</Label>
+              <Input id="res-start" type="time" {...register('startTime')} />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="res-end">End time</Label>
+              <Input id="res-end" type="time" {...register('endTime')} />
+            </div>
+          </div>
+
+          {/* Hotel booking link */}
+          {hotelBookings.length > 0 && (
+            <div className="space-y-1">
+              <Label>Linked hotel booking</Label>
+              <Select
+                value={watch('hotelBookingId') ?? NONE}
+                onValueChange={(v) => setValue('hotelBookingId', v === NONE ? '' : v)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NONE}>None</SelectItem>
+                  {hotelBookings.map((b) => (
+                    <SelectItem key={b.id} value={b.id}>
+                      {b.guest_name} ({b.guest_count} guests)
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Program item link */}
+          {programItems.length > 0 && (
+            <div className="space-y-1">
+              <Label>Linked program item</Label>
+              <Select
+                value={watch('programItemId') ?? NONE}
+                onValueChange={(v) => setValue('programItemId', v === NONE ? '' : v)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NONE}>None</SelectItem>
+                  {programItems
+                    .filter((p) => p.table_breakdown && p.table_breakdown.length > 0)
+                    .map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.title}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+
+              {/* Table index */}
+              {hasBreakdown && (
+                <div className="mt-2 space-y-1">
+                  <Label>Table</Label>
+                  <Select
+                    value={watch('tableIndex') ?? ''}
+                    onValueChange={(v) => setValue('tableIndex', v)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select table" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {selectedItem!.table_breakdown!.map((seats, i) => (
+                        <SelectItem key={i} value={String(i)}>
+                          Table {i + 1} ({seats} places)
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Notes */}
+          <div className="space-y-1">
+            <Label htmlFor="res-notes">Notes</Label>
+            <Textarea id="res-notes" rows={2} {...register('notes')} />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={onClose}>Cancel</Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultValues(editItem?: Reservation | null): FormData {
+  if (!editItem) {
+    return {
+      guestName: '', guestEmail: '', guestPhone: '',
+      guestCount: '', startTime: '', endTime: '', notes: '',
+      hotelBookingId: '', programItemId: '', tableIndex: '',
+    };
+  }
+  return {
+    guestName: editItem.guest_name ?? '',
+    guestEmail: editItem.guest_email ?? '',
+    guestPhone: editItem.guest_phone ?? '',
+    guestCount: editItem.guest_count != null ? String(editItem.guest_count) : '',
+    startTime: editItem.start_time ?? '',
+    endTime: editItem.end_time ?? '',
+    notes: editItem.notes ?? '',
+    hotelBookingId: editItem.hotel_booking_id ?? '',
+    programItemId: editItem.program_item_id ?? '',
+    tableIndex: editItem.table_index != null ? String(editItem.table_index) : '',
+  };
+}

--- a/components/reservation-card.tsx
+++ b/components/reservation-card.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Pencil, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { deleteReservation } from '@/app/actions/reservations';
+import type { ReservationWithRelations } from '@/types/index';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+type Props = {
+  item: ReservationWithRelations;
+  isEditor: boolean;
+  onEdit: (item: ReservationWithRelations) => void;
+  onDeleted: (id: string) => void;
+};
+
+export function ReservationCard({ item, isEditor, onEdit, onDeleted }: Props) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, startDeleteTransition] = useTransition();
+
+  function handleDelete() {
+    startDeleteTransition(async () => {
+      const result = await deleteReservation(item.id);
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success('Reservation deleted.');
+      setDeleteOpen(false);
+      onDeleted(item.id);
+    });
+  }
+
+  const linkedTable =
+    item.program_item?.table_breakdown && item.table_index != null
+      ? `Table ${item.table_index + 1} (${item.program_item.table_breakdown[item.table_index]} places)`
+      : null;
+
+  return (
+    <>
+      <Card>
+        <CardContent className="py-3 px-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1 min-w-0 space-y-1">
+              {/* Name + count */}
+              <div className="flex items-baseline gap-2">
+                <p className="font-medium">
+                  {item.guest_name ?? 'Guest'}
+                </p>
+                {item.guest_count != null && (
+                  <span className="text-sm text-muted-foreground">
+                    {item.guest_count} {item.guest_count === 1 ? 'guest' : 'guests'}
+                  </span>
+                )}
+              </div>
+
+              {/* Time range */}
+              {(item.start_time || item.end_time) && (
+                <p className="text-sm text-muted-foreground">
+                  {formatTimeRange(item.start_time, item.end_time)}
+                </p>
+              )}
+
+              {/* Contact */}
+              {(item.guest_email || item.guest_phone) && (
+                <p className="text-sm text-muted-foreground">
+                  {[item.guest_email, item.guest_phone].filter(Boolean).join(' · ')}
+                </p>
+              )}
+
+              {/* Linked hotel booking */}
+              {item.hotel_booking && (
+                <p className="text-sm text-muted-foreground">
+                  Hotel: {item.hotel_booking.guest_name}
+                </p>
+              )}
+
+              {/* Linked table */}
+              {linkedTable && (
+                <p className="text-sm text-muted-foreground">
+                  {linkedTable}
+                </p>
+              )}
+
+              {/* Notes */}
+              {item.notes && (
+                <p className="text-sm text-muted-foreground italic">{item.notes}</p>
+              )}
+            </div>
+
+            {isEditor && (
+              <div className="flex gap-1 shrink-0">
+                <Button variant="ghost" size="icon" onClick={() => onEdit(item)}>
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => setDeleteOpen(true)}>
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete reservation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the reservation
+              {item.guest_name ? <> for <strong>{item.guest_name}</strong></> : ''}.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? 'Deleting…' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function formatTimeRange(start: string | null, end: string | null): string {
+  if (start && end) return `${start} – ${end}`;
+  if (start) return `From ${start}`;
+  if (end) return `Until ${end}`;
+  return '';
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -118,3 +118,9 @@ export type ProgramItemWithRelations = ProgramItem & {
   venue_type: VenueType | null;
   point_of_contact: PointOfContact | null;
 };
+
+/** Reservation with joined hotel_booking and program_item relations */
+export type ReservationWithRelations = Reservation & {
+  hotel_booking: HotelBooking | null;
+  program_item: ProgramItem | null;
+};


### PR DESCRIPTION
## Summary

- `components/add-reservation-modal.tsx` — Dialog with guest contact fields, times, notes, hotel booking select, program item select + cascading table index select; supports add and edit mode
- `components/reservation-card.tsx` — Displays guest name, count, time range, contact, linked hotel booking, linked table ("Table N (X places)"), notes; edit + delete (AlertDialog) for editors
- `app/[tenant]/day/[date]/DayViewClient.tsx` — Fully wired: reservation state, `openAddReservation`, `openEditReservation`, `handleReservationSaved`, `handleReservationDeleted`; hotel bookings section placeholder for T-27
- `types/index.ts` — Adds `ReservationWithRelations` (Reservation + joined hotel_booking and program_item)

Depends on T-23 (now merged).

## Test plan
- [ ] Add reservation from day view — appears in list sorted by start_time
- [ ] Edit reservation — modal pre-fills, update persists
- [ ] Delete reservation — confirmation dialog, removed from list
- [ ] Linked hotel booking shows guest name under the card
- [ ] Linked table shows "Table N (X places)"
- [ ] Edit/delete buttons only visible to editors

🤖 Generated with [Claude Code](https://claude.com/claude-code)