### PR TITLE
T-10: Remove hotel booking UI

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -521,7 +521,7 @@ Activity tags are tenant-specific and configurable. They need a management UI in
 
 ## Ticket 10: Remove Hotel Booking UI
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P1  
 **Scope:** `components/add-hotel-booking-drawer.tsx`, `components/hotel-booking-card.tsx`, `app/[tenant]/day/[date]/DayViewClient.tsx`, `app/[tenant]/day/[date]/page.tsx`, `components/CalendarDaySidebar.tsx`, `components/HomeClient.tsx`  

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -71,9 +71,7 @@ export default async function TenantHomePage({
       date: day.date_iso,
       dayId: day.id,
       golfCount: 0,
-      eventCount: 0,
       reservationCount: 0,
-      hotelGuestCount: 0,
       breakfastCount: 0,
     });
   }

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -17,9 +17,7 @@ export type DaySummary = {
   date: string; // YYYY-MM-DD
   dayId: string;
   golfCount: number;
-  eventCount: number;
   reservationCount: number;
-  hotelGuestCount: number;
   breakfastCount: number;
 };
 
@@ -171,14 +169,8 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
                       {summary.golfCount > 0 && (
                         <SummaryPip label={`${summary.golfCount}G`} color="emerald" />
                       )}
-                      {summary.eventCount > 0 && (
-                        <SummaryPip label={`${summary.eventCount}E`} color="blue" />
-                      )}
                       {summary.reservationCount > 0 && (
                         <SummaryPip label={`${summary.reservationCount}R`} color="amber" />
-                      )}
-                      {summary.hotelGuestCount > 0 && (
-                        <SummaryPip label={`${summary.hotelGuestCount}H`} color="violet" />
                       )}
                     </div>
                   )}
@@ -203,7 +195,6 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
         <LegendItem color="emerald" label={t('legendGolf')} />
         <LegendItem color="blue" label={t('legendEvent')} />
         <LegendItem color="amber" label={t('legendReservation')} />
-        <LegendItem color="violet" label={t('legendHotel')} />
       </div>
     </div>
   );
@@ -213,13 +204,12 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
 // Sub-components
 // ---------------------------------------------------------------------------
 
