### PR TITLE
T-31: Admin indicator and tenant chrome

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -1,8 +1,31 @@
+import type { Metadata } from 'next';
+import { Toaster } from 'sonner';
 import { Logo } from '@/components/logo';
 import { UserMenu } from '@/components/user-menu';
 import { getUser } from '@/app/actions/auth';
 import { getTenantFromHeaders } from '@/lib/tenant';
 import { TenantProvider } from '@/lib/tenant-context';
+import { AuthProvider } from '@/lib/AuthProvider';
+import { AdminIndicator } from '@/components/admin-indicator';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+
+export async function generateMetadata(): Promise<Metadata> {
+  try {
+    const tenant = await getTenantFromHeaders();
+    const supabase = await createSupabaseServerClient();
+    const { data } = await supabase
+      .from('tenants')
+      .select('name')
+      .eq('id', tenant.id)
+      .single();
+    const name = data?.name as string | undefined;
+    return {
+      title: name ? `${name} · Golf Schedule` : 'Golf Schedule',
+    };
+  } catch {
+    return { title: 'Golf Schedule' };
+  }
+}
 
 export default async function TenantLayout({
   children,
@@ -16,13 +39,17 @@ export default async function TenantLayout({
 
   return (
     <TenantProvider tenantId={tenant.id} tenantSlug={tenant.slug}>
-      <div className="min-h-screen flex flex-col">
-        <header className="border-b px-6 h-14 flex items-center justify-between">
-          <Logo />
-          {user && <UserMenu user={user} />}
-        </header>
-        <main className="flex-1">{children}</main>
-      </div>
+      <AuthProvider>
+        <div className="min-h-screen flex flex-col">
+          <header className="border-b px-6 h-14 flex items-center justify-between">
+            <Logo />
+            {user && <UserMenu user={user} />}
+          </header>
+          <main className="flex-1">{children}</main>
+        </div>
+        <AdminIndicator />
+        <Toaster richColors closeButton />
+      </AuthProvider>
     </TenantProvider>
   );
 }

--- a/components/admin-indicator.tsx
+++ b/components/admin-indicator.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useRef, useState, useTransition } from 'react';
+import { Settings, LogOut, ChevronUp } from 'lucide-react';
+import Link from 'next/link';
+import { signOut } from '@/app/actions/auth';
+import { useAuth } from '@/lib/AuthProvider';
+import { cn } from '@/lib/utils';
+
+export function AdminIndicator() {
+  const { user, isEditor, isLoading } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  if (isLoading || !isEditor) return null;
+
+  return (
+    <div ref={ref} className="fixed bottom-4 right-4 z-50">
+      {/* Expanded panel */}
+      {open && (
+        <div className="mb-2 w-56 rounded-lg border bg-popover shadow-lg overflow-hidden">
+          <div className="px-3 py-2.5">
+            <p className="text-xs text-muted-foreground truncate">{user?.email}</p>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          <Link
+            href="/admin/settings"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2.5 text-sm hover:bg-accent transition-colors"
+          >
+            <Settings className="h-4 w-4 shrink-0" />
+            Settings
+          </Link>
+
+          <div className="h-px bg-border" />
+
+          <button
+            onClick={() => startTransition(() => signOut())}
+            disabled={isPending}
+            className="flex w-full items-center gap-2 px-3 py-2.5 text-sm text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+          >
+            <LogOut className="h-4 w-4 shrink-0" />
+            {isPending ? 'Signing out…' : 'Sign out'}
+          </button>
+        </div>
+      )}
+
+      {/* Trigger */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'flex h-9 w-9 items-center justify-center rounded-full border bg-background shadow-md',
+          'hover:bg-accent transition-colors',
+          open && 'bg-accent'
+        )}
+        aria-label="Admin menu"
+      >
+        {open
+          ? <ChevronUp className="h-4 w-4" />
+          : <Settings className="h-4 w-4" />
+        }
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `components/admin-indicator.tsx` — fixed bottom-right floating button (gear icon); expands on click to show:
  - Current user email (from `useAuth()`)
  - Link to `/admin/settings`
  - Sign-out button (calls `signOut` server action)
  - Collapses on outside click; shows `ChevronUp` when open
  - Returns null while auth is loading or user is not an editor — no flash
- `app/[tenant]/layout.tsx` — updated to:
  - Wrap with `AuthProvider` so all tenant client components can `useAuth()`
  - Mount `AdminIndicator` outside the page content flow
  - Mount `Toaster` (sonner, richColors + closeButton) — fixes toasts that were firing without a provider
  - Add `generateMetadata()` for a dynamic tab title: `{Tenant Name} · Golf Schedule`

Depends on T-07, T-08.

## Test plan
- [ ] Gear button visible in bottom-right for editors; hidden for viewers and unauthenticated users
- [ ] Clicking gear opens panel with email, Settings link, Sign out
- [ ] Clicking outside closes the panel
- [ ] Settings link navigates to `/admin/settings`
- [ ] Sign out redirects to `/auth/sign-in`
- [ ] Toast notifications (from add/edit/delete actions) now appear correctly
- [ ] Browser tab title shows `{Tenant Name} · Golf Schedule`

🤖 Generated with [Claude Code](https://claude.com/claude-code)