### PR TITLE
feat: per-tenant white-labelling with accent color and logo

### DIFF
--- a/app/[tenant]/admin/settings/client.tsx
+++ b/app/[tenant]/admin/settings/client.tsx
@@ -4,15 +4,22 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PocManagement } from '@/components/poc-management';
 import { VenueTypeManagement } from '@/components/venue-type-management';
+import { SettingsForm } from './settings-form';
 
-const TABS = ['poc', 'venue-types'] as const;
+const TABS = ['poc', 'venue-types', 'branding'] as const;
 type Tab = (typeof TABS)[number];
 
 function isValidTab(v: string | null): v is Tab {
   return TABS.includes(v as Tab);
 }
 
-export function SettingsClient() {
+interface SettingsClientProps {
+  tenantId: string;
+  initialAccentColor: string | null;
+  initialLogoUrl: string | null;
+}
+
+export function SettingsClient({ tenantId, initialAccentColor, initialLogoUrl }: SettingsClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -33,6 +40,7 @@ export function SettingsClient() {
         <TabsList className="mb-6">
           <TabsTrigger value="poc">Points of Contact</TabsTrigger>
           <TabsTrigger value="venue-types">Venue Types</TabsTrigger>
+          <TabsTrigger value="branding">Branding</TabsTrigger>
         </TabsList>
 
         <TabsContent value="poc">
@@ -41,6 +49,14 @@ export function SettingsClient() {
 
         <TabsContent value="venue-types">
           <VenueTypeManagement />
+        </TabsContent>
+
+        <TabsContent value="branding">
+          <SettingsForm
+            tenantId={tenantId}
+            initialAccentColor={initialAccentColor}
+            initialLogoUrl={initialLogoUrl}
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/app/[tenant]/admin/settings/page.tsx
+++ b/app/[tenant]/admin/settings/page.tsx
@@ -1,8 +1,27 @@
 import { requireTenantEditor } from '@/lib/guards';
+import { getTenantFromHeaders } from '@/lib/tenant';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { SettingsClient } from './client';
 
 export default async function SettingsPage() {
   await requireTenantEditor();
+  const tenant = await getTenantFromHeaders();
 
-  return <SettingsClient />;
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('tenants')
+    .select('accent_color, logo_url')
+    .eq('id', tenant.id)
+    .single();
+
+  const accentColor = (data as { accent_color?: string | null } | null)?.accent_color ?? null;
+  const logoUrl = (data as { logo_url?: string | null } | null)?.logo_url ?? null;
+
+  return (
+    <SettingsClient
+      tenantId={tenant.id}
+      initialAccentColor={accentColor}
+      initialLogoUrl={logoUrl}
+    />
+  );
 }

--- a/app/[tenant]/admin/settings/settings-form.tsx
+++ b/app/[tenant]/admin/settings/settings-form.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import Image from 'next/image';
+import { toast } from 'sonner';
+import { updateTenant } from '@/app/actions/tenants';
+import { createSupabaseBrowserClient } from '@/lib/supabase-client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+interface SettingsFormProps {
+  tenantId: string;
+  initialAccentColor: string | null;
+  initialLogoUrl: string | null;
+}
+
+export function SettingsForm({ tenantId, initialAccentColor, initialLogoUrl }: SettingsFormProps) {
+  const [accentColor, setAccentColor] = useState(initialAccentColor ?? '#1a1a1a');
+  const [logoUrl, setLogoUrl] = useState(initialLogoUrl ?? '');
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  function handleColorChange(value: string) {
+    setAccentColor(value);
+    // Live preview: update the CSS variable on the page
+    document.documentElement.style.setProperty('--tenant-accent', value);
+  }
+
+  async function handleLogoUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const ext = file.name.split('.').pop() ?? 'png';
+      const path = `${tenantId}/logo.${ext}`;
+
+      const { error } = await supabase.storage
+        .from('tenant-logos')
+        .upload(path, file, { upsert: true });
+
+      if (error) throw error;
+
+      const { data: { publicUrl } } = supabase.storage
+        .from('tenant-logos')
+        .getPublicUrl(path);
+
+      setLogoUrl(publicUrl);
+      toast.success('Logo uploaded');
+    } catch {
+      toast.error('Failed to upload logo');
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }
+
+  async function handleRemoveLogo() {
+    setLogoUrl('');
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const result = await updateTenant(tenantId, {
+        accent_color: accentColor || null,
+        logo_url: logoUrl || null,
+      });
+
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success('Settings saved');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Accent Color */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Brand Color</CardTitle>
+          <CardDescription>
+            Applied as the primary accent color across your tenant's interface.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-3">
+            <input
+              id="accent-color-picker"
+              type="color"
+              value={accentColor.startsWith('#') ? accentColor : '#1a1a1a'}
+              onChange={(e) => handleColorChange(e.target.value)}
+              className="h-10 w-10 cursor-pointer rounded border border-input bg-transparent p-0.5"
+            />
+            <div className="flex-1">
+              <Label htmlFor="accent-color-input" className="sr-only">Hex color</Label>
+              <Input
+                id="accent-color-input"
+                value={accentColor}
+                onChange={(e) => handleColorChange(e.target.value)}
+                className="w-36 font-mono"
+                placeholder="#1a1a1a"
+              />
+            </div>
+          </div>
+          <div
+            className="h-8 w-full rounded-md border"
+            style={{ backgroundColor: accentColor }}
+            aria-label="Color preview"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Logo */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Logo</CardTitle>
+          <CardDescription>
+            Shown in the header. Recommended: PNG or SVG, max 5 MB.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {logoUrl && (
+            <div className="flex items-center gap-4 rounded-md border p-3">
+              <Image
+                src={logoUrl}
+                alt="Logo preview"
+                width={160}
+                height={48}
+                className="max-h-12 w-auto object-contain"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleRemoveLogo}
+              >
+                Remove
+              </Button>
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleLogoUpload}
+              className="hidden"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+            >
+              {uploading ? 'Uploading…' : logoUrl ? 'Replace logo' : 'Upload logo'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Button onClick={handleSave} disabled={saving}>
+        {saving ? 'Saving…' : 'Save changes'}
+      </Button>
+    </div>
+  );
+}

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { Toaster } from 'sonner';
+import { Settings } from 'lucide-react';
 import { Logo } from '@/components/logo';
 import { UserMenu } from '@/components/user-menu';
 import { getUser } from '@/app/actions/auth';
@@ -8,6 +10,7 @@ import { TenantProvider } from '@/lib/tenant-context';
 import { AuthProvider } from '@/lib/AuthProvider';
 import { AdminIndicator } from '@/components/admin-indicator';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { isEditor } from '@/lib/membership';
 
 export async function generateMetadata(): Promise<Metadata> {
   try {
@@ -40,22 +43,36 @@ export default async function TenantLayout({
   const supabase = await createSupabaseServerClient();
   const { data: tenantRow } = await supabase
     .from('tenants')
-    .select('accent_color')
+    .select('accent_color, logo_url, name')
     .eq('id', tenant.id)
     .single();
 
-  const accentColor = (tenantRow as { accent_color?: string | null } | null)?.accent_color;
+  const row = tenantRow as { accent_color?: string | null; logo_url?: string | null; name?: string | null } | null;
+  const accentColor = row?.accent_color;
   const accentStyle = accentColor
     ? ({ '--tenant-accent': accentColor } as React.CSSProperties)
     : undefined;
+
+  const editor = await isEditor(tenant.id);
 
   return (
     <TenantProvider tenantId={tenant.id} tenantSlug={tenant.slug}>
       <AuthProvider>
         <div className="min-h-screen flex flex-col" style={accentStyle}>
           <header className="border-b px-6 h-14 flex items-center justify-between">
-            <Logo />
-            {user && <UserMenu user={user} />}
+            <Logo logoUrl={row?.logo_url} tenantName={row?.name} />
+            <div className="flex items-center gap-2">
+              {editor && (
+                <Link
+                  href="/admin/settings?tab=branding"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label="Branding settings"
+                >
+                  <Settings className="h-4 w-4" />
+                </Link>
+              )}
+              {user && <UserMenu user={user} />}
+            </div>
           </header>
           <main className="flex-1">{children}</main>
         </div>

--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -126,7 +126,7 @@ export async function getTenantBySlug(
 // ---------------------------------------------------------------------------
 export async function updateTenant(
   id: string,
-  data: { name?: string; slug?: string; logo_url?: string; timezone?: string }
+  data: { name?: string; slug?: string; logo_url?: string | null; accent_color?: string | null; timezone?: string }
 ): Promise<ActionResponse<TenantRedisData>> {
   const serviceClient = createSupabaseServiceClient();
 

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -1,13 +1,29 @@
+import Image from 'next/image';
 import { cn } from '@/lib/utils';
 
 interface LogoProps {
   className?: string;
+  logoUrl?: string | null;
+  tenantName?: string | null;
 }
 
-export function Logo({ className }: LogoProps) {
+export function Logo({ className, logoUrl, tenantName }: LogoProps) {
+  if (logoUrl) {
+    return (
+      <Image
+        src={logoUrl}
+        alt={tenantName ?? 'Logo'}
+        width={120}
+        height={36}
+        className={cn('object-contain max-h-9', className)}
+        priority
+      />
+    );
+  }
+
   return (
     <span className={cn('font-bold tracking-tight text-foreground', className)}>
-      Courseday
+      {tenantName ?? 'Courseday'}
     </span>
   );
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,15 @@ const nextConfig: NextConfig = {
     // @ts-expect-error nodeMiddleware is not yet in ExperimentalConfig types
     nodeMiddleware: true,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.supabase.co',
+        pathname: '/storage/v1/object/public/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/supabase/migrations/00012_tenant_logo_storage.sql
+++ b/supabase/migrations/00012_tenant_logo_storage.sql
@@ -1,0 +1,58 @@
+-- Create storage bucket for tenant logos
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'tenant-logos',
+  'tenant-logos',
+  true,
+  5242880,
+  ARRAY['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml', 'image/gif']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Public read access for logos
+CREATE POLICY "public_can_read_logos"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'tenant-logos');
+
+-- Editors can upload logos for their tenant (path must start with tenant UUID)
+CREATE POLICY "tenant_editors_can_upload_logo"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'tenant-logos'
+  AND (storage.foldername(name))[1] IN (
+    SELECT t.id::text
+    FROM tenants t
+    JOIN memberships m ON m.tenant_id = t.id
+    WHERE m.user_id = auth.uid() AND m.role = 'editor'
+  )
+);
+
+-- Editors can replace (update) logos for their tenant
+CREATE POLICY "tenant_editors_can_update_logo"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'tenant-logos'
+  AND (storage.foldername(name))[1] IN (
+    SELECT t.id::text
+    FROM tenants t
+    JOIN memberships m ON m.tenant_id = t.id
+    WHERE m.user_id = auth.uid() AND m.role = 'editor'
+  )
+);
+
+-- Editors can delete logos for their tenant
+CREATE POLICY "tenant_editors_can_delete_logo"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'tenant-logos'
+  AND (storage.foldername(name))[1] IN (
+    SELECT t.id::text
+    FROM tenants t
+    JOIN memberships m ON m.tenant_id = t.id
+    WHERE m.user_id = auth.uid() AND m.role = 'editor'
+  )
+);


### PR DESCRIPTION
- Add `accent_color` support to `updateTenant` action
- Add Branding tab to /admin/settings with accent color picker and logo upload
- Upload logos to Supabase Storage bucket (`tenant-logos`) with editor-scoped RLS
- Display tenant logo (or name fallback) in the header via updated Logo component
- Apply accent color as `--tenant-accent` CSS var in tenant layout
- Add settings gear icon link in header for editors
- Add next/image remote patterns for Supabase Storage URLs
- Add migration 00012 to create the `tenant-logos` storage bucket and policies

https://claude.ai/code/session_01DG1BE8xqj2JCvAY16xJY96