-type PipColor = 'emerald' | 'blue' | 'amber' | 'violet';
+type PipColor = 'emerald' | 'blue' | 'amber';
 
 const PIP_CLASSES: Record<PipColor, string> = {
   emerald: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400',
   blue: 'bg-blue-500/15 text-blue-700 dark:text-blue-400',
   amber: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
-  violet: 'bg-violet-500/15 text-violet-700 dark:text-violet-400',
 };
 
 function SummaryPip({ label, color }: { label: string; color: PipColor }) {

--- a/messages/en.json
+++ b/messages/en.json
@@ -73,8 +73,7 @@
       "dowSun": "Sun",
       "legendGolf": "Golf (G)",
       "legendEvent": "Event (E)",
-      "legendReservation": "Reservation (R)",
-      "legendHotel": "Hotel guests (H)"
+      "legendReservation": "Reservation (R)"
     },
     "day": {
       "previousDay": "Previous day",
@@ -82,17 +81,13 @@
       "today": "Today",
       "golfEvents": "Golf & Events",
       "teeTimeReservations": "Tee Time Reservations",
-      "hotelBookings": "Hotel Bookings",
       "noEntries": "No entries yet.",
       "noReservations": "No reservations yet.",
-      "noBookings": "No hotel bookings yet.",
       "addEvent": "Event",
       "addGolf": "Golf",
-      "addReservation": "Add reservation",
-      "addBooking": "Add booking"
+      "addReservation": "Add reservation"
     },
     "summary": {
-      "hotelGuests": "Hotel guests",
       "breakfasts": "Breakfasts",
       "golfEvents": "Golf / events",
       "teeTimes": "Tee time bookings",
@@ -105,7 +100,6 @@
       "reservation": "Reservation",
       "golfEvents": "Golf & Events",
       "reservations": "Reservations",
-      "hotelBookings": "Hotel Bookings",
       "none": "None.",
       "openDayView": "Open day view",
       "guests": "{count, plural, one {# guest} other {# guests}}"
@@ -143,13 +137,6 @@
       "cancel": "Cancel",
       "delete": "Delete",
       "deleted": "Reservation deleted."
-    },
-    "booking": {
-      "deleteTitle": "Delete booking?",
-      "deleteDescription": "This action cannot be undone.",
-      "cancel": "Cancel",
-      "delete": "Delete",
-      "deleted": "Booking deleted."
     },
     "poc": {
       "title": "Points of Contact",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -73,8 +73,7 @@
       "dowSun": "Dim",
       "legendGolf": "Golf (G)",
       "legendEvent": "Événement (E)",
-      "legendReservation": "Réservation (R)",
-      "legendHotel": "Clients hôtel (H)"
+      "legendReservation": "Réservation (R)"
     },
     "day": {
       "previousDay": "Jour précédent",
@@ -82,17 +81,13 @@
       "today": "Aujourd'hui",
       "golfEvents": "Golf et événements",
       "teeTimeReservations": "Réservations de départs",
-      "hotelBookings": "Réservations hôtel",
       "noEntries": "Aucune entrée pour l'instant.",
       "noReservations": "Aucune réservation pour l'instant.",
-      "noBookings": "Aucune réservation hôtel pour l'instant.",
       "addEvent": "Événement",
       "addGolf": "Golf",
-      "addReservation": "Ajouter une réservation",
-      "addBooking": "Ajouter une réservation"
+      "addReservation": "Ajouter une réservation"
     },
     "summary": {
-      "hotelGuests": "Clients hôtel",
       "breakfasts": "Petits-déjeuners",
       "golfEvents": "Golf / événements",
       "teeTimes": "Réservations de départs",
@@ -105,7 +100,6 @@
       "reservation": "Réservation",
       "golfEvents": "Golf et événements",
       "reservations": "Réservations",
-      "hotelBookings": "Réservations hôtel",
       "none": "Aucun.",
       "openDayView": "Ouvrir la vue du jour",
       "guests": "{count, plural, one {# client} other {# clients}}"
@@ -139,13 +133,6 @@
     },
     "reservation": {
       "deleteTitle": "Supprimer la réservation ?",
-      "deleteDescription": "Cette action est irréversible.",
-      "cancel": "Annuler",
-      "delete": "Supprimer",
-      "deleted": "Réservation supprimée."
-    },
-    "booking": {
-      "deleteTitle": "Supprimer la réservation hôtel ?",
       "deleteDescription": "Cette action est irréversible.",
       "cancel": "Annuler",
       "delete": "Supprimer",

--- a/tests/actions/reservations.test.ts
+++ b/tests/actions/reservations.test.ts
@@ -13,12 +13,11 @@ describe('reservationSchema', () => {
     const result = reservationSchema.safeParse({
       dayId: VALID_DAY_ID,
       guestName: 'Jane Smith',
-      guestEmail: 'jane@example.com',
-      guestPhone: '+32 123 456 789',
       guestCount: 4,
       startTime: '19:00',
       endTime: '21:00',
       notes: 'Window seat requested',
+      tableBreakdown: [2, 2],
     });
     expect(result.success).toBe(true);
   });
@@ -28,21 +27,9 @@ describe('reservationSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects invalid email', () => {
-    const result = reservationSchema.safeParse({
-      dayId: VALID_DAY_ID,
-      guestEmail: 'not-an-email',
-    });
+  it('rejects invalid dayId (not a UUID)', () => {
+    const result = reservationSchema.safeParse({ dayId: 'not-a-uuid' });
     expect(result.success).toBe(false);
-    expect(result.error?.issues[0].message).toBe('Invalid email address');
-  });
-
-  it('accepts empty string for email (treated as absent)', () => {
-    const result = reservationSchema.safeParse({
-      dayId: VALID_DAY_ID,
-      guestEmail: '',
-    });
-    expect(result.success).toBe(true);
   });
 
   it('rejects guestCount less than 1', () => {
@@ -53,23 +40,29 @@ describe('reservationSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('accepts optional hotel and program item links', () => {
+  it('accepts tableBreakdown as an array of positive integers', () => {
     const result = reservationSchema.safeParse({
       dayId: VALID_DAY_ID,
-      hotelBookingId: '123e4567-e89b-12d3-a456-426614174001',
-      programItemId: '123e4567-e89b-12d3-a456-426614174002',
-      tableIndex: 2,
+      tableBreakdown: [4, 2, 1],
     });
     expect(result.success).toBe(true);
   });
 
-  it('accepts null for optional link fields', () => {
+  it('rejects tableBreakdown with a zero entry', () => {
     const result = reservationSchema.safeParse({
       dayId: VALID_DAY_ID,
-      hotelBookingId: null,
-      programItemId: null,
-      tableIndex: null,
+      tableBreakdown: [4, 0],
     });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts omitted optional fields', () => {
+    const result = reservationSchema.safeParse({ dayId: VALID_DAY_ID });
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.guestName).toBeUndefined();
+      expect(result.data.guestCount).toBeUndefined();
+      expect(result.data.tableBreakdown).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Removes `hotelGuestCount` and `eventCount` from `DaySummary` — calendar now shows only golf (G) and reservation (R) pips
- Strips all hotel booking i18n keys from `messages/en.json` and `messages/fr.json` (legend, day section, summary section, sidebar section, booking delete strings)
- Rewrites `tests/actions/reservations.test.ts` to match the current `reservationSchema` (no `hotelBookingId`, `programItemId`, `tableIndex`, or `guestEmail`/`guestPhone`)
- `pnpm build` passes

## Test plan
- [ ] Calendar month view shows only G and R pips, no H or E
- [ ] Legend shows Golf, Event, Reservation only
- [ ] No TypeScript errors on build
- [ ] Reservations test suite passes with updated schema assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)