### PR TITLE
T-33: Auth guards and route protection

### DIFF
--- a/app/[tenant]/admin/settings/page.tsx
+++ b/app/[tenant]/admin/settings/page.tsx
@@ -1,10 +1,8 @@
-import { getTenantFromHeaders } from '@/lib/tenant';
-import { requireEditor } from '@/lib/membership';
+import { requireTenantEditor } from '@/lib/guards';
 import { SettingsClient } from './client';
 
 export default async function SettingsPage() {
-  const tenant = await getTenantFromHeaders();
-  await requireEditor(tenant.id);
+  await requireTenantEditor();
 
   return <SettingsClient />;
 }

--- a/app/[tenant]/auth/sign-in/page.tsx
+++ b/app/[tenant]/auth/sign-in/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useActionState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { signIn } from '@/app/actions/auth';
 import { Logo } from '@/components/logo';
@@ -11,6 +12,8 @@ import { Label } from '@/components/ui/label';
 
 export default function SignInPage() {
   const [state, action, isPending] = useActionState(signIn, null);
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get('redirectTo') ?? '/';
 
   return (
     <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center p-4">
@@ -27,6 +30,7 @@ export default function SignInPage() {
           </CardHeader>
 
           <form action={action}>
+            <input type="hidden" name="redirectTo" value={redirectTo} />
             <CardContent className="space-y-4">
               {state?.error && (
                 <p className="text-sm text-destructive">{state.error}</p>

--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getTenantFromHeaders } from '@/lib/tenant';
+import { requireTenantMember } from '@/lib/guards';
 import { getAuthState } from '@/app/actions/auth';
 import { ensureDayExists } from '@/app/actions/days';
 import { getAllPOCs } from '@/app/actions/poc';
@@ -44,6 +45,7 @@ export default async function DayPage({
   params: Promise<{ date: string }>;
 }) {
   const { date } = await params;
+  await requireTenantMember();
   const tenant = await getTenantFromHeaders();
 
   // Fetch tenant timezone

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getTenantFromHeaders } from '@/lib/tenant';
-import { getAuthState } from '@/app/actions/auth';
+import { requireTenantMember } from '@/lib/guards';
 import { ensureDaysRange } from '@/app/actions/days';
 import { getTenantToday, getMonthDateRange } from '@/lib/day-utils';
 import {
@@ -22,7 +22,7 @@ export default async function TenantHomePage({
   searchParams: Promise<{ month?: string }>;
 }) {
   const tenant = await getTenantFromHeaders();
-  const authState = await getAuthState();
+  const { role } = await requireTenantMember();
 
   // Fetch tenant timezone
   const supabase = await createSupabaseServerClient();
@@ -36,7 +36,7 @@ export default async function TenantHomePage({
   const today = getTenantToday(timezone);
 
   // Viewers see the day view; calendar is editor-only
-  if (!authState.isEditor) {
+  if (role !== 'editor') {
     redirect(`/day/${today}`);
   }
 

--- a/lib/guards.ts
+++ b/lib/guards.ts
@@ -1,0 +1,35 @@
+import { redirect, notFound } from 'next/navigation';
+import { getUser } from '@/app/actions/auth';
+import { getTenantFromHeaders } from '@/lib/tenant';
+import { getUserRole } from '@/lib/membership';
+import type { Role } from '@/lib/membership';
+import type { User } from '@supabase/supabase-js';
+
+/** Returns the authenticated user or redirects to sign-in. */
+export async function requireAuth(): Promise<User> {
+  const user = await getUser();
+  if (!user) redirect('/auth/sign-in');
+  return user;
+}
+
+/**
+ * Returns the user + role or renders a 404 if the user is not a member of the
+ * current tenant. Redirects to sign-in if unauthenticated.
+ */
+export async function requireTenantMember(): Promise<{ user: User; role: Role }> {
+  const user = await requireAuth();
+  const tenant = await getTenantFromHeaders();
+  const role = await getUserRole(tenant.id);
+  if (!role) notFound();
+  return { user, role };
+}
+
+/**
+ * Returns the user + role or redirects to tenant home if the user is not an
+ * editor. Renders a 404 if the user is not a member at all.
+ */
+export async function requireTenantEditor(): Promise<{ user: User; role: 'editor' }> {
+  const { user, role } = await requireTenantMember();
+  if (role !== 'editor') redirect('/');
+  return { user, role: 'editor' };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -75,16 +75,16 @@ export async function middleware(request: NextRequest) {
 
   // -------------------------------------------------------------------------
   // 4. Auth guard for tenant routes.
-  //    Public paths (no login required): /auth/*, /day/*
+  //    Public paths (no login required): /auth/*
   // -------------------------------------------------------------------------
   const isPublicPath =
     pathname === '/auth/sign-in' ||
     pathname === '/auth/sign-up' ||
-    pathname.startsWith('/auth/') ||
-    pathname.startsWith('/day/');
+    pathname.startsWith('/auth/');
 
   if (!user && !isPublicPath) {
     const signInUrl = new URL('/auth/sign-in', request.url);
+    signInUrl.searchParams.set('redirectTo', pathname);
     return applyAuthCookies(NextResponse.redirect(signInUrl));
   }
 


### PR DESCRIPTION
## Summary
- Creates `lib/guards.ts` with `requireAuth()`, `requireTenantMember()`, and `requireTenantEditor()` server-side helpers
- Removes `/day/` from middleware public paths so day pages now require authentication
- Middleware preserves intended destination via `?redirectTo=` on sign-in redirects
- Tenant sign-in page reads `redirectTo` from search params and submits it as a hidden input (the `signIn` action already supported this)
- `requireTenantMember()` applied to calendar home and day pages; `requireTenantEditor()` applied to admin settings

## Test plan
- [ ] Unauthenticated user visiting any tenant route (including `/day/...`) is redirected to `/auth/sign-in?redirectTo=<path>`
- [ ] Signing in redirects back to the original destination
- [ ] Authenticated non-member visiting a tenant subdomain gets a 404
- [ ] Authenticated viewer visiting `/` is redirected to `/day/<today>`; can access day pages
- [ ] Authenticated viewer cannot access `/admin/settings` (redirected to `/`)
- [ ] Authenticated editor can access all routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)