### PR TITLE
T-28: Month calendar view (editor-only home page)

### DIFF
--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -1,9 +1,6 @@
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import type { ProgramItem, Reservation, HotelBooking, BreakfastConfiguration } from '@/types/index';
 
-// These queries target tables created in T-20, T-23, T-25, T-26.
-// Until those migrations are applied they return empty arrays gracefully.
-
 export async function getProgramItemsForDay(
   tenantId: string,
   dayId: string
@@ -24,11 +21,11 @@ export async function getReservationsForDay(
 ): Promise<Reservation[]> {
   const supabase = await createSupabaseServerClient();
   const { data } = await supabase
-    .from('reservations')
-    .select('*, hotel_bookings(*)')
+    .from('reservation')
+    .select('*, hotel_booking(*), program_item(*)')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .order('tee_time', { nullsFirst: true });
+    .order('start_time', { nullsFirst: true });
   return (data ?? []) as unknown as Reservation[];
 }
 
@@ -37,9 +34,8 @@ export async function getHotelBookingsForDate(
   dateIso: string
 ): Promise<HotelBooking[]> {
   const supabase = await createSupabaseServerClient();
-  // Bookings where check_in <= dateIso < check_out (guest is on property)
   const { data } = await supabase
-    .from('hotel_bookings')
+    .from('hotel_booking')
     .select('*')
     .eq('tenant_id', tenantId)
     .lte('check_in', dateIso)
@@ -54,7 +50,7 @@ export async function getBreakfastConfigsForDay(
 ): Promise<BreakfastConfiguration[]> {
   const supabase = await createSupabaseServerClient();
   const { data } = await supabase
-    .from('breakfast_configurations')
+    .from('breakfast_configuration')
     .select('*')
     .eq('tenant_id', tenantId)
     .eq('breakfast_date', dateIso)

--- a/app/[tenant]/month-queries.ts
+++ b/app/[tenant]/month-queries.ts
@@ -1,0 +1,74 @@
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import type { ProgramItem, Reservation, HotelBooking, BreakfastConfiguration } from '@/types/index';
+
+/**
+ * Returns all program items for days whose date_iso falls in [start, end].
+ * dayIds should be the IDs returned by ensureDaysRange for the same range.
+ */
+export async function getProgramItemsForMonth(
+  tenantId: string,
+  dayIds: string[]
+): Promise<ProgramItem[]> {
+  if (dayIds.length === 0) return [];
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('program_item')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .in('day_id', dayIds);
+  return (data ?? []) as ProgramItem[];
+}
+
+/**
+ * Returns all reservations for days whose date_iso falls in [start, end].
+ */
+export async function getReservationsForMonth(
+  tenantId: string,
+  dayIds: string[]
+): Promise<Reservation[]> {
+  if (dayIds.length === 0) return [];
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('reservation')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .in('day_id', dayIds);
+  return (data ?? []) as Reservation[];
+}
+
+/**
+ * Returns hotel bookings overlapping the [start, end] range.
+ * Overlap: check_in < end AND check_out > start.
+ */
+export async function getHotelBookingsForMonth(
+  tenantId: string,
+  start: string,
+  end: string
+): Promise<HotelBooking[]> {
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('hotel_booking')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .lt('check_in', end)
+    .gt('check_out', start);
+  return (data ?? []) as HotelBooking[];
+}
+
+/**
+ * Returns all breakfast configs whose breakfast_date falls in [start, end].
+ */
+export async function getBreakfastConfigsForMonth(
+  tenantId: string,
+  start: string,
+  end: string
+): Promise<BreakfastConfiguration[]> {
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('breakfast_configuration')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .gte('breakfast_date', start)
+    .lte('breakfast_date', end);
+  return (data ?? []) as BreakfastConfiguration[];
+}

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -1,13 +1,121 @@
+import { redirect } from 'next/navigation';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getTenantFromHeaders } from '@/lib/tenant';
+import { getAuthState } from '@/app/actions/auth';
+import { ensureDaysRange } from '@/app/actions/days';
+import { getTenantToday, getMonthDateRange } from '@/lib/day-utils';
+import {
+  getProgramItemsForMonth,
+  getReservationsForMonth,
+  getHotelBookingsForMonth,
+  getBreakfastConfigsForMonth,
+} from './month-queries';
+import { HomeClient } from '@/components/HomeClient';
+import type { DaySummary } from '@/components/HomeClient';
+import type { Day } from '@/types/index';
 
-export default async function TenantHomePage() {
-  const { slug } = await getTenantFromHeaders();
+const MONTH_REGEX = /^\d{4}-\d{2}$/;
+
+export default async function TenantHomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ month?: string }>;
+}) {
+  const tenant = await getTenantFromHeaders();
+  const authState = await getAuthState();
+
+  // Fetch tenant timezone
+  const supabase = await createSupabaseServerClient();
+  const { data: tenantRow } = await supabase
+    .from('tenants')
+    .select('timezone')
+    .eq('id', tenant.id)
+    .single();
+  const timezone = tenantRow?.timezone ?? 'UTC';
+
+  const today = getTenantToday(timezone);
+
+  // Viewers see the day view; calendar is editor-only
+  if (!authState.isEditor) {
+    redirect(`/day/${today}`);
+  }
+
+  // Parse ?month=YYYY-MM, default to current month
+  const { month: rawMonth } = await searchParams;
+  const month =
+    rawMonth && MONTH_REGEX.test(rawMonth)
+      ? rawMonth
+      : today.slice(0, 7);
+
+  const [year, monthNum] = month.split('-').map(Number);
+  const { start, end } = getMonthDateRange(year, monthNum);
+
+  // Ensure all Day rows for the month exist (idempotent batch upsert)
+  const daysResult = await ensureDaysRange(start, end);
+  const monthDays: Day[] = daysResult.success ? daysResult.data : [];
+  const dayIds = monthDays.map((d) => d.id);
+  const dayDateMap = new Map(monthDays.map((d) => [d.id, d.date_iso]));
+
+  // Load all month data in parallel
+  const [programItems, reservations, hotelBookings, breakfastConfigs] =
+    await Promise.all([
+      getProgramItemsForMonth(tenant.id, dayIds),
+      getReservationsForMonth(tenant.id, dayIds),
+      getHotelBookingsForMonth(tenant.id, start, end),
+      getBreakfastConfigsForMonth(tenant.id, start, end),
+    ]);
+
+  // Build per-day summary map
+  const summaryMap = new Map<string, DaySummary>();
+
+  for (const day of monthDays) {
+    summaryMap.set(day.date_iso, {
+      date: day.date_iso,
+      dayId: day.id,
+      golfCount: 0,
+      eventCount: 0,
+      reservationCount: 0,
+      hotelGuestCount: 0,
+      breakfastCount: 0,
+    });
+  }
+
+  for (const item of programItems) {
+    const date = dayDateMap.get(item.day_id);
+    if (!date) continue;
+    const s = summaryMap.get(date);
+    if (!s) continue;
+    if (item.type === 'golf') s.golfCount++;
+    else s.eventCount++;
+  }
+
+  for (const res of reservations) {
+    const date = dayDateMap.get(res.day_id);
+    if (!date) continue;
+    const s = summaryMap.get(date);
+    if (s) s.reservationCount++;
+  }
+
+  for (const booking of hotelBookings) {
+    for (const [date, s] of summaryMap) {
+      if (booking.check_in <= date && date < booking.check_out) {
+        s.hotelGuestCount += booking.guest_count;
+      }
+    }
+  }
+
+  for (const config of breakfastConfigs) {
+    const s = summaryMap.get(config.breakfast_date);
+    if (s) s.breakfastCount += config.total_guests;
+  }
+
+  const days = [...summaryMap.values()].sort((a, b) => a.date.localeCompare(b.date));
 
   return (
-    <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center">
-      <p className="text-muted-foreground">
-        Welcome to <span className="font-medium text-foreground">{slug}</span>. Coming soon.
-      </p>
-    </div>
+    <HomeClient
+      month={month}
+      today={today}
+      days={days}
+    />
   );
 }

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import { useState } from 'react';
+import { format, parseISO, getDay } from 'date-fns';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DaySummary = {
+  date: string; // YYYY-MM-DD
+  dayId: string;
+  golfCount: number;
+  eventCount: number;
+  reservationCount: number;
+  hotelGuestCount: number;
+  breakfastCount: number;
+};
+
+type Props = {
+  month: string;  // YYYY-MM
+  today: string;  // YYYY-MM-DD
+  days: DaySummary[];
+};
+
+// Day-of-week header labels — Monday first
+const DOW_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function HomeClient({ month, today, days }: Props) {
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const dayMap = new Map(days.map((d) => [d.date, d]));
+
+  // Compute grid layout
+  const [year, monthNum] = month.split('-').map(Number);
+  const firstOfMonth = new Date(year, monthNum - 1, 1);
+  const daysInMonth = new Date(year, monthNum, 0).getDate();
+
+  // Monday-start: Mon=0, Tue=1, ..., Sun=6
+  const startPadding = (getDay(firstOfMonth) + 6) % 7;
+
+  const selectedSummary = selectedDate ? dayMap.get(selectedDate) ?? null : null;
+
+  return (
+    <div className="max-w-5xl mx-auto px-6 py-8">
+      {/* Month heading */}
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold">
+          {format(firstOfMonth, 'MMMM yyyy')}
+        </h1>
+        {/* Month navigation placeholder — filled by T-30 */}
+      </div>
+
+      <div className={cn('flex gap-6', selectedDate && 'lg:gap-8')}>
+        {/* Calendar grid */}
+        <div className="flex-1 min-w-0">
+          {/* Day-of-week header */}
+          <div className="grid grid-cols-7 mb-1">
+            {DOW_LABELS.map((label) => (
+              <div
+                key={label}
+                className="text-center text-xs font-medium text-muted-foreground py-1"
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+
+          {/* Day cells */}
+          <div className="grid grid-cols-7 border-l border-t">
+            {/* Leading empty cells */}
+            {Array.from({ length: startPadding }).map((_, i) => (
+              <div
+                key={`pad-${i}`}
+                className="border-r border-b min-h-[80px] bg-muted/20"
+              />
+            ))}
+
+            {/* Day cells */}
+            {Array.from({ length: daysInMonth }).map((_, i) => {
+              const dayNum = i + 1;
+              const dateStr = `${month}-${String(dayNum).padStart(2, '0')}`;
+              const summary = dayMap.get(dateStr);
+              const isToday = dateStr === today;
+              const isSelected = dateStr === selectedDate;
+
+              return (
+                <button
+                  key={dateStr}
+                  onClick={() => setSelectedDate(isSelected ? null : dateStr)}
+                  className={cn(
+                    'border-r border-b min-h-[80px] p-1.5 text-left transition-colors',
+                    'hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+                    isSelected && 'bg-accent',
+                    !isSelected && 'bg-background'
+                  )}
+                >
+                  {/* Date number */}
+                  <span
+                    className={cn(
+                      'flex h-6 w-6 items-center justify-center rounded-full text-sm font-medium mb-1',
+                      isToday && 'bg-primary text-primary-foreground',
+                      !isToday && 'text-foreground'
+                    )}
+                  >
+                    {dayNum}
+                  </span>
+
+                  {/* Summary badges */}
+                  {summary && (
+                    <div className="flex flex-col gap-0.5">
+                      {summary.golfCount > 0 && (
+                        <SummaryPip label={`${summary.golfCount}G`} color="emerald" />
+                      )}
+                      {summary.eventCount > 0 && (
+                        <SummaryPip label={`${summary.eventCount}E`} color="blue" />
+                      )}
+                      {summary.reservationCount > 0 && (
+                        <SummaryPip label={`${summary.reservationCount}R`} color="amber" />
+                      )}
+                      {summary.hotelGuestCount > 0 && (
+                        <SummaryPip label={`${summary.hotelGuestCount}H`} color="violet" />
+                      )}
+                    </div>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Day sidebar — expanded by T-29 */}
+        {selectedDate && selectedSummary && (
+          <aside className="w-64 shrink-0">
+            <div className="sticky top-6 space-y-4">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground uppercase tracking-wide">
+                  Selected
+                </p>
+                <p className="text-lg font-semibold">
+                  {format(parseISO(selectedDate), 'EEEE d MMMM')}
+                </p>
+              </div>
+
+              {/* Summary counts */}
+              <div className="space-y-2 text-sm">
+                {selectedSummary.golfCount > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Golf</span>
+                    <span>{selectedSummary.golfCount}</span>
+                  </div>
+                )}
+                {selectedSummary.eventCount > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Events</span>
+                    <span>{selectedSummary.eventCount}</span>
+                  </div>
+                )}
+                {selectedSummary.reservationCount > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Reservations</span>
+                    <span>{selectedSummary.reservationCount}</span>
+                  </div>
+                )}
+                {selectedSummary.hotelGuestCount > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Hotel guests</span>
+                    <span>{selectedSummary.hotelGuestCount}</span>
+                  </div>
+                )}
+                {selectedSummary.breakfastCount > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Breakfasts</span>
+                    <span>{selectedSummary.breakfastCount}</span>
+                  </div>
+                )}
+                {!selectedSummary.golfCount &&
+                  !selectedSummary.eventCount &&
+                  !selectedSummary.reservationCount &&
+                  !selectedSummary.hotelGuestCount && (
+                    <p className="text-muted-foreground">Nothing scheduled.</p>
+                  )}
+              </div>
+
+              <Button asChild size="sm" className="w-full">
+                <Link href={`/day/${selectedDate}`}>
+                  View day <ArrowRight className="ml-1 h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          </aside>
+        )}
+      </div>
+
+      {/* Legend */}
+      <div className="mt-4 flex flex-wrap gap-3 text-xs text-muted-foreground">
+        <LegendItem color="emerald" label="Golf (G)" />
+        <LegendItem color="blue" label="Event (E)" />
+        <LegendItem color="amber" label="Reservation (R)" />
+        <LegendItem color="violet" label="Hotel guests (H)" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+type PipColor = 'emerald' | 'blue' | 'amber' | 'violet';
+
+const PIP_CLASSES: Record<PipColor, string> = {
+  emerald: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400',
+  blue: 'bg-blue-500/15 text-blue-700 dark:text-blue-400',
+  amber: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  violet: 'bg-violet-500/15 text-violet-700 dark:text-violet-400',
+};
+
+function SummaryPip({ label, color }: { label: string; color: PipColor }) {
+  return (
+    <span
+      className={cn(
+        'inline-block rounded px-1 py-0.5 text-[10px] font-medium leading-none',
+        PIP_CLASSES[color]
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function LegendItem({ color, label }: { color: PipColor; label: string }) {
+  return (
+    <span className="flex items-center gap-1">
+      <span className={cn('rounded px-1 py-0.5 text-[10px] font-medium', PIP_CLASSES[color])}>
+        {label.charAt(0)}
+      </span>
+      {label}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- `app/[tenant]/page.tsx` — replaced placeholder with a full server component:
  - Redirects non-editors to `/day/{today}`
  - Reads `?month=YYYY-MM` (defaults to current month)
  - Calls `ensureDaysRange` for the month, parallelises all data fetches
  - Aggregates per-day summaries (golf count, event count, reservation count, hotel guest count, breakfast count) server-side before passing to the client
- `app/[tenant]/month-queries.ts` — `getProgramItemsForMonth`, `getReservationsForMonth`, `getHotelBookingsForMonth`, `getBreakfastConfigsForMonth`
- `components/HomeClient.tsx` — client-side month grid:
  - Monday-start 7-column grid with `border-l border-t` cell borders
  - Today's date highlighted with `bg-primary` circle
  - Colour-coded summary pips per cell: G (emerald), E (blue), R (amber), H (violet)
  - Clicking a day selects it; clicking again deselects
  - Selected day shows a sticky sidebar with counts + "View day" link — content expanded in T-29
- `app/[tenant]/day/[date]/queries.ts` — fixed wrong table names (`reservations` → `reservation`, `hotel_bookings` → `hotel_booking`, `breakfast_configurations` → `breakfast_configuration`)

Depends on T-17, T-20, T-23, T-25, T-26.

## Test plan
- [ ] Non-editor visiting `/` is redirected to `/day/{today}`
- [ ] Editor sees month grid for current month by default
- [ ] `?month=2025-06` shows June 2025
- [ ] Invalid `?month` param falls back to current month
- [ ] Day cells show correct counts for a day with known data
- [ ] Today's date has the primary-colour circle
- [ ] Clicking a day opens the sidebar; clicking again closes it
- [ ] "View day" link navigates to the correct day view

🤖 Generated with [Claude Code](https://claude.com/claude-code)