### PR TITLE
T-35: Integration tests for critical flows

### DIFF
--- a/tests/actions/auth.test.ts
+++ b/tests/actions/auth.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { redirect } from 'next/navigation';
+import { signIn, signOut } from '@/app/actions/auth';
+
+function makeAuthClient(signInResult: { error: { message: string } | null }) {
+  return {
+    auth: {
+      signInWithPassword: vi.fn().mockResolvedValue({ error: signInResult.error }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+    },
+  };
+}
+
+// ── signIn ────────────────────────────────────────────────────────────────────
+
+describe('signIn', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns error when credentials are invalid', async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeAuthClient({ error: { message: 'Invalid login credentials' } }) as never
+    );
+
+    const formData = new FormData();
+    formData.set('email', 'wrong@example.com');
+    formData.set('password', 'badpassword');
+
+    const result = await signIn(null, formData);
+    expect(result).toEqual({ error: 'Invalid login credentials' });
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects to / on successful sign-in (no redirectTo)', async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeAuthClient({ error: null }) as never
+    );
+
+    const formData = new FormData();
+    formData.set('email', 'user@example.com');
+    formData.set('password', 'correct');
+
+    await signIn(null, formData);
+    expect(redirect).toHaveBeenCalledWith('/');
+  });
+
+  it('redirects to the given redirectTo path after sign-in', async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeAuthClient({ error: null }) as never
+    );
+
+    const formData = new FormData();
+    formData.set('email', 'user@example.com');
+    formData.set('password', 'correct');
+    formData.set('redirectTo', '/day/2024-06-15');
+
+    await signIn(null, formData);
+    expect(redirect).toHaveBeenCalledWith('/day/2024-06-15');
+  });
+});
+
+// ── signOut ───────────────────────────────────────────────────────────────────
+
+describe('signOut', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls signOut on the Supabase client and redirects to sign-in', async () => {
+    const client = makeAuthClient({ error: null });
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(client as never);
+
+    await signOut();
+
+    expect(client.auth.signOut).toHaveBeenCalled();
+    expect(redirect).toHaveBeenCalledWith('/auth/sign-in');
+  });
+});

