### PR TITLE
T-32: Error boundaries, not-found pages, and loading skeletons

### DIFF
--- a/app/[tenant]/admin/settings/loading.tsx
+++ b/app/[tenant]/admin/settings/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function SettingsLoading() {
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-8 space-y-6">
+      <Skeleton className="h-7 w-28" />
+      {/* Tab bar */}
+      <div className="flex gap-2">
+        <Skeleton className="h-9 w-24 rounded-md" />
+        <Skeleton className="h-9 w-28 rounded-md" />
+      </div>
+      {/* Content rows */}
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-16 w-full rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/[tenant]/day/[date]/loading.tsx
+++ b/app/[tenant]/day/[date]/loading.tsx
@@ -1,33 +1,5 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { DayPageSkeleton } from '@/components/day-page-skeleton';
 
 export default function DayLoading() {
-  return (
-    <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
-      {/* Date nav */}
-      <div className="flex items-center gap-3">
-        <Skeleton className="h-9 w-9 rounded-md" />
-        <Skeleton className="h-7 w-48" />
-        <Skeleton className="h-9 w-9 rounded-md" />
-        <Skeleton className="h-9 w-20 rounded-md ml-auto" />
-      </div>
-
-      {/* Summary card */}
-      <Skeleton className="h-28 w-full rounded-xl" />
-
-      {/* Program items section */}
-      <div className="space-y-3">
-        <Skeleton className="h-5 w-36" />
-        <Skeleton className="h-20 w-full rounded-lg" />
-        <Skeleton className="h-20 w-full rounded-lg" />
-      </div>
-
-      {/* Reservations section */}
-      <div className="space-y-3">
-        <Skeleton className="h-5 w-32" />
-        <Skeleton className="h-16 w-full rounded-lg" />
-        <Skeleton className="h-16 w-full rounded-lg" />
-        <Skeleton className="h-16 w-full rounded-lg" />
-      </div>
-    </div>
-  );
+  return <DayPageSkeleton />;
 }

--- a/app/[tenant]/loading.tsx
+++ b/app/[tenant]/loading.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function CalendarLoading() {
+  return (
+    <div className="max-w-5xl mx-auto px-6 py-8 space-y-6">
+      {/* Month header */}
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-40" />
+        <div className="flex gap-1">
+          <Skeleton className="h-9 w-9 rounded-md" />
+          <Skeleton className="h-9 w-9 rounded-md" />
+        </div>
+      </div>
+
+      {/* Day-of-week labels */}
+      <div className="grid grid-cols-7 gap-px">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <Skeleton key={i} className="h-5 rounded" />
+        ))}
+      </div>
+
+      {/* Calendar cells — 5 rows */}
+      <div className="grid grid-cols-7 gap-px">
+        {Array.from({ length: 35 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 rounded-md" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/[tenant]/not-found.tsx
+++ b/app/[tenant]/not-found.tsx
@@ -1,16 +1,16 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
-export default function NotFound() {
+export default function TenantNotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-center px-4">
+    <div className="flex min-h-[calc(100vh-3.5rem)] flex-col items-center justify-center gap-4 text-center px-4">
       <p className="text-6xl font-bold text-muted-foreground/30">404</p>
       <h1 className="text-2xl font-semibold">Page not found</h1>
       <p className="text-muted-foreground max-w-sm">
-        The page you&apos;re looking for doesn&apos;t exist.
+        This page doesn&apos;t exist within your course.
       </p>
       <Button asChild>
-        <Link href="/">Go home</Link>
+        <Link href="/">Back to calendar</Link>
       </Button>
     </div>
   );

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(error);
+    }
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-center px-4">
+      <p className="text-5xl font-bold text-muted-foreground/40">Oops</p>
+      <h1 className="text-2xl font-semibold">Something went wrong</h1>
+      <p className="text-muted-foreground max-w-sm">
+        An unexpected error occurred. You can try again or refresh the page.
+      </p>
+      <Button onClick={reset}>Try again</Button>
+    </div>
+  );
+}

--- a/components/day-page-skeleton.tsx
+++ b/components/day-page-skeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function DayPageSkeleton() {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+      {/* Date nav */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-9 w-9 rounded-md" />
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-9 w-9 rounded-md" />
+        <Skeleton className="h-9 w-20 rounded-md ml-auto" />
+      </div>
+
+      {/* Summary card */}
+      <Skeleton className="h-28 w-full rounded-xl" />
+
+      {/* Program items section */}
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-36" />
+        <Skeleton className="h-20 w-full rounded-lg" />
+        <Skeleton className="h-20 w-full rounded-lg" />
+      </div>
+
+      {/* Reservations section */}
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `app/error.tsx` — global error boundary (client component): friendly "Something went wrong" message, Try again button, logs to console in development
- `app/not-found.tsx` — replaced the old subdomain-specific 404 (stale from the Platforms Starter Kit) with a clean generic page
- `app/[tenant]/not-found.tsx` — tenant-scoped 404 with "Back to calendar" link; respects the `min-h-[calc(100vh-3.5rem)]` to account for the header
- `components/day-page-skeleton.tsx` — extracted reusable skeleton component: date nav row, summary card placeholder, two content section placeholders
- `app/[tenant]/day/[date]/loading.tsx` — now delegates to `DayPageSkeleton` (1 line)
- `app/[tenant]/loading.tsx` — calendar loading: month header, DOW labels row, 5×7 cell grid
- `app/[tenant]/admin/settings/loading.tsx` — settings loading: heading, tab bar, content rows

Depends on T-04.

## Test plan
- [ ] Throwing in a server component shows the error boundary with a working "Try again" button
- [ ] Navigating to a non-existent platform path shows the global 404
- [ ] Navigating to a non-existent tenant path shows the tenant 404
- [ ] Slow connections show the calendar skeleton before the grid loads
- [ ] Day view skeleton matches the real layout proportions

🤖 Generated with [Claude Code](https://claude.com/claude-code)