### PR TITLE
Fix: cross-subdomain session sharing after platform sign-in

### DIFF
--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -2,6 +2,13 @@ import { createServerClient } from '@supabase/ssr';
 import { createClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
 import { getTenantId } from '@/lib/tenant';
+import { rootDomain } from '@/lib/utils';
+
+// Cookies must be shared across all subdomains so a session established on the
+// root domain (platform sign-in) is immediately available on tenant subdomains.
+// Strip the port (cookies ignore ports) and prepend '.' to cover all subdomains.
+// e.g. 'localhost:3000' → '.localhost',  'example.com' → '.example.com'
+const cookieDomain = '.' + rootDomain.split(':')[0];
 
 export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
@@ -17,7 +24,7 @@ export async function createSupabaseServerClient() {
         setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
+              cookieStore.set(name, value, { ...options, domain: cookieDomain })
             );
           } catch {
             // setAll called from a Server Component — session refresh still

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,10 +38,13 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
+  // Cookies must be shared across subdomains — strip port, prepend '.'.
+  const cookieDomain = '.' + rootDomain.split(':')[0];
+
   function applyAuthCookies(response: NextResponse): NextResponse {
     authCookies.forEach(({ name, value, options }) =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      response.cookies.set(name, value, options as any)
+      response.cookies.set(name, value, { ...(options as any), domain: cookieDomain })
     );
     return response;
   }


### PR DESCRIPTION
## Problem
After signing in at the root domain (`example.com/auth/sign-in`), the `platformSignIn` action redirected the user to their tenant subdomain (`tenant.example.com`). However the session cookies were scoped to `example.com` only — the browser didn't send them to `tenant.example.com`, so the middleware found no session and immediately bounced the user back to the tenant sign-in page.

## Root cause
`createSupabaseServerClient` and the middleware's `applyAuthCookies` both set auth cookies without a `domain` attribute, defaulting to the current request domain. A cookie set on `example.com` is not sent to `tenant.example.com`.

## Fix
Derive a shared cookie domain in both places:

```
'.' + rootDomain.split(':')[0]
// 'localhost:3000' → '.localhost'
// 'example.com'   → '.example.com'
```

The leading `.` makes the cookie available to all subdomains. The port is stripped because cookie `domain` attributes don't include ports.

Applied in:
- `lib/supabase-server.ts` — `createSupabaseServerClient` `setAll` callback
- `middleware.ts` — `applyAuthCookies` helper

Both paths need the fix: `supabase-server.ts` handles sign-in/sign-out, while the middleware handles session refresh on every subsequent request.

## Test plan
- [ ] Sign in at root domain → redirected to tenant subdomain → already authenticated, no second sign-in prompt
- [ ] Sign out → clears session on both root and tenant domains (verify in DevTools → Application → Cookies)
- [ ] Local dev: sign in at `localhost:3000` → redirected to `tenant.localhost:3000` → no second sign-in
- [ ] `pnpm test:run` passes (178 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)