### PR TITLE
Add PWA support to tenant subdomains

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -11,6 +11,8 @@ import { AuthProvider } from '@/lib/AuthProvider';
 import { AdminIndicator } from '@/components/admin-indicator';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { isEditor } from '@/lib/membership';
+import { PwaRegister } from '@/components/pwa-register';
+import { PwaInstallPrompt } from '@/components/pwa-install-prompt';
 
 export async function generateMetadata(): Promise<Metadata> {
   try {
@@ -24,9 +26,29 @@ export async function generateMetadata(): Promise<Metadata> {
     const name = data?.name as string | undefined;
     return {
       title: name ? `${name} · Golf Schedule` : 'Golf Schedule',
+      manifest: '/manifest.webmanifest',
+      appleWebApp: {
+        capable: true,
+        statusBarStyle: 'default',
+        title: name ?? 'Golf Schedule',
+      },
+      icons: {
+        apple: '/icon.svg',
+      },
     };
   } catch {
-    return { title: 'Golf Schedule' };
+    return {
+      title: 'Golf Schedule',
+      manifest: '/manifest.webmanifest',
+      appleWebApp: {
+        capable: true,
+        statusBarStyle: 'default',
+        title: 'Golf Schedule',
+      },
+      icons: {
+        apple: '/icon.svg',
+      },
+    };
   }
 }
 
@@ -78,6 +100,8 @@ export default async function TenantLayout({
         </div>
         <AdminIndicator />
         <Toaster richColors closeButton />
+        <PwaRegister />
+        <PwaInstallPrompt />
       </AuthProvider>
     </TenantProvider>
   );

--- a/components/pwa-install-prompt.tsx
+++ b/components/pwa-install-prompt.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Download, Share, X } from 'lucide-react';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+export function PwaInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [showIosHint, setShowIosHint] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    // Already installed as standalone — don't show
+    if (window.matchMedia('(display-mode: standalone)').matches) return;
+
+    // Dismissed this session
+    if (sessionStorage.getItem('pwa-prompt-dismissed')) return;
+
+    const isIos =
+      /iphone|ipad|ipod/i.test(navigator.userAgent) &&
+      !('MSStream' in window);
+
+    if (isIos) {
+      setShowIosHint(true);
+      return;
+    }
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  const dismiss = () => {
+    sessionStorage.setItem('pwa-prompt-dismissed', '1');
+    setDismissed(true);
+  };
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === 'accepted') setDeferredPrompt(null);
+    dismiss();
+  };
+
+  if (dismissed) return null;
+
+  if (deferredPrompt) {
+    return (
+      <div className="fixed bottom-4 left-4 right-4 z-50 flex items-center gap-3 rounded-xl border bg-background p-4 shadow-lg sm:left-auto sm:right-4 sm:w-80">
+        <Download className="h-5 w-5 shrink-0 text-primary" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">Add to Home Screen</p>
+          <p className="text-xs text-muted-foreground">Install for quick offline access</p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            onClick={handleInstall}
+            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Install
+          </button>
+          <button
+            onClick={dismiss}
+            className="rounded-md p-1 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Dismiss"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (showIosHint) {
+    return (
+      <div className="fixed bottom-4 left-4 right-4 z-50 flex items-start gap-3 rounded-xl border bg-background p-4 shadow-lg sm:left-auto sm:right-4 sm:w-80">
+        <Share className="h-5 w-5 shrink-0 text-primary mt-0.5" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">Add to Home Screen</p>
+          <p className="text-xs text-muted-foreground">
+            Tap <Share className="inline h-3 w-3 mx-0.5" /> then &ldquo;Add to Home Screen&rdquo;
+          </p>
+        </div>
+        <button
+          onClick={dismiss}
+          className="rounded-md p-1 text-muted-foreground hover:text-foreground transition-colors shrink-0"
+          aria-label="Dismiss"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/components/pwa-register.tsx
+++ b/components/pwa-register.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function PwaRegister() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(console.error);
+    }
+  }, []);
+
+  return null;
+}

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- Background -->
+  <rect width="512" height="512" rx="80" fill="#166534"/>
+  <!-- Flag pole -->
+  <rect x="224" y="72" width="14" height="310" rx="7" fill="white"/>
+  <!-- Flag -->
+  <polygon points="238,72 370,130 238,188" fill="white"/>
+  <!-- Ground line -->
+  <rect x="80" y="390" width="352" height="10" rx="5" fill="#4ade80"/>
+  <!-- Golf ball -->
+  <circle cx="224" cy="380" r="38" fill="white"/>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Golf Schedule",
+  "short_name": "Golf Schedule",
+  "description": "Daily operations and team communication for golf venues, private clubs, and resorts.",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#ffffff",
+  "theme_color": "#166534",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,49 @@
+const CACHE_NAME = 'golf-schedule-v1';
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+      )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+
+  const url = new URL(event.request.url);
+
+  // Cache-first for Next.js static assets (immutable, content-hashed)
+  if (url.pathname.startsWith('/_next/static/')) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(async (cache) => {
+        const cached = await cache.match(event.request);
+        if (cached) return cached;
+        const response = await fetch(event.request);
+        if (response.ok) cache.put(event.request, response.clone());
+        return response;
+      })
+    );
+    return;
+  }
+
+  // Network-first for pages — fall back to cache when offline
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        if (response.ok) {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        }
+        return response;
+      })
+      .catch(() => caches.match(event.request))
+  );
+});


### PR DESCRIPTION
Registers a service worker and web app manifest on all subdomain
(tenant) routes so users can install the app to their home screen.
The main domain remains a plain website with no manifest or SW.

- public/manifest.webmanifest – app name, standalone display, golf icon
- public/sw.js – cache-first for static assets, network-first for pages
- public/icon.svg – golf flag icon (SVG, scales to any size)
- components/pwa-register.tsx – registers /sw.js on mount
- components/pwa-install-prompt.tsx – beforeinstallprompt banner
  (Android/Chrome) + share-sheet hint (iOS Safari)
- app/[tenant]/layout.tsx – links manifest, apple-web-app meta tags,
  and mounts the two PWA client components

https://claude.ai/code/session_01XSHj9u3brmVZVYKr52WDnC