### PR TITLE
T-4: Server Actions Refactor

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -200,7 +200,7 @@ The database migration in Ticket 1 renames `program_item` to `activity`, drops `
 
 ## Ticket 4: Server Actions Refactor
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P0  
 **Scope:** `app/actions/program-items.ts`, `app/actions/hotel-bookings.ts`, `app/actions/reservations.ts`, `app/actions/breakfast.ts`, `lib/reservation-schema.ts`, new `app/actions/activities.ts`, new `app/actions/activity-tags.ts`  

--- a/app/actions/activities.ts
+++ b/app/actions/activities.ts
@@ -8,12 +8,11 @@ import { generateRecurrenceDates } from '@/lib/day-utils';
 import { activitySchema } from '@/lib/program-item-schema';
 import { ensureDayExists } from '@/app/actions/days';
 import type { ActionResponse } from '@/types/actions';
-import type { Activity } from '@/types/index';
+import type { Activity, ActivityWithRelations } from '@/types/index';
 import type { ActivityFormData } from '@/lib/program-item-schema';
 
-
 // ---------------------------------------------------------------------------
-// Internal row builder
+// Internal helpers
 // ---------------------------------------------------------------------------
 
 function toRow(
@@ -38,11 +37,29 @@ function toRow(
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function assignTags(supabase: any, activityId: string, tagIds: string[]): Promise<string | null> {
+  const { error: delErr } = await supabase
+    .from('activity_tag_assignment')
+    .delete()
+    .eq('activity_id', activityId);
+  if (delErr) return delErr.message;
+
+  if (tagIds.length === 0) return null;
+
+  const { error: insErr } = await supabase
+    .from('activity_tag_assignment')
+    .insert(tagIds.map((tagId) => ({ activity_id: activityId, tag_id: tagId })));
+  if (insErr) return insErr.message;
+
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Actions
 // ---------------------------------------------------------------------------
 
-export async function createProgramItem(
+export async function createActivity(
   raw: ActivityFormData
 ): Promise<ActionResponse<Activity>> {
   const parsed = activitySchema.safeParse(raw);
@@ -56,6 +73,7 @@ export async function createProgramItem(
   const { supabase } = await createTenantClient();
   const data = parsed.data;
   const isRecurring = data.isRecurring && !!data.recurrenceFrequency;
+  const tagIds = data.tagIds ?? [];
 
   if (!isRecurring) {
     const { data: row, error } = await supabase
@@ -65,6 +83,12 @@ export async function createProgramItem(
       .single();
 
     if (error) return { success: false, error: error.message };
+
+    if (tagIds.length > 0) {
+      const tagErr = await assignTags(supabase, (row as Activity).id, tagIds);
+      if (tagErr) return { success: false, error: tagErr };
+    }
+
     return { success: true, data: row as Activity };
   }
 
@@ -79,7 +103,7 @@ export async function createProgramItem(
     return { success: false, error: 'Could not find the day record.' };
   }
 
-  const startDate = dayRow.date_iso;
+  const startDate = (dayRow as { date_iso: string }).date_iso;
   const futureDates = generateRecurrenceDates(startDate, data.recurrenceFrequency!);
   const allDates = [startDate, ...futureDates];
 
@@ -97,7 +121,7 @@ export async function createProgramItem(
     return { success: false, error: 'Could not resolve day records for recurrence.' };
   }
 
-  const dateToId = new Map(dayRows.map((d) => [d.date_iso, d.id]));
+  const dateToId = new Map((dayRows as { id: string; date_iso: string }[]).map((d) => [d.date_iso, d.id]));
   const rows = allDates
     .map((d) => dateToId.get(d))
     .filter((id): id is string => !!id)
@@ -117,10 +141,16 @@ export async function createProgramItem(
     .single();
 
   if (insertErr) return { success: false, error: insertErr.message };
+
+  if (tagIds.length > 0) {
+    const tagErr = await assignTags(supabase, (inserted as Activity).id, tagIds);
+    if (tagErr) return { success: false, error: tagErr };
+  }
+
   return { success: true, data: inserted as Activity };
 }
 
-export async function updateProgramItem(
+export async function updateActivity(
   id: string,
   raw: ActivityFormData
 ): Promise<ActionResponse<Activity>> {
@@ -154,10 +184,14 @@ export async function updateProgramItem(
     .single();
 
   if (error) return { success: false, error: error.message };
+
+  const tagErr = await assignTags(supabase, id, data.tagIds ?? []);
+  if (tagErr) return { success: false, error: tagErr };
+
   return { success: true, data: row as Activity };
 }
 
-export async function deleteProgramItem(id: string): Promise<ActionResponse> {
+export async function deleteActivity(id: string): Promise<ActionResponse> {
   const tenantId = await getTenantId();
   await requireEditor(tenantId);
 
@@ -172,7 +206,7 @@ export async function deleteProgramItem(id: string): Promise<ActionResponse> {
   return { success: true, data: undefined };
 }
 
-export async function deleteRecurrenceGroup(groupId: string): Promise<ActionResponse> {
+export async function deleteActivityRecurrenceGroup(groupId: string): Promise<ActionResponse> {
   const tenantId = await getTenantId();
   await requireEditor(tenantId);
 
@@ -187,9 +221,9 @@ export async function deleteRecurrenceGroup(groupId: string): Promise<ActionResp
   return { success: true, data: undefined };
 }
 
-export async function getProgramItemsForDay(
+export async function getActivitiesForDay(
   dayId: string
-): Promise<ActionResponse<Activity[]>> {
+): Promise<ActionResponse<ActivityWithRelations[]>> {
   const tenantId = await getTenantId();
   const role = await getUserRole(tenantId);
   if (!role) return { success: false, error: 'Not authorized.' };
@@ -197,11 +231,19 @@ export async function getProgramItemsForDay(
   const { supabase } = await createTenantClient();
   const { data, error } = await supabase
     .from('activity')
-    .select('*, venue_type(*), point_of_contact(*)')
+    .select('*, venue_type(*), point_of_contact(*), activity_tag_assignment(activity_tag(*))')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
     .order('start_time', { nullsFirst: true });
 
   if (error) return { success: false, error: error.message };
-  return { success: true, data: data as unknown as Activity[] };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const items = (data as any[]).map((row) => ({
+    ...row,
+    tags: (row.activity_tag_assignment ?? []).map((a: { activity_tag: unknown }) => a.activity_tag),
+    activity_tag_assignment: undefined,
+  }));
+
+  return { success: true, data: items as ActivityWithRelations[] };
 }

--- a/app/actions/activity-tags.ts
+++ b/app/actions/activity-tags.ts
@@ -1,0 +1,100 @@
+'use server';
+
+import { createTenantClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { getUserRole, requireEditor } from '@/lib/membership';
+import { activityTagSchema } from '@/lib/activity-tag-schema';
+import type { ActionResponse } from '@/types/actions';
+import type { ActivityTag } from '@/types/index';
+
+export async function getAllActivityTags(): Promise<ActionResponse<ActivityTag[]>> {
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('activity_tag')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .order('name');
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as ActivityTag[] };
+}
+
+export async function createActivityTag(
+  name: string
+): Promise<ActionResponse<ActivityTag>> {
+  const parsed = activityTagSchema.safeParse({ name });
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('activity_tag')
+    .insert({ tenant_id: tenantId, name: parsed.data.name.trim() })
+    .select()
+    .single();
+
+  if (error) {
+    const isDupe = error.code === '23505';
+    return {
+      success: false,
+      error: isDupe ? 'A tag with that name already exists.' : error.message,
+    };
+  }
+
+  return { success: true, data: data as ActivityTag };
+}
+
+export async function updateActivityTag(
+  id: string,
+  name: string
+): Promise<ActionResponse<ActivityTag>> {
+  const parsed = activityTagSchema.safeParse({ name });
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('activity_tag')
+    .update({ name: parsed.data.name.trim() })
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .select()
+    .single();
+
+  if (error) {
+    const isDupe = error.code === '23505';
+    return {
+      success: false,
+      error: isDupe ? 'A tag with that name already exists.' : error.message,
+    };
+  }
+
+  return { success: true, data: data as ActivityTag };
+}
+
+export async function deleteActivityTag(id: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { error } = await supabase
+    .from('activity_tag')
+    .delete()
+    .eq('id', id)
+    .eq('tenant_id', tenantId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}

--- a/app/actions/breakfast.ts
+++ b/app/actions/breakfast.ts
@@ -23,28 +23,27 @@ export async function createBreakfastConfiguration(
   const { supabase } = await createTenantClient();
   const d = parsed.data;
 
-  // Validate breakfast_date falls within the booking window
-  const { data: booking, error: bookingError } = await supabase
-    .from('hotel_booking')
-    .select('check_in, check_out')
-    .eq('id', d.hotelBookingId)
+  // Resolve the day's date_iso (needed for the breakfast_date column)
+  const { data: dayRow, error: dayErr } = await supabase
+    .from('day')
+    .select('date_iso')
+    .eq('id', d.dayId)
     .eq('tenant_id', tenantId)
     .single();
-
-  if (bookingError) return { success: false, error: bookingError.message };
-  if (d.breakfastDate < booking.check_in || d.breakfastDate >= booking.check_out) {
-    return { success: false, error: 'Breakfast date must fall within the booking window.' };
-  }
+  if (dayErr || !dayRow) return { success: false, error: 'Day not found.' };
 
   const tableBreakdown = parseTableBreakdown(d.tableBreakdown ?? null);
+  const totalGuests = tableBreakdown ? tableBreakdown.reduce((s, n) => s + n, 0) : 0;
 
   const { data, error } = await supabase
     .from('breakfast_configuration')
     .insert({
       tenant_id: tenantId,
-      hotel_booking_id: d.hotelBookingId,
-      breakfast_date: d.breakfastDate,
+      day_id: d.dayId,
+      breakfast_date: (dayRow as { date_iso: string }).date_iso,
+      group_name: d.groupName || null,
       table_breakdown: tableBreakdown,
+      total_guests: totalGuests,
       start_time: d.startTime || null,
       notes: d.notes || null,
     })
@@ -71,11 +70,13 @@ export async function updateBreakfastConfiguration(
   const d = parsed.data;
 
   const tableBreakdown = parseTableBreakdown(d.tableBreakdown ?? null);
+  const totalGuests = tableBreakdown ? tableBreakdown.reduce((s, n) => s + n, 0) : 0;
 
   const { data, error } = await supabase
     .from('breakfast_configuration')
     .update({
       table_breakdown: tableBreakdown,
+      total_guests: totalGuests,
       start_time: d.startTime || null,
       notes: d.notes || null,
       updated_at: new Date().toISOString(),
@@ -104,27 +105,8 @@ export async function deleteBreakfastConfiguration(id: string): Promise<ActionRe
   return { success: true, data: undefined };
 }
 
-export async function getBreakfastConfigurationsForBooking(
-  bookingId: string
-): Promise<ActionResponse<BreakfastConfiguration[]>> {
-  const tenantId = await getTenantId();
-  const role = await getUserRole(tenantId);
-  if (!role) return { success: false, error: 'Not authorized.' };
-
-  const { supabase } = await createTenantClient();
-  const { data, error } = await supabase
-    .from('breakfast_configuration')
-    .select('*')
-    .eq('tenant_id', tenantId)
-    .eq('hotel_booking_id', bookingId)
-    .order('breakfast_date');
-
-  if (error) return { success: false, error: error.message };
-  return { success: true, data: data as BreakfastConfiguration[] };
-}
-
 export async function getBreakfastConfigurationsForDay(
-  dateIso: string
+  dayId: string
 ): Promise<ActionResponse<BreakfastConfiguration[]>> {
   const tenantId = await getTenantId();
   const role = await getUserRole(tenantId);
@@ -135,8 +117,8 @@ export async function getBreakfastConfigurationsForDay(
     .from('breakfast_configuration')
     .select('*')
     .eq('tenant_id', tenantId)
-    .eq('breakfast_date', dateIso)
-    .order('created_at');
+    .eq('day_id', dayId)
+    .order('start_time', { nullsFirst: true });
 
   if (error) return { success: false, error: error.message };
   return { success: true, data: data as BreakfastConfiguration[] };

--- a/app/actions/reservations.ts
+++ b/app/actions/reservations.ts
@@ -32,6 +32,7 @@ export async function createReservation(
       start_time: d.startTime || null,
       end_time: d.endTime || null,
       notes: d.notes || null,
+      table_breakdown: d.tableBreakdown ?? null,
     })
     .select()
     .single();
@@ -63,6 +64,7 @@ export async function updateReservation(
       start_time: d.startTime || null,
       end_time: d.endTime || null,
       notes: d.notes || null,
+      table_breakdown: d.tableBreakdown ?? null,
       updated_at: new Date().toISOString(),
     })
     .eq('id', id)

--- a/components/CalendarDaySidebar.tsx
+++ b/components/CalendarDaySidebar.tsx
@@ -6,7 +6,7 @@ import { X, Plus, ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { ensureDayExists } from '@/app/actions/days';
-import { getProgramItemsForDay } from '@/app/actions/program-items';
+import { getActivitiesForDay } from '@/app/actions/activities';
 import { getReservationsForDay } from '@/app/actions/reservations';
 import { getAllPOCs } from '@/app/actions/poc';
 import { getAllVenueTypes } from '@/app/actions/venue-type';
@@ -66,7 +66,7 @@ export function CalendarDaySidebar({ date, onClose, onSummaryChanged }: Props) {
 
       const [itemsResult, resResult, pocsResult, venuesResult] =
         await Promise.all([
-          getProgramItemsForDay(dayId),
+          getActivitiesForDay(dayId),
           getReservationsForDay(dayId),
           getAllPOCs(),
           getAllVenueTypes(),

--- a/components/add-entry-modal.tsx
+++ b/components/add-entry-modal.tsx
@@ -7,9 +7,9 @@ import { z } from 'zod';
 import { toast } from 'sonner';
 import { Plus } from 'lucide-react';
 import {
-  createProgramItem,
-  updateProgramItem,
-} from '@/app/actions/program-items';
+  createActivity,
+  updateActivity,
+} from '@/app/actions/activities';
 import { createPOC } from '@/app/actions/poc';
 import { createVenueType } from '@/app/actions/venue-type';
 import { generateRecurrenceDates } from '@/lib/day-utils';
@@ -180,8 +180,8 @@ export function AddEntryModal({
       };
 
       const result = isEditing
-        ? await updateProgramItem(editItem!.id, payload)
-        : await createProgramItem(payload);
+        ? await updateActivity(editItem!.id, payload)
+        : await createActivity(payload);
 
       if (!result.success) {
         toast.error(result.error);

--- a/components/entry-card.tsx
+++ b/components/entry-card.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react';
 import { Pencil, Trash2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
-import { deleteProgramItem, deleteRecurrenceGroup } from '@/app/actions/program-items';
+import { deleteActivity, deleteActivityRecurrenceGroup } from '@/app/actions/activities';
 import type { ActivityWithRelations } from '@/types/index';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -34,8 +34,8 @@ export function EntryCard({ item, isEditor, onEdit, onDeleted }: Props) {
     startDeleteTransition(async () => {
       const result =
         mode === 'all' && item.recurrence_group_id
-          ? await deleteRecurrenceGroup(item.recurrence_group_id)
-          : await deleteProgramItem(item.id);
+          ? await deleteActivityRecurrenceGroup(item.recurrence_group_id)
+          : await deleteActivity(item.id);
 
       if (!result.success) {
         toast.error(result.error);

--- a/lib/activity-tag-schema.ts
+++ b/lib/activity-tag-schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const activityTagSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+});
+
+export type ActivityTagFormData = z.infer<typeof activityTagSchema>;

--- a/lib/breakfast-schema.ts
+++ b/lib/breakfast-schema.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const createBreakfastSchema = z.object({
-  hotelBookingId: z.string().uuid('Hotel booking ID is required'),
-  breakfastDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format'),
+  dayId: z.string().uuid('Day ID is required'),
+  groupName: z.string().optional(),
   tableBreakdown: z.string().optional(),
   startTime: z.string().optional(),
   notes: z.string().optional(),

--- a/lib/reservation-schema.ts
+++ b/lib/reservation-schema.ts
@@ -7,6 +7,7 @@ export const reservationSchema = z.object({
   startTime: z.string().optional(),
   endTime: z.string().optional(),
   notes: z.string().optional(),
+  tableBreakdown: z.array(z.number().int().min(1)).optional(),
 });
 
 export type ReservationFormData = z.infer<typeof reservationSchema>;

--- a/tests/actions/program-item-actions.test.ts
+++ b/tests/actions/program-item-actions.test.ts
@@ -11,12 +11,12 @@ vi.mock('@/app/actions/days', () => ({ ensureDayExists: vi.fn().mockResolvedValu
 
 import { createTenantClient } from '@/lib/supabase-server';
 import {
-  createProgramItem,
-  updateProgramItem,
-  deleteProgramItem,
-  deleteRecurrenceGroup,
-  getProgramItemsForDay,
-} from '@/app/actions/program-items';
+  createActivity,
+  updateActivity,
+  deleteActivity,
+  deleteActivityRecurrenceGroup,
+  getActivitiesForDay,
+} from '@/app/actions/activities';
 
 type QueryResult = { data: unknown; error: { message: string } | null };
 
@@ -35,7 +35,6 @@ function makeChain(result: QueryResult = { data: null, error: null }) {
 
 const VALID_ITEM = {
   title: 'Morning Round',
-  type: 'golf' as const,
   dayId: '123e4567-e89b-12d3-a456-426614174000',
 };
 
@@ -43,54 +42,49 @@ const ITEM_ROW = {
   id: 'item-1',
   tenant_id: 'tenant-1',
   day_id: VALID_ITEM.dayId,
-  type: 'golf',
   title: 'Morning Round',
   is_recurring: false,
 };
 
-// ── createProgramItem ─────────────────────────────────────────────────────────
+// ── createActivity ────────────────────────────────────────────────────────────
 
-describe('createProgramItem (non-recurring)', () => {
+describe('createActivity (non-recurring)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns error on schema validation failure', async () => {
-    const result = await createProgramItem({ ...VALID_ITEM, title: '' });
+    const result = await createActivity({ ...VALID_ITEM, title: '' });
     expect(result.success).toBe(false);
     expect(result.error).toBe('Title is required');
   });
 
-  it('inserts a golf item and returns it', async () => {
-    const from = vi.fn().mockReturnValue(makeChain({ data: ITEM_ROW, error: null }));
+  it('inserts an activity and returns it', async () => {
+    const chain = makeChain({ data: ITEM_ROW, error: null });
+    const from = vi.fn().mockReturnValue(chain);
     vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
 
-    const result = await createProgramItem(VALID_ITEM);
+    const result = await createActivity(VALID_ITEM);
 
     expect(result.success).toBe(true);
-    expect(result.data).toMatchObject({ type: 'golf', title: 'Morning Round' });
-    expect(from).toHaveBeenCalledWith('program_item');
+    expect(result.data).toMatchObject({ title: 'Morning Round' });
+    expect(from).toHaveBeenCalledWith('activity');
   });
 
   it('returns error when Supabase insert fails', async () => {
     const from = vi.fn().mockReturnValue(makeChain({ data: null, error: { message: 'db error' } }));
     vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
 
-    const result = await createProgramItem(VALID_ITEM);
+    const result = await createActivity(VALID_ITEM);
     expect(result.success).toBe(false);
     expect(result.error).toBe('db error');
   });
 });
 
-// ── createProgramItem (recurring) ────────────────────────────────────────────
+// ── createActivity (recurring) ────────────────────────────────────────────────
 
-describe('createProgramItem (recurring)', () => {
+describe('createActivity (recurring)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('fans out to multiple day records and returns the first-day item', async () => {
-    // Call sequence:
-    // 1. from('day').select().eq().single() → date_iso
-    // 2. from('day').select().eq().in() → all day rows (thenable)
-    // 3. from('program_item').insert().select().eq().single() → inserted item
-
     const dayRow = { date_iso: '2024-06-01' };
     const allDayRows = [
       { id: 'day-1', date_iso: '2024-06-01' },
@@ -98,20 +92,19 @@ describe('createProgramItem (recurring)', () => {
     ];
 
     const from = vi.fn()
-      .mockReturnValueOnce(makeChain({ data: dayRow, error: null }))          // fetch date_iso
-      .mockReturnValueOnce(makeChain({ data: allDayRows, error: null }))      // fetch day IDs
-      .mockReturnValue(makeChain({ data: ITEM_ROW, error: null }));           // insert items
+      .mockReturnValueOnce(makeChain({ data: dayRow, error: null }))
+      .mockReturnValueOnce(makeChain({ data: allDayRows, error: null }))
+      .mockReturnValue(makeChain({ data: ITEM_ROW, error: null }));
 
     vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
 
-    const result = await createProgramItem({
+    const result = await createActivity({
       ...VALID_ITEM,
       isRecurring: true,
       recurrenceFrequency: 'weekly',
     });
 
     expect(result.success).toBe(true);
-    // insert should be called with an array of rows (one per occurrence)
     const insertFn = (from.mock.results[2].value as ReturnType<typeof makeChain>)
       .insert as ReturnType<typeof vi.fn>;
     const insertedRows = insertFn.mock.calls[0][0] as unknown[];
@@ -120,31 +113,32 @@ describe('createProgramItem (recurring)', () => {
   });
 });
 
-// ── updateProgramItem ─────────────────────────────────────────────────────────
+// ── updateActivity ────────────────────────────────────────────────────────────
 
-describe('updateProgramItem', () => {
+describe('updateActivity', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('updates the item and returns it', async () => {
     const updated = { ...ITEM_ROW, title: 'Afternoon Round' };
-    const from = vi.fn().mockReturnValue(makeChain({ data: updated, error: null }));
+    const chain = makeChain({ data: updated, error: null });
+    const from = vi.fn().mockReturnValue(chain);
     vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
 
-    const result = await updateProgramItem('item-1', { ...VALID_ITEM, title: 'Afternoon Round' });
+    const result = await updateActivity('item-1', { ...VALID_ITEM, title: 'Afternoon Round' });
 
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({ title: 'Afternoon Round' });
   });
 
   it('returns error on schema validation failure', async () => {
-    const result = await updateProgramItem('item-1', { ...VALID_ITEM, title: '' });
+    const result = await updateActivity('item-1', { ...VALID_ITEM, title: '' });
     expect(result.success).toBe(false);
   });
 });
 
-// ── deleteProgramItem ─────────────────────────────────────────────────────────
+// ── deleteActivity ────────────────────────────────────────────────────────────
 
-describe('deleteProgramItem', () => {
+describe('deleteActivity', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('deletes by id and tenant and returns success', async () => {
@@ -152,9 +146,9 @@ describe('deleteProgramItem', () => {
     const from = vi.fn().mockReturnValue(chain);
     vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
 
-    const result = await deleteProgramItem('item-1');
+    const result = await deleteActivity('item-1');
     expect(result.success).toBe(true);
-    expect(from).toHaveBeenCalledWith('program_item');
+    expect(from).toHaveBeenCalledWith('activity');
     expect((chain.delete as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
   });
 
@@ -162,15 +156,15 @@ describe('deleteProgramItem', () => {
     const from = vi.fn().mockReturnValue(makeChain({ data: null, error: { message: 'delete error' } }));
     vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
 
-    const result = await deleteProgramItem('item-1');
+    const result = await deleteActivity('item-1');
     expect(result.success).toBe(false);
     expect(result.error).toBe('delete error');
   });
 });
 
-// ── deleteRecurrenceGroup ─────────────────────────────────────────────────────
+// ── deleteActivityRecurrenceGroup ─────────────────────────────────────────────
 
-describe('deleteRecurrenceGroup', () => {
+describe('deleteActivityRecurrenceGroup', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('deletes all items in the recurrence group', async () => {
@@ -178,18 +172,17 @@ describe('deleteRecurrenceGroup', () => {
     const from = vi.fn().mockReturnValue(chain);
     vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
 
-    const result = await deleteRecurrenceGroup('group-abc');
+    const result = await deleteActivityRecurrenceGroup('group-abc');
     expect(result.success).toBe(true);
 
-    // Must filter by recurrence_group_id
     const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
     expect(eqCalls).toContainEqual(['recurrence_group_id', 'group-abc']);
   });
 });
 
-// ── getProgramItemsForDay ─────────────────────────────────────────────────────
+// ── getActivitiesForDay ───────────────────────────────────────────────────────
 
-describe('getProgramItemsForDay', () => {
+describe('getActivitiesForDay', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns items for the given day', async () => {
@@ -197,7 +190,7 @@ describe('getProgramItemsForDay', () => {
     const from = vi.fn().mockReturnValue(makeChain({ data: items, error: null }));
     vi.mocked(createTenantClient).mockResolvedValue({ supabase: { from } as never, tenantId: 'tenant-1' });
 
-    const result = await getProgramItemsForDay('day-1');
+    const result = await getActivitiesForDay('day-1');
     expect(result.success).toBe(true);
     expect(result.data).toHaveLength(2);
   });
@@ -206,7 +199,7 @@ describe('getProgramItemsForDay', () => {
     const { getUserRole } = await import('@/lib/membership');
     vi.mocked(getUserRole).mockResolvedValue(null);
 
-    const result = await getProgramItemsForDay('day-1');
+    const result = await getActivitiesForDay('day-1');
     expect(result.success).toBe(false);
     expect(result.error).toBe('Not authorized.');
   });


### PR DESCRIPTION
## Summary

- Renames `app/actions/program-items.ts` → `app/actions/activities.ts` with all exported functions renamed (`createActivity`, `updateActivity`, `deleteActivity`, `deleteActivityRecurrenceGroup`, `getActivitiesForDay`)
- `createActivity`/`updateActivity` now manage tag assignments via `activity_tag_assignment` (delete-and-reinsert)
- `getActivitiesForDay` joins through `activity_tag_assignment` and flattens tags into `ActivityWithRelations`
- Creates `app/actions/activity-tags.ts` with full CRUD following the `venue-type.ts` pattern
- Rewrites `app/actions/breakfast.ts`: `createBreakfastConfiguration` now scoped to `day_id`; `getBreakfastConfigurationsForDay` queries by `day_id` (not `breakfast_date`); all `hotel_booking` references removed
- Updates `lib/breakfast-schema.ts` to accept `dayId`/`groupName` instead of `hotelBookingId`/`breakfastDate`
- Adds `table_breakdown` to `lib/reservation-schema.ts` and the reservation create/update actions
- Updates all import sites (`add-entry-modal`, `entry-card`, `CalendarDaySidebar`, test file)

## Test plan

- [ ] `pnpm build` passes (verified locally)
- [ ] No file imports from `@/app/actions/program-items` or `@/app/actions/hotel-bookings`
- [ ] `app/actions/breakfast.ts` has no `hotel_booking_id` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)