### PR TITLE
T-34: Theming, globals.css, and tenant-aware styling

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -37,10 +37,22 @@ export default async function TenantLayout({
     getTenantFromHeaders(),
   ]);
 
+  const supabase = await createSupabaseServerClient();
+  const { data: tenantRow } = await supabase
+    .from('tenants')
+    .select('accent_color')
+    .eq('id', tenant.id)
+    .single();
+
+  const accentColor = (tenantRow as { accent_color?: string | null } | null)?.accent_color;
+  const accentStyle = accentColor
+    ? ({ '--tenant-accent': accentColor } as React.CSSProperties)
+    : undefined;
+
   return (
     <TenantProvider tenantId={tenant.id} tenantSlug={tenant.slug}>
       <AuthProvider>
-        <div className="min-h-screen flex flex-col">
+        <div className="min-h-screen flex flex-col" style={accentStyle}>
           <header className="border-b px-6 h-14 flex items-center justify-between">
             <Logo />
             {user && <UserMenu user={user} />}

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,6 +45,7 @@
 
 :root {
   --radius: 0.625rem;
+  --tenant-accent: oklch(0.21 0.006 285.885); /* matches --primary light default */
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
   --card: oklch(1 0 0);
@@ -79,6 +80,7 @@
 }
 
 .dark {
+  --tenant-accent: oklch(0.92 0.004 286.32); /* matches --primary dark default */
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,28 +1,36 @@
 import type { Metadata } from 'next';
-import { Geist } from 'next/font/google';
+import { Geist, Geist_Mono } from 'next/font/google';
 import { SpeedInsights } from '@vercel/speed-insights/next';
+import { ThemeProvider } from '@/components/theme-provider';
 import './globals.css';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
-  subsets: ['latin']
+  subsets: ['latin'],
+});
+
+const geistMono = Geist_Mono({
+  variable: '--font-geist-mono',
+  subsets: ['latin'],
 });
 
 export const metadata: Metadata = {
   title: 'Platforms Starter Kit',
-  description: 'Next.js template for building a multi-tenant SaaS.'
+  description: 'Next.js template for building a multi-tenant SaaS.',
 };
 
 export default function RootLayout({
-  children
+  children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${geistSans.variable} antialiased`}>
-        {children}
-        <SpeedInsights />
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`} suppressHydrationWarning>
+      <body className="antialiased">
+        <ThemeProvider>
+          {children}
+          <SpeedInsights />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/components/admin-indicator.tsx
+++ b/components/admin-indicator.tsx
@@ -1,17 +1,40 @@
 'use client';
 
 import { useEffect, useRef, useState, useTransition } from 'react';
-import { Settings, LogOut, ChevronUp } from 'lucide-react';
+import { Settings, LogOut, ChevronUp, Sun, Moon, Monitor } from 'lucide-react';
 import Link from 'next/link';
+import { useTheme } from 'next-themes';
 import { signOut } from '@/app/actions/auth';
 import { useAuth } from '@/lib/AuthProvider';
 import { cn } from '@/lib/utils';
 
+const THEMES = ['system', 'light', 'dark'] as const;
+type ThemeValue = (typeof THEMES)[number];
+
+const themeIcon: Record<ThemeValue, React.ReactNode> = {
+  system: <Monitor className="h-4 w-4 shrink-0" />,
+  light: <Sun className="h-4 w-4 shrink-0" />,
+  dark: <Moon className="h-4 w-4 shrink-0" />,
+};
+
+const themeLabel: Record<ThemeValue, string> = {
+  system: 'System',
+  light: 'Light',
+  dark: 'Dark',
+};
+
 export function AdminIndicator() {
   const { user, isEditor, isLoading } = useAuth();
+  const { theme, setTheme } = useTheme();
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const ref = useRef<HTMLDivElement>(null);
+
+  const currentTheme = (theme as ThemeValue | undefined) ?? 'system';
+  function cycleTheme() {
+    const idx = THEMES.indexOf(currentTheme);
+    setTheme(THEMES[(idx + 1) % THEMES.length]);
+  }
 
   // Close on outside click
   useEffect(() => {
@@ -45,6 +68,16 @@ export function AdminIndicator() {
             <Settings className="h-4 w-4 shrink-0" />
             Settings
           </Link>
+
+          <div className="h-px bg-border" />
+
+          <button
+            onClick={cycleTheme}
+            className="flex w-full items-center gap-2 px-3 py-2.5 text-sm hover:bg-accent transition-colors"
+          >
+            {themeIcon[currentTheme]}
+            {themeLabel[currentTheme]}
+          </button>
 
           <div className="h-px bg-border" />
 

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/supabase/migrations/00011_add_tenant_accent_color.sql
+++ b/supabase/migrations/00011_add_tenant_accent_color.sql
@@ -1,0 +1,2 @@
+-- Add optional accent color to tenants for future per-tenant theming
+ALTER TABLE tenants ADD COLUMN accent_color TEXT;


### PR DESCRIPTION
## Summary
- Adds `next-themes` `ThemeProvider` to the root layout with `defaultTheme="system"` and `suppressHydrationWarning` on `<html>` to prevent flash
- Loads Geist Mono via `next/font/google` (alongside Geist Sans already in place); moves both font variable classNames to `<html>` per Tailwind v4 best practice
- Theme toggle in `AdminIndicator` panel — cycles system → light → dark with matching icon
- `--tenant-accent` CSS variable added to globals.css (defaults to `--primary` in each theme); tenant layout reads `accent_color` from the DB row and overrides the variable via inline style if set
- Migration `00011` adds nullable `accent_color TEXT` column to `tenants`

## Test plan
- [ ] Page loads without theme flash in light, dark, and system modes
- [ ] Theme toggle in admin panel cycles through system/light/dark
- [ ] Geist Mono renders correctly in monospace contexts (e.g., timestamps, IDs)
- [ ] `--tenant-accent` resolves correctly in both light and dark themes
- [ ] Migration applies cleanly (`supabase db push`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)