### PR TITLE
T-5: Visual Table Breakdown Builder Component

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -270,7 +270,7 @@ Server actions reference old table names (`program_item`), old column names (`gu
 
 ## Ticket 5: Visual Table Breakdown Builder Component
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P1  
 **Scope:** New `components/table-breakdown-builder.tsx`  

--- a/components/table-breakdown-builder.tsx
+++ b/components/table-breakdown-builder.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useRef } from 'react';
+import { Plus, Minus, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type TableBreakdownBuilderProps = {
+  value: number[];
+  onChange: (breakdown: number[]) => void;
+  disabled?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TableBreakdownBuilder({ value, onChange, disabled = false }: TableBreakdownBuilderProps) {
+  const addBtnRef = useRef<HTMLButtonElement>(null);
+
+  const totalCovers = value.reduce((s, n) => s + n, 0);
+
+  function addTable() {
+    onChange([...value, 2]);
+  }
+
+  function removeTable(index: number) {
+    onChange(value.filter((_, i) => i !== index));
+  }
+
+  function adjustSeats(index: number, delta: number) {
+    const next = value[index] + delta;
+    if (next < 1 || next > 20) return;
+    const updated = [...value];
+    updated[index] = next;
+    onChange(updated);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>, index: number) {
+    if (e.key === '+' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      adjustSeats(index, 1);
+    } else if (e.key === '-' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      adjustSeats(index, -1);
+    } else if (e.key === 'Delete' || e.key === 'Backspace') {
+      e.preventDefault();
+      removeTable(index);
+      // Move focus to add button after removal
+      addBtnRef.current?.focus();
+    }
+  }
+
+  if (value.length === 0) {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs text-muted-foreground">Add tables to define the seating layout</p>
+        <Button
+          ref={addBtnRef}
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={addTable}
+          disabled={disabled}
+          aria-label="Add table"
+        >
+          <Plus className="h-3 w-3 mr-1" /> Add table
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Table blocks */}
+      <div className="flex flex-wrap gap-2">
+        {value.map((seats, index) => (
+          <TableBlock
+            key={index}
+            index={index}
+            seats={seats}
+            disabled={disabled}
+            onAdjust={(delta) => adjustSeats(index, delta)}
+            onRemove={() => removeTable(index)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+          />
+        ))}
+
+        <Button
+          ref={addBtnRef}
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={addTable}
+          disabled={disabled}
+          className="h-auto self-start"
+          aria-label="Add table"
+        >
+          <Plus className="h-3 w-3 mr-1" /> Add table
+        </Button>
+      </div>
+
+      {/* Summary */}
+      <p className="text-xs text-muted-foreground">
+        {value.length} {value.length === 1 ? 'table' : 'tables'} · {totalCovers} total covers
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TableBlock sub-component
+// ---------------------------------------------------------------------------
+
+type TableBlockProps = {
+  index: number;
+  seats: number;
+  disabled: boolean;
+  onAdjust: (delta: number) => void;
+  onRemove: () => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+};
+
+function TableBlock({ index, seats, disabled, onAdjust, onRemove, onKeyDown }: TableBlockProps) {
+  const tableNumber = index + 1;
+
+  return (
+    <div
+      role="group"
+      aria-label={`Table ${tableNumber}, ${seats} seats`}
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      className="relative flex flex-col items-center rounded-md border bg-card px-3 pt-5 pb-2 gap-1 min-w-[64px] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      {/* Remove button */}
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={disabled}
+        aria-label={`Remove table ${tableNumber}`}
+        tabIndex={-1}
+        className="absolute top-1 right-1 h-4 w-4 flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-muted disabled:pointer-events-none"
+      >
+        <X className="h-3 w-3" />
+      </button>
+
+      {/* Increase */}
+      <Button
+        type="button"
+        size="icon"
+        variant="ghost"
+        className="h-5 w-5"
+        onClick={() => onAdjust(1)}
+        disabled={disabled || seats >= 20}
+        aria-label={`Add seat to table ${tableNumber}`}
+        tabIndex={-1}
+      >
+        <Plus className="h-3 w-3" />
+      </Button>
+
+      {/* Seat count */}
+      <span className="text-lg font-semibold tabular-nums leading-none">{seats}</span>
+
+      {/* Decrease */}
+      <Button
+        type="button"
+        size="icon"
+        variant="ghost"
+        className="h-5 w-5"
+        onClick={() => onAdjust(-1)}
+        disabled={disabled || seats <= 1}
+        aria-label={`Remove seat from table ${tableNumber}`}
+        tabIndex={-1}
+      >
+        <Minus className="h-3 w-3" />
+      </Button>
+
+      <span className="text-[10px] text-muted-foreground leading-none">seats</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `components/table-breakdown-builder.tsx` — a controlled component (`value: number[], onChange`) for managing table seating layouts visually
- Each table block shows seat count with +/- steppers (min 1, max 20) and a × remove button
- "Add table" button appends a new table with 2 default seats
- Empty state with helper text when no tables added
- Live summary below the grid: "X tables · Y total covers"
- Keyboard accessible: focusable group, Arrow Up/Down or +/- to adjust seats, Delete/Backspace to remove table
- Tables wrap on narrow screens (`flex flex-wrap gap-2`)
- Uses shadcn/ui `Button` primitives for consistent styling

This component is shared infrastructure for Ticket 8 (reservation form) and Ticket 9 (breakfast configuration form).

## Test plan

- [ ] `pnpm build` passes (verified locally)
- [ ] Empty state renders when `value={[]}`
- [ ] Add table → `onChange([2])`, + on 2-seat table → `onChange([3])`, - on 2-seat → `onChange([1])`
- [ ] - on 1-seat table does nothing
- [ ] × removes the table
- [ ] Summary text correct for `[3, 3, 2]` → "3 tables · 8 total covers"

🤖 Generated with [Claude Code](https://claude.com/claude-code)