--- a/tests/actions/hotel-bookings.test.ts
+++ b/tests/actions/hotel-bookings.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/tenant', () => ({ getTenantId: vi.fn().mockResolvedValue('tenant-1') }));
+vi.mock('@/lib/membership', () => ({ requireEditor: vi.fn(), getUserRole: vi.fn().mockResolvedValue('editor') }));
+vi.mock('@/lib/supabase-server', () => ({ createTenantClient: vi.fn() }));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+import { createTenantClient } from '@/lib/supabase-server';
+import {
+  createHotelBooking,
+  updateHotelBooking,
+  deleteHotelBooking,
+} from '@/app/actions/hotel-bookings';
+import { hotelBookingSchema } from '@/lib/hotel-booking-schema';
+
+type QueryResult = { data: unknown; error: { message: string; code?: string } | null };
+
+/** Creates a chainable query builder that is also directly awaitable. */
+function makeChain(result: QueryResult = { data: null, error: null }) {
+  const chain: Record<string, unknown> = {};
+  ['select', 'insert', 'update', 'delete', 'upsert',
+   'eq', 'neq', 'in', 'lt', 'lte', 'gt', 'gte', 'order', 'limit'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  chain.single = vi.fn().mockResolvedValue(result);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  // Thenable: allows `await supabase.from('t').insert(...)` without .single()
+  (chain as { then?: unknown }).then = (fn: (v: QueryResult) => void) =>
+    Promise.resolve(result).then(fn);
+  return chain;
+}
+
+const VALID_BOOKING = {
+  guestName: 'Smith Party',
+  guestCount: 4,
+  checkIn: '2024-06-01',
+  checkOut: '2024-06-04',
+  isTourOperator: false,
+};
+
+const BOOKING_ROW = {
+  id: 'booking-1',
+  tenant_id: 'tenant-1',
+  ...VALID_BOOKING,
+  notes: null,
+};
+
+// ── hotelBookingSchema ────────────────────────────────────────────────────────
+
+describe('hotelBookingSchema', () => {
+  it('accepts a valid booking', () => {
+    expect(hotelBookingSchema.safeParse(VALID_BOOKING).success).toBe(true);
+  });
+
+  it('rejects empty guestName', () => {
+    const r = hotelBookingSchema.safeParse({ ...VALID_BOOKING, guestName: '' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects guestCount less than 1', () => {
+    const r = hotelBookingSchema.safeParse({ ...VALID_BOOKING, guestCount: 0 });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects checkOut on same day as checkIn', () => {
+    const r = hotelBookingSchema.safeParse({ ...VALID_BOOKING, checkOut: '2024-06-01' });
+    expect(r.success).toBe(false);
+    expect(r.error?.issues[0].message).toBe('Check-out must be after check-in');
+  });
+
+  it('rejects checkOut before checkIn', () => {
+    const r = hotelBookingSchema.safeParse({ ...VALID_BOOKING, checkOut: '2024-05-31' });
+    expect(r.success).toBe(false);
+  });
+});
+
+// ── createHotelBooking ────────────────────────────────────────────────────────
+
+describe('createHotelBooking', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns error on schema validation failure', async () => {
+    const result = await createHotelBooking({
+      ...VALID_BOOKING,
+      guestName: '',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('inserts the booking and auto-creates breakfast configs for each night', async () => {
+    const from = vi.fn()
+      .mockReturnValueOnce(makeChain({ data: BOOKING_ROW, error: null }))   // hotel_booking insert
+      .mockReturnValue(makeChain({ data: null, error: null }));              // breakfast_configuration insert
+
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: { from } as never,
+      tenantId: 'tenant-1',
+    });
+
+    const result = await createHotelBooking(VALID_BOOKING);
+
+    expect(result.success).toBe(true);
+
+    // breakfast_configuration.insert should be called once, for nights Jun 1, Jun 2, Jun 3
+    const bfFrom = from.mock.calls.find(([table]) => table === 'breakfast_configuration');
+    expect(bfFrom).toBeDefined();
+
+    const insertCall = (from.mock.results.find((_, i) =>
+      from.mock.calls[i]?.[0] === 'breakfast_configuration'
+    )?.value as ReturnType<typeof makeChain>);
+    expect((insertCall?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toHaveLength(3); // 3 nights
+  });
+
+  it('returns error when Supabase insert fails', async () => {
+    const from = vi.fn().mockReturnValue(
+      makeChain({ data: null, error: { message: 'insert error' } })
+    );
+
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: { from } as never,
+      tenantId: 'tenant-1',
+    });
+
+    const result = await createHotelBooking(VALID_BOOKING);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('insert error');
+  });
+});
+
+// ── updateHotelBooking ────────────────────────────────────────────────────────
+
+describe('updateHotelBooking', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reconciles breakfast configs when check-out is extended by one night', async () => {
+    // Existing: Jun 1–3 (nights: Jun 1, Jun 2)
+    // Updated:  Jun 1–4 (nights: Jun 1, Jun 2, Jun 3) → toAdd: Jun 3
+    const updatedBooking = { ...BOOKING_ROW, check_out: '2024-06-04' };
+
+    const from = vi.fn()
+      .mockReturnValueOnce(makeChain({ data: { check_in: '2024-06-01', check_out: '2024-06-03' }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: updatedBooking, error: null }))
+      .mockReturnValue(makeChain({ data: null, error: null })); // breakfast_configuration insert
+
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: { from } as never,
+      tenantId: 'tenant-1',
+    });
+
+    const result = await updateHotelBooking('booking-1', {
+      ...VALID_BOOKING,
+      checkOut: '2024-06-04',
+    });
+
+    expect(result.success).toBe(true);
+
+    // Verify breakfast_configuration insert was called for the new night
+    const insertCalls = from.mock.calls
+      .map((args, i) => ({ table: args[0], chain: from.mock.results[i].value }))
+      .filter(({ table }) => table === 'breakfast_configuration');
+
+    expect(insertCalls.length).toBeGreaterThan(0);
+    const insertArgs = (insertCalls[0].chain.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(insertArgs).toContainEqual(expect.objectContaining({ breakfast_date: '2024-06-03' }));
+  });
+
+  it('returns error when initial fetch fails', async () => {
+    const from = vi.fn().mockReturnValue(
+      makeChain({ data: null, error: { message: 'fetch error' } })
+    );
+
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: { from } as never,
+      tenantId: 'tenant-1',
+    });
+
+    const result = await updateHotelBooking('booking-1', VALID_BOOKING);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('fetch error');
+  });
+});
+
+// ── deleteHotelBooking ────────────────────────────────────────────────────────
+
+describe('deleteHotelBooking', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes the booking and returns success', async () => {
+    const chain = makeChain({ data: null, error: null });
+    const from = vi.fn().mockReturnValue(chain);
+
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: { from } as never,
+      tenantId: 'tenant-1',
+    });
+
+    const result = await deleteHotelBooking('booking-1');
+    expect(result.success).toBe(true);
+    expect(from).toHaveBeenCalledWith('hotel_booking');
+    expect((chain.delete as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+
+  it('returns error when Supabase delete fails', async () => {
+    const from = vi.fn().mockReturnValue(
+      makeChain({ data: null, error: { message: 'delete error' } })
+    );
+
+    vi.mocked(createTenantClient).mockResolvedValue({
+      supabase: { from } as never,
+      tenantId: 'tenant-1',
+    });
+
+    const result = await deleteHotelBooking('booking-1');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('delete error');
+  });
+});

