### PR TITLE
Rebrand to Courseday, rewrite landing page

### DIFF
--- a/app/(platform)/page.tsx
+++ b/app/(platform)/page.tsx
@@ -1,18 +1,81 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
 
 export default function LandingPage() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-3.5rem)] gap-6 p-4 text-center">
-      <h1 className="text-4xl font-bold tracking-tight">
-        Golf course operations, simplified
-      </h1>
-      <p className="text-lg text-muted-foreground max-w-md">
-        Manage your tee sheet, reservations, and daily programme — all in one place.
-      </p>
-      <Link href="/new">
-        <Button size="lg">Create your course</Button>
-      </Link>
+    <div className="flex flex-col">
+
+      {/* Hero */}
+      <section className="flex flex-col items-center justify-center text-center px-6 py-24 gap-6">
+        <h1 className="text-4xl sm:text-5xl font-bold tracking-tight max-w-2xl leading-tight">
+          Your venue's day, visible to everyone who needs it
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-xl">
+          Courseday keeps your operations team and food &amp; beverage service on the
+          same page — daily programme, covers, reservations, and hotel guests, all in
+          one shared view.
+        </p>
+        <div className="flex items-center gap-3 pt-2">
+          <Link href="/new">
+            <Button size="lg">Get started</Button>
+          </Link>
+          <Link href="/auth/sign-in">
+            <Button size="lg" variant="outline">Sign in</Button>
+          </Link>
+        </div>
+      </section>
+
+      <Separator />
+
+      {/* Features */}
+      <section className="max-w-5xl mx-auto w-full px-6 py-20 grid sm:grid-cols-3 gap-12">
+
+        <div className="flex flex-col gap-3">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">Daily programme</p>
+          <h2 className="text-lg font-semibold">One view for the whole day</h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Golf rounds, events, and group activities are published each day with times,
+            guest counts, and venue details. Everyone on the team sees the same picture —
+            no calls, no printouts.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">F&amp;B coordination</p>
+          <h2 className="text-lg font-semibold">Covers and timing, always current</h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Restaurant reservations, hotel breakfast configurations, and table breakdowns
+            sit alongside the programme. Your kitchen and front-of-house have the right
+            numbers without chasing them down.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">Your venue</p>
+          <h2 className="text-lg font-semibold">Private workspace, simple setup</h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Each venue gets its own subdomain and team. Editors manage the schedule;
+            the rest of the team can follow along on any device. No app to install,
+            no complicated onboarding.
+          </p>
+        </div>
+
+      </section>
+
+      <Separator />
+
+      {/* Footer CTA */}
+      <section className="flex flex-col items-center text-center px-6 py-20 gap-5">
+        <h2 className="text-2xl font-semibold tracking-tight">Ready to get your team aligned?</h2>
+        <p className="text-muted-foreground max-w-sm">
+          Set up your venue in a few minutes. No credit card required.
+        </p>
+        <Link href="/new">
+          <Button size="lg">Create your venue</Button>
+        </Link>
+      </section>
+
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,8 +15,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Platforms Starter Kit',
-  description: 'Next.js template for building a multi-tenant SaaS.',
+  title: 'Courseday',
+  description: 'Daily operations and team communication for golf venues, private clubs, and resorts.',
 };
 
 export default function RootLayout({

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -4,11 +4,10 @@ interface LogoProps {
   className?: string;
 }
 
-// Placeholder logo — swap this component out when a real brand asset is ready.
 export function Logo({ className }: LogoProps) {
   return (
     <span className={cn('font-bold tracking-tight text-foreground', className)}>
-      Golf Schedule
+      Courseday
     </span>
   );
 }


### PR DESCRIPTION
## Changes
- **Logo**: updated from 'Golf Schedule' to 'Courseday' everywhere
- **Metadata**: title and description updated to match the new brand
- **Landing page**: full rewrite

## Landing page structure
1. **Hero** — lead with the core value prop (shared daily view for ops + F&B teams), two CTAs
2. **Three feature blocks** — Daily programme / F&B coordination / Private workspace. Honest and specific about what the product actually does
3. **Footer CTA** — soft close, no credit card copy

Copy intentionally avoids over-promising — describes what the product does today, not a roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)