### PR TITLE
T-02: RLS policy verification & fixes (post-migration)

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -106,7 +106,7 @@ Migration files 00001 through 00012 exist in `supabase/migrations/`. Two files s
 
 ## Ticket 2: RLS Policy Verification & Fixes (post-migration)
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P1  
 **Scope:** `supabase/migrations/` (new migration file)  

--- a/supabase/migrations/00015_rls_verification.sql
+++ b/supabase/migrations/00015_rls_verification.sql
@@ -1,0 +1,36 @@
+-- =============================================================================
+-- Migration 00015: RLS policy verification & fixes (post-migration 00014)
+-- =============================================================================
+-- Migration 00014 renamed program_item → activity (policies renamed in-place),
+-- created activity_tag (full CRUD policies), and activity_tag_assignment
+-- (SELECT/INSERT/DELETE policies). This migration adds the missing UPDATE policy
+-- on activity_tag_assignment to give editors full CRUD, matching the pattern
+-- used on all other editor-writable tables.
+--
+-- All other tables have been audited and their policies are correct:
+--   activity           — SELECT (members), INSERT/UPDATE/DELETE (editors) ✓
+--   reservation        — SELECT (members), INSERT/UPDATE/DELETE (editors) ✓
+--   breakfast_config   — SELECT (members), INSERT/UPDATE/DELETE (editors) ✓
+--   activity_tag       — SELECT (members), INSERT/UPDATE/DELETE (editors) ✓
+--   day                — SELECT (members) only; INSERT via service role ✓
+--   venue_type         — SELECT (members), INSERT/UPDATE/DELETE (editors) ✓
+--   point_of_contact   — SELECT (members), INSERT/UPDATE/DELETE (editors) ✓
+--   tenants            — SELECT (members via is_tenant_member) ✓
+--   memberships        — unchanged inline policies ✓
+--
+-- Helper functions is_tenant_member / is_tenant_editor (00003_rls_helpers.sql)
+-- query only the memberships table and are unaffected by the 00014 rename. ✓
+-- =============================================================================
+
+-- activity_tag_assignment was missing an UPDATE policy for editors.
+-- (The table has only PK columns so UPDATE is a no-op in practice, but the
+-- policy is required to satisfy the full-CRUD editor requirement consistently.)
+CREATE POLICY "activity_tag_assignment: editors can update"
+  ON activity_tag_assignment FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM activity a
+      WHERE a.id = activity_id
+        AND is_tenant_editor(a.tenant_id)
+    )
+  );


### PR DESCRIPTION
## Summary

- Full audit of all RLS policies after the Ticket 1 overhaul
- Only gap found: `activity_tag_assignment` was missing an `UPDATE` policy for editors — all other tables were already correct
- New migration `00015_rls_verification.sql` adds the missing policy and documents the full audit result

## Policy audit

| Table | Members SELECT | Editors full CRUD | Notes |
|---|---|---|---|
| `activity` | ✅ | ✅ | Policies renamed from `program_item:` in 00014 |
| `activity_tag` | ✅ | ✅ | Created in 00014 |
| `activity_tag_assignment` | ✅ | ✅ | UPDATE policy added in this migration |
| `reservation` | ✅ | ✅ | Unchanged from 00008 |
| `breakfast_configuration` | ✅ | ✅ | Scoped directly via `tenant_id` |
| `day` | ✅ | — | INSERT via service role only (unchanged) |
| `venue_type` | ✅ | ✅ | Unchanged from 00005 |
| `point_of_contact` | ✅ | ✅ | Unchanged from 00004 |
| `tenants` | ✅ | — | SELECT via `is_tenant_member` |
| `memberships` | ✅ | ✅ | Inline policies, unchanged |

`is_tenant_member` / `is_tenant_editor` helpers query only `memberships` — unaffected by the 00014 rename.

## Test plan

- [ ] `supabase db push` applies cleanly (verified ✅)
- [ ] `activity_tag_assignment` has SELECT/INSERT/UPDATE/DELETE policies for editors

🤖 Generated with [Claude Code](https://claude.com/claude-code)