--- a/tests/actions/poc-actions.test.ts
+++ b/tests/actions/poc-actions.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/tenant', () => ({ getTenantId: vi.fn().mockResolvedValue('tenant-1') }));
+vi.mock('@/lib/membership', () => ({ requireEditor: vi.fn(), getUserRole: vi.fn().mockResolvedValue('editor') }));
+vi.mock('@/lib/supabase-server', () => ({ createTenantClient: vi.fn() }));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+import { createTenantClient } from '@/lib/supabase-server';
+import { createPOC, deletePOC, getAllPOCs } from '@/app/actions/poc';
+
+type QueryResult = { data: unknown; error: { message: string; code?: string } | null };
+
+function makeChain(result: QueryResult = { data: null, error: null }) {
+  const chain: Record<string, unknown> = {};
+  ['select', 'insert', 'update', 'delete', 'upsert',
+   'eq', 'neq', 'in', 'order'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  chain.single = vi.fn().mockResolvedValue(result);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  (chain as { then?: unknown }).then = (fn: (v: QueryResult) => void) =>
+    Promise.resolve(result).then(fn);
+  return chain;
+}
+
+const VALID_POC = { name: 'Alice Dupont', email: 'alice@example.com', phone: '' };
+
+const POC_ROW = {
+  id: 'poc-1',
+  tenant_id: 'tenant-1',
+  name: 'Alice Dupont',
+  email: 'alice@example.com',
+  phone: null,
+};
+
+// ── createPOC ─────────────────────────────────────────────────────────────────
+
+describe('createPOC', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a POC and returns it', async () => {
+    const from = vi.fn().mockReturnValue(makeChain({ data: POC_ROW, error: null }));
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await createPOC(VALID_POC);
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ name: 'Alice Dupont' });
+  });
+
+  it('returns validation error for empty name', async () => {
+    const result = await createPOC({ name: '', email: '', phone: '' });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Name is required');
+  });
+
+  it('maps Postgres unique-constraint error (23505) to human-readable message', async () => {
+    const from = vi.fn().mockReturnValue(
+      makeChain({ data: null, error: { message: 'duplicate key value', code: '23505' } })
+    );
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await createPOC(VALID_POC);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('A contact with that name, email, or phone already exists.');
+  });
+});
+
+// ── deletePOC ─────────────────────────────────────────────────────────────────
+
+describe('deletePOC', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes the POC and returns success', async () => {
+    const chain = makeChain({ data: null, error: null });
+    const from = vi.fn().mockReturnValue(chain);
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await deletePOC('poc-1');
+    expect(result.success).toBe(true);
+    expect((chain.delete as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+
+  it('surfaces FK constraint error when POC is still referenced by a program item', async () => {
+    // Supabase returns error code 23503 (FK violation) when a referencing row exists
+    const from = vi.fn().mockReturnValue(
+      makeChain({
+        data: null,
+        error: { message: 'update or delete on table "point_of_contact" violates foreign key', code: '23503' },
+      })
+    );
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await deletePOC('poc-1');
+    expect(result.success).toBe(false);
+    // Error message is surfaced as-is from Supabase
+    expect(result.error).toContain('foreign key');
+  });
+});
+
+// ── getAllPOCs ────────────────────────────────────────────────────────────────
+
+describe('getAllPOCs', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns all POCs for the tenant', async () => {
+    const pocs = [POC_ROW, { ...POC_ROW, id: 'poc-2', name: 'Bob Martin' }];
+    const from = vi.fn().mockReturnValue(makeChain({ data: pocs, error: null }));
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await getAllPOCs();
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveLength(2);
+  });
+
+  it('returns error when user has no role (not a member)', async () => {
+    const { getUserRole } = await import('@/lib/membership');
+    vi.mocked(getUserRole).mockResolvedValueOnce(null);
+
+    const result = await getAllPOCs();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Not authorized.');
+  });
+});

