### PR TITLE
T-26: Breakfast configuration data model and server actions

### DIFF
--- a/app/actions/breakfast.ts
+++ b/app/actions/breakfast.ts
@@ -1,0 +1,124 @@
+'use server';
+
+import { createTenantClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { requireEditor, getUserRole } from '@/lib/membership';
+import { createBreakfastSchema, updateBreakfastSchema } from '@/lib/breakfast-schema';
+import type { CreateBreakfastFormData, UpdateBreakfastFormData } from '@/lib/breakfast-schema';
+import { parseTableBreakdown } from '@/lib/day-utils';
+import type { ActionResponse } from '@/types/actions';
+import type { BreakfastConfiguration } from '@/types/index';
+
+export async function createBreakfastConfiguration(
+  raw: CreateBreakfastFormData
+): Promise<ActionResponse<BreakfastConfiguration>> {
+  const parsed = createBreakfastSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const d = parsed.data;
+
+  // Validate breakfast_date falls within the booking window
+  const { data: booking, error: bookingError } = await supabase
+    .from('hotel_booking')
+    .select('check_in, check_out')
+    .eq('id', d.hotelBookingId)
+    .eq('tenant_id', tenantId)
+    .single();
+
+  if (bookingError) return { success: false, error: bookingError.message };
+  if (d.breakfastDate < booking.check_in || d.breakfastDate >= booking.check_out) {
+    return { success: false, error: 'Breakfast date must fall within the booking window.' };
+  }
+
+  const tableBreakdown = parseTableBreakdown(d.tableBreakdown ?? null);
+
+  const { data, error } = await supabase
+    .from('breakfast_configuration')
+    .insert({
+      tenant_id: tenantId,
+      hotel_booking_id: d.hotelBookingId,
+      breakfast_date: d.breakfastDate,
+      table_breakdown: tableBreakdown,
+      start_time: d.startTime || null,
+      notes: d.notes || null,
+    })
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as BreakfastConfiguration };
+}
+
+export async function updateBreakfastConfiguration(
+  id: string,
+  raw: UpdateBreakfastFormData
+): Promise<ActionResponse<BreakfastConfiguration>> {
+  const parsed = updateBreakfastSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const d = parsed.data;
+
+  const tableBreakdown = parseTableBreakdown(d.tableBreakdown ?? null);
+
+  const { data, error } = await supabase
+    .from('breakfast_configuration')
+    .update({
+      table_breakdown: tableBreakdown,
+      start_time: d.startTime || null,
+      notes: d.notes || null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as BreakfastConfiguration };
+}
+
+export async function deleteBreakfastConfiguration(id: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { error } = await supabase
+    .from('breakfast_configuration')
+    .delete()
+    .eq('id', id)
+    .eq('tenant_id', tenantId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}
+
+export async function getBreakfastConfigurationsForDay(
+  dateIso: string
+): Promise<ActionResponse<BreakfastConfiguration[]>> {
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('breakfast_configuration')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('breakfast_date', dateIso)
+    .order('created_at');
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as BreakfastConfiguration[] };
+}

--- a/lib/breakfast-schema.ts
+++ b/lib/breakfast-schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const createBreakfastSchema = z.object({
+  hotelBookingId: z.string().uuid('Hotel booking ID is required'),
+  breakfastDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format'),
+  tableBreakdown: z.string().optional(),
+  startTime: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+export const updateBreakfastSchema = z.object({
+  tableBreakdown: z.string().optional(),
+  startTime: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+export type CreateBreakfastFormData = z.infer<typeof createBreakfastSchema>;
+export type UpdateBreakfastFormData = z.infer<typeof updateBreakfastSchema>;

--- a/supabase/migrations/00010_create_breakfast_configuration.sql
+++ b/supabase/migrations/00010_create_breakfast_configuration.sql
@@ -1,0 +1,52 @@
+CREATE TABLE breakfast_configuration (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id        UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  hotel_booking_id UUID NOT NULL REFERENCES hotel_booking(id) ON DELETE CASCADE,
+  breakfast_date   TEXT NOT NULL,
+  table_breakdown  JSONB,
+  total_guests     INT NOT NULL DEFAULT 0,
+  start_time       TEXT,
+  notes            TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT breakfast_configuration_unique UNIQUE (hotel_booking_id, breakfast_date)
+);
+
+-- Trigger: recompute total_guests from table_breakdown on every insert/update
+CREATE OR REPLACE FUNCTION compute_breakfast_total_guests()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.table_breakdown IS NULL THEN
+    NEW.total_guests := 0;
+  ELSE
+    SELECT COALESCE(SUM(val::int), 0)
+    INTO NEW.total_guests
+    FROM jsonb_array_elements(NEW.table_breakdown) AS val;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER breakfast_total_guests_trigger
+  BEFORE INSERT OR UPDATE OF table_breakdown
+  ON breakfast_configuration
+  FOR EACH ROW
+  EXECUTE FUNCTION compute_breakfast_total_guests();
+
+ALTER TABLE breakfast_configuration ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "breakfast_configuration: members can select"
+  ON breakfast_configuration FOR SELECT TO authenticated
+  USING (is_tenant_member(tenant_id));
+
+CREATE POLICY "breakfast_configuration: editors can insert"
+  ON breakfast_configuration FOR INSERT TO authenticated
+  WITH CHECK (is_tenant_editor(tenant_id));
+
+CREATE POLICY "breakfast_configuration: editors can update"
+  ON breakfast_configuration FOR UPDATE TO authenticated
+  USING (is_tenant_editor(tenant_id));
+
+CREATE POLICY "breakfast_configuration: editors can delete"
+  ON breakfast_configuration FOR DELETE TO authenticated
+  USING (is_tenant_editor(tenant_id));


### PR DESCRIPTION
## Summary

- `supabase/migrations/00010_create_breakfast_configuration.sql`
  - `breakfast_configuration` table: `hotel_booking_id` FK (CASCADE delete), `breakfast_date` TEXT, `table_breakdown` JSONB, `total_guests` INT (auto-computed), `start_time`, `notes`
  - `UNIQUE (hotel_booking_id, breakfast_date)` — one config per night per booking
  - `BEFORE INSERT OR UPDATE OF table_breakdown` trigger: sums the JSONB integer array into `total_guests`
  - Standard RLS policies
- `lib/breakfast-schema.ts` — separate create schema (requires `hotelBookingId` + `breakfastDate`) and update schema (breakdown, time, notes only — date is immutable)
- `app/actions/breakfast.ts`
  - `createBreakfastConfiguration` — validates `breakfastDate` is within `[check_in, check_out)` of the parent booking
  - `updateBreakfastConfiguration` — updates breakdown, start_time, notes; DB trigger recomputes `total_guests`
  - `deleteBreakfastConfiguration`
  - `getBreakfastConfigurationsForDay(dateIso)` — all configs for a given date across all bookings

Depends on T-25. The auto-insert scaffolding in `createHotelBooking` / `reconcileBreakfastConfigs` (T-25) will now work correctly with this table in place.

## Test plan
- [ ] Migration applies cleanly after T-25 (`00009_create_hotel_booking.sql`)
- [ ] Creating a hotel booking auto-inserts breakfast configs for each night (T-25 action)
- [ ] `createBreakfastConfiguration` rejects dates outside the booking window
- [ ] Unique constraint prevents duplicate (hotel_booking_id, breakfast_date)
- [ ] Setting `table_breakdown = [3,2,1]` → `total_guests = 6` via trigger
- [ ] Deleting a hotel booking cascades and removes all breakfast configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)