### PR TITLE
Fix: top spacing on submit buttons across auth forms

### DIFF
--- a/app/(platform)/auth/sign-in/sign-in-form.tsx
+++ b/app/(platform)/auth/sign-in/sign-in-form.tsx
@@ -55,7 +55,7 @@ export function SignInForm() {
               </div>
             </CardContent>
 
-            <CardFooter className="flex flex-col gap-3">
+            <CardFooter className="flex flex-col gap-3 pt-2">
               <Button type="submit" className="w-full" disabled={isPending}>
                 {isPending ? 'Signing in…' : 'Sign in'}
               </Button>

--- a/app/(platform)/new/new-tenant-form.tsx
+++ b/app/(platform)/new/new-tenant-form.tsx
@@ -157,7 +157,7 @@ export function NewTenantForm() {
               </div>
             </CardContent>
 
-            <CardFooter>
+            <CardFooter className="pt-2">
               <Button
                 type="submit"
                 className="w-full"

--- a/app/[tenant]/auth/sign-in/page.tsx
+++ b/app/[tenant]/auth/sign-in/page.tsx
@@ -59,7 +59,7 @@ export default function SignInPage() {
               </div>
             </CardContent>
 
-            <CardFooter className="flex flex-col gap-3">
+            <CardFooter className="flex flex-col gap-3 pt-2">
               <Button type="submit" className="w-full" disabled={isPending}>
                 {isPending ? 'Signing in…' : 'Sign in'}
               </Button>

--- a/app/[tenant]/auth/sign-up/page.tsx
+++ b/app/[tenant]/auth/sign-up/page.tsx
@@ -75,7 +75,7 @@ export default function SignUpPage() {
               </div>
             </CardContent>
 
-            <CardFooter className="flex flex-col gap-3">
+            <CardFooter className="flex flex-col gap-3 pt-2">
               <Button type="submit" className="w-full" disabled={isPending}>
                 {isPending ? 'Creating account…' : 'Create account'}
               </Button>


### PR DESCRIPTION
## Change
Adds `pt-2` to the `CardFooter` on all sign-in, sign-up, and create-course forms so the submit button is visually separated from the last input field.

## Files changed
- `app/[tenant]/auth/sign-in/page.tsx`
- `app/[tenant]/auth/sign-up/page.tsx`
- `app/(platform)/auth/sign-in/sign-in-form.tsx`
- `app/(platform)/new/new-tenant-form.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)