--- a/tests/actions/program-item-actions.test.ts
+++ b/tests/actions/program-item-actions.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/tenant', () => ({ getTenantId: vi.fn().mockResolvedValue('tenant-1') }));
+vi.mock('@/lib/membership', () => ({ requireEditor: vi.fn(), getUserRole: vi.fn().mockResolvedValue('editor') }));
+vi.mock('@/lib/supabase-server', () => ({ createTenantClient: vi.fn() }));
+vi.mock('@/app/actions/days', () => ({ ensureDayExists: vi.fn().mockResolvedValue({ success: true, data: { id: 'day-1', date_iso: '2024-06-01' } }) }));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+import { createTenantClient } from '@/lib/supabase-server';
+import {
+  createProgramItem,
+  updateProgramItem,
+  deleteProgramItem,
+  deleteRecurrenceGroup,
+  getProgramItemsForDay,
+} from '@/app/actions/program-items';
+
+type QueryResult = { data: unknown; error: { message: string } | null };
+
+function makeChain(result: QueryResult = { data: null, error: null }) {
+  const chain: Record<string, unknown> = {};
+  ['select', 'insert', 'update', 'delete', 'upsert',
+   'eq', 'neq', 'in', 'lt', 'lte', 'gt', 'gte', 'order', 'limit'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  chain.single = vi.fn().mockResolvedValue(result);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  (chain as { then?: unknown }).then = (fn: (v: QueryResult) => void) =>
+    Promise.resolve(result).then(fn);
+  return chain;
+}
+
+const VALID_ITEM = {
+  title: 'Morning Round',
+  type: 'golf' as const,
+  dayId: '123e4567-e89b-12d3-a456-426614174000',
+};
+
+const ITEM_ROW = {
+  id: 'item-1',
+  tenant_id: 'tenant-1',
+  day_id: VALID_ITEM.dayId,
+  type: 'golf',
+  title: 'Morning Round',
+  is_recurring: false,
+};
+
+// ── createProgramItem ─────────────────────────────────────────────────────────
+
+describe('createProgramItem (non-recurring)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns error on schema validation failure', async () => {
+    const result = await createProgramItem({ ...VALID_ITEM, title: '' });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Title is required');
+  });
+
+  it('inserts a golf item and returns it', async () => {
+    const from = vi.fn().mockReturnValue(makeChain({ data: ITEM_ROW, error: null }));
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await createProgramItem(VALID_ITEM);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ type: 'golf', title: 'Morning Round' });
+    expect(from).toHaveBeenCalledWith('program_item');
+  });
+
+  it('returns error when Supabase insert fails', async () => {
+    const from = vi.fn().mockReturnValue(makeChain({ data: null, error: { message: 'db error' } }));
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await createProgramItem(VALID_ITEM);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('db error');
+  });
+});
+
+// ── createProgramItem (recurring) ────────────────────────────────────────────
+
+describe('createProgramItem (recurring)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fans out to multiple day records and returns the first-day item', async () => {
+    // Call sequence:
+    // 1. from('day').select().eq().single() → date_iso
+    // 2. from('day').select().eq().in() → all day rows (thenable)
+    // 3. from('program_item').insert().select().eq().single() → inserted item
+
+    const dayRow = { date_iso: '2024-06-01' };
+    const allDayRows = [
+      { id: 'day-1', date_iso: '2024-06-01' },
+      { id: 'day-2', date_iso: '2024-06-08' },
+    ];
+
+    const from = vi.fn()
+      .mockReturnValueOnce(makeChain({ data: dayRow, error: null }))          // fetch date_iso
+      .mockReturnValueOnce(makeChain({ data: allDayRows, error: null }))      // fetch day IDs
+      .mockReturnValue(makeChain({ data: ITEM_ROW, error: null }));           // insert items
+
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await createProgramItem({
+      ...VALID_ITEM,
+      isRecurring: true,
+      recurrenceFrequency: 'weekly',
+    });
+
+    expect(result.success).toBe(true);
+    // insert should be called with an array of rows (one per occurrence)
+    const insertFn = (from.mock.results[2].value as ReturnType<typeof makeChain>)
+      .insert as ReturnType<typeof vi.fn>;
+    const insertedRows = insertFn.mock.calls[0][0] as unknown[];
+    expect(Array.isArray(insertedRows)).toBe(true);
+    expect(insertedRows.length).toBeGreaterThan(1);
+  });
+});
+
+// ── updateProgramItem ─────────────────────────────────────────────────────────
+
+describe('updateProgramItem', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates the item and returns it', async () => {
+    const updated = { ...ITEM_ROW, title: 'Afternoon Round' };
+    const from = vi.fn().mockReturnValue(makeChain({ data: updated, error: null }));
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await updateProgramItem('item-1', { ...VALID_ITEM, title: 'Afternoon Round' });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ title: 'Afternoon Round' });
+  });
+
+  it('returns error on schema validation failure', async () => {
+    const result = await updateProgramItem('item-1', { ...VALID_ITEM, title: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── deleteProgramItem ─────────────────────────────────────────────────────────
+
+describe('deleteProgramItem', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes by id and tenant and returns success', async () => {
+    const chain = makeChain({ data: null, error: null });
+    const from = vi.fn().mockReturnValue(chain);
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await deleteProgramItem('item-1');
+    expect(result.success).toBe(true);
+    expect(from).toHaveBeenCalledWith('program_item');
+    expect((chain.delete as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+
+  it('returns error when Supabase delete fails', async () => {
+    const from = vi.fn().mockReturnValue(makeChain({ data: null, error: { message: 'delete error' } }));
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await deleteProgramItem('item-1');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('delete error');
+  });
+});
+
+// ── deleteRecurrenceGroup ─────────────────────────────────────────────────────
+
+describe('deleteRecurrenceGroup', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes all items in the recurrence group', async () => {
+    const chain = makeChain({ data: null, error: null });
+    const from = vi.fn().mockReturnValue(chain);
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await deleteRecurrenceGroup('group-abc');
+    expect(result.success).toBe(true);
+
+    // Must filter by recurrence_group_id
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls).toContainEqual(['recurrence_group_id', 'group-abc']);
+  });
+});
+
+// ── getProgramItemsForDay ─────────────────────────────────────────────────────
+
+describe('getProgramItemsForDay', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns items for the given day', async () => {
+    const items = [ITEM_ROW, { ...ITEM_ROW, id: 'item-2', title: 'Evening Event' }];
+    const from = vi.fn().mockReturnValue(makeChain({ data: items, error: null }));
+    vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
+
+    const result = await getProgramItemsForDay('day-1');
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveLength(2);
+  });
+
+  it('returns error when not authorized', async () => {
+    const { getUserRole } = await import('@/lib/membership');
+    vi.mocked(getUserRole).mockResolvedValue(null);
+
+    const result = await getProgramItemsForDay('day-1');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Not authorized.');
+  });
+});

--- a/tests/lib/guards.test.ts
+++ b/tests/lib/guards.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+  notFound: vi.fn(),
+}));
+
+vi.mock('@/app/actions/auth', () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock('@/lib/membership', () => ({
+  getUserRole: vi.fn(),
+}));
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantFromHeaders: vi.fn().mockResolvedValue({ id: 'tenant-1', slug: 'test' }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+import { getUser } from '@/app/actions/auth';
+import { getUserRole } from '@/lib/membership';
+import { redirect, notFound } from 'next/navigation';
+import { requireAuth, requireTenantMember, requireTenantEditor } from '@/lib/guards';
+
+const MOCK_USER = { id: 'user-1', email: 'test@example.com' };
+
+// ── requireAuth ───────────────────────────────────────────────────────────────
+
+describe('requireAuth', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls redirect to sign-in when user is not authenticated', async () => {
+    vi.mocked(getUser).mockResolvedValue(null);
+    await requireAuth();
+    expect(redirect).toHaveBeenCalledWith('/auth/sign-in');
+  });
+
+  it('returns the user when authenticated', async () => {
+    vi.mocked(getUser).mockResolvedValue(MOCK_USER as never);
+    const user = await requireAuth();
+    expect(user).toBe(MOCK_USER);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});
+
+// ── requireTenantMember ───────────────────────────────────────────────────────
+
+describe('requireTenantMember', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls redirect to sign-in when unauthenticated', async () => {
+    vi.mocked(getUser).mockResolvedValue(null);
+    await requireTenantMember();
+    expect(redirect).toHaveBeenCalledWith('/auth/sign-in');
+  });
+
+  it('calls notFound when user is not a member of the tenant', async () => {
+    vi.mocked(getUser).mockResolvedValue(MOCK_USER as never);
+    vi.mocked(getUserRole).mockResolvedValue(null);
+    await requireTenantMember();
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('returns { user, role } for a viewer member', async () => {
+    vi.mocked(getUser).mockResolvedValue(MOCK_USER as never);
+    vi.mocked(getUserRole).mockResolvedValue('viewer');
+    const result = await requireTenantMember();
+    expect(result.user).toBe(MOCK_USER);
+    expect(result.role).toBe('viewer');
+    expect(redirect).not.toHaveBeenCalled();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('returns { user, role } for an editor member', async () => {
+    vi.mocked(getUser).mockResolvedValue(MOCK_USER as never);
+    vi.mocked(getUserRole).mockResolvedValue('editor');
+    const result = await requireTenantMember();
+    expect(result.role).toBe('editor');
+  });
+});
+
+// ── requireTenantEditor ───────────────────────────────────────────────────────
+
+describe('requireTenantEditor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls redirect to / when user is a viewer', async () => {
+    vi.mocked(getUser).mockResolvedValue(MOCK_USER as never);
+    vi.mocked(getUserRole).mockResolvedValue('viewer');
+    await requireTenantEditor();
+    expect(redirect).toHaveBeenCalledWith('/');
+  });
+
+  it('returns { user, role: editor } for an editor', async () => {
+    vi.mocked(getUser).mockResolvedValue(MOCK_USER as never);
+    vi.mocked(getUserRole).mockResolvedValue('editor');
+    const result = await requireTenantEditor();
+    expect(result.role).toBe('editor');
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('calls redirect to sign-in when unauthenticated', async () => {
+    vi.mocked(getUser).mockResolvedValue(null);
+    await requireTenantEditor();
+    expect(redirect).toHaveBeenCalledWith('/auth/sign-in');
+  });
+});

--- a/tests/lib/tenant.test.ts
+++ b/tests/lib/tenant.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue({ get: mockGet }),
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+import { getTenantFromHeaders, getTenantId } from '@/lib/tenant';
+
+describe('Tenant isolation — getTenantFromHeaders', () => {
+  beforeEach(() => {
+    mockGet.mockReturnValue(null);
+  });
+
+  it('throws when x-tenant-id header is absent', async () => {
+    await expect(getTenantFromHeaders()).rejects.toThrow(
+      'getTenantFromHeaders() called outside of a tenant context'
+    );
+  });
+
+  it('throws when only x-tenant-id is present (slug missing)', async () => {
+    mockGet.mockImplementation((key: string) =>
+      key === 'x-tenant-id' ? 'tenant-abc' : null
+    );
+    await expect(getTenantFromHeaders()).rejects.toThrow(
+      'getTenantFromHeaders() called outside of a tenant context'
+    );
+  });
+
+  it('returns { id, slug } when both headers are present', async () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'x-tenant-id') return 'tenant-abc';
+      if (key === 'x-tenant-slug') return 'my-club';
+      return null;
+    });
+    const ctx = await getTenantFromHeaders();
+    expect(ctx.id).toBe('tenant-abc');
+    expect(ctx.slug).toBe('my-club');
+  });
+});
+
+describe('Tenant isolation — getTenantId', () => {
+  it('throws when called outside of tenant context', async () => {
+    mockGet.mockReturnValue(null);
+    await expect(getTenantId()).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- 6 new test files, 47 new tests (178 total, all passing)
- Builds on the existing test suite (schemas, day-utils, membership, queries) by adding action-level integration tests with mocked Supabase

## Coverage added
| File | What is tested |
|------|----------------|
| `tests/lib/tenant.test.ts` | `getTenantFromHeaders` throws when headers are absent — tenant isolation |
| `tests/lib/guards.test.ts` | `requireAuth` → redirect; `requireTenantMember` → notFound for non-members; `requireTenantEditor` → redirect for viewers |
| `tests/actions/auth.test.ts` | `signIn` returns error on bad credentials, redirects on success, respects `redirectTo`; `signOut` calls Supabase + redirects |
| `tests/actions/hotel-bookings.test.ts` | Schema cross-field validation; `createHotelBooking` auto-creates breakfast configs for each night; `updateHotelBooking` reconciles configs when dates extend; `deleteHotelBooking` success/error |
| `tests/actions/program-item-actions.test.ts` | Non-recurring create/update/delete CRUD; recurring fanout inserts one row per occurrence; `deleteRecurrenceGroup` filters by group ID; `getProgramItemsForDay` auth check |
| `tests/actions/poc-actions.test.ts` | `createPOC` maps Postgres `23505` unique error to human message; `deletePOC` surfaces FK `23503` error (referential integrity); `getAllPOCs` auth guard |

## Test plan
- [x] `pnpm test:run` — 17 files, 178 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)