### PR TITLE
T-13: Editor agenda/timeline view

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -684,7 +684,7 @@ Currently viewers see the same `DayViewClient` but with edit buttons hidden and 
 
 ## Ticket 13: Editor Agenda/Timeline View
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P2  
 **Scope:** New `components/AgendaView.tsx`, `components/HomeClient.tsx`  

--- a/app/actions/agenda.ts
+++ b/app/actions/agenda.ts
@@ -1,0 +1,96 @@
+'use server';
+
+import { createSupabaseServerClient, createSupabaseServiceClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { datesInRange, getWeekdayName } from '@/lib/day-utils';
+import type { ActionResponse } from '@/types/actions';
+import type { DaySummary } from '@/components/HomeClient';
+
+/**
+ * Returns aggregated DaySummary rows for every date in [start, end].
+ * Upserts Day rows as a side effect (idempotent).
+ */
+export async function getDaySummaries(
+  start: string,
+  end: string
+): Promise<ActionResponse<DaySummary[]>> {
+  const tenantId = await getTenantId();
+  const supabase = await createSupabaseServerClient();
+  const serviceClient = createSupabaseServiceClient();
+
+  // Ensure Day rows exist for every date in the range
+  const dates = datesInRange(start, end);
+  const rows = dates.map((d) => ({
+    tenant_id: tenantId,
+    date_iso: d,
+    weekday: getWeekdayName(d),
+  }));
+
+  const { data: dayRows, error: dayErr } = await serviceClient
+    .from('day')
+    .upsert(rows, { onConflict: 'tenant_id,date_iso' })
+    .select('id,date_iso');
+
+  if (dayErr || !dayRows) {
+    return { success: false, error: dayErr?.message ?? 'Failed to load days.' };
+  }
+
+  const dayIds = dayRows.map((d) => d.id);
+  const dayDateMap = new Map<string, string>(dayRows.map((d) => [d.id, d.date_iso as string]));
+
+  // Fetch counts in parallel — only select the columns we need
+  const [activitiesRes, reservationsRes, breakfastRes] = await Promise.all([
+    supabase
+      .from('activity')
+      .select('day_id')
+      .eq('tenant_id', tenantId)
+      .in('day_id', dayIds),
+    supabase
+      .from('reservation')
+      .select('day_id')
+      .eq('tenant_id', tenantId)
+      .in('day_id', dayIds),
+    supabase
+      .from('breakfast_configuration')
+      .select('breakfast_date,total_guests')
+      .eq('tenant_id', tenantId)
+      .gte('breakfast_date', start)
+      .lte('breakfast_date', end),
+  ]);
+
+  // Build summary map
+  const summaryMap = new Map<string, DaySummary>();
+  for (const row of dayRows) {
+    summaryMap.set(row.date_iso as string, {
+      date: row.date_iso as string,
+      dayId: row.id as string,
+      golfCount: 0,
+      reservationCount: 0,
+      breakfastCount: 0,
+    });
+  }
+
+  for (const item of activitiesRes.data ?? []) {
+    const date = dayDateMap.get((item as { day_id: string }).day_id);
+    if (!date) continue;
+    const s = summaryMap.get(date);
+    if (s) s.golfCount++;
+  }
+
+  for (const item of reservationsRes.data ?? []) {
+    const date = dayDateMap.get((item as { day_id: string }).day_id);
+    if (!date) continue;
+    const s = summaryMap.get(date);
+    if (s) s.reservationCount++;
+  }
+
+  for (const item of breakfastRes.data ?? []) {
+    const s = summaryMap.get((item as { breakfast_date: string }).breakfast_date);
+    if (s) s.breakfastCount += (item as { total_guests: number }).total_guests;
+  }
+
+  const summaries = [...summaryMap.values()].sort((a, b) =>
+    a.date.localeCompare(b.date)
+  );
+  return { success: true, data: summaries };
+}

--- a/components/AgendaView.tsx
+++ b/components/AgendaView.tsx
@@ -1,0 +1,432 @@
+'use client';
+
+import { useState, useTransition, useEffect, useRef } from 'react';
+import { format, addDays, parseISO } from 'date-fns';
+import { ChevronDown, ChevronRight, ArrowRight, Plus } from 'lucide-react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { getDaySummaries } from '@/app/actions/agenda';
+import { getActivitiesForDay } from '@/app/actions/activities';
+import { getReservationsForDay } from '@/app/actions/reservations';
+import { getBreakfastConfigurationsForDay } from '@/app/actions/breakfast';
+import { getAllPOCs } from '@/app/actions/poc';
+import { getAllVenueTypes } from '@/app/actions/venue-type';
+import { ActivityForm } from '@/components/activity-form';
+import { ReservationForm } from '@/components/reservation-form';
+import { BreakfastForm } from '@/components/breakfast-form';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+import type {
+  Activity,
+  ActivityWithRelations,
+  Reservation,
+  BreakfastConfiguration,
+  PointOfContact,
+  VenueType,
+} from '@/types/index';
+import type { DaySummary } from '@/components/HomeClient';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Props = {
+  today: string;
+};
+
+type ExpandedData = {
+  activities: ActivityWithRelations[];
+  reservations: Reservation[];
+  breakfastConfigs: BreakfastConfiguration[];
+  pocs: PointOfContact[];
+  venueTypes: VenueType[];
+};
+
+const PAGE_SIZE = 14;
+
+// ---------------------------------------------------------------------------
+// AgendaView
+// ---------------------------------------------------------------------------
+
+export function AgendaView({ today }: Props) {
+  const t = useTranslations('Tenant.home');
+  const [summaries, setSummaries] = useState<DaySummary[]>([]);
+  const [initialLoading, startInitialLoad] = useTransition();
+  const [loadingMore, startLoadMore] = useTransition();
+  const [expandedDate, setExpandedDate] = useState<string | null>(null);
+  const initialized = useRef(false);
+
+  // Load initial 14 days on mount
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+    const end = format(addDays(parseISO(today), PAGE_SIZE - 1), 'yyyy-MM-dd');
+    startInitialLoad(async () => {
+      const result = await getDaySummaries(today, end);
+      if (result.success) setSummaries(result.data);
+    });
+  }, [today]);
+
+  function handleSummaryChanged(date: string, patch: Partial<DaySummary>) {
+    setSummaries((prev) =>
+      prev.map((s) => (s.date === date ? { ...s, ...patch } : s))
+    );
+  }
+
+  function loadMore() {
+    if (summaries.length === 0) return;
+    const lastDate = summaries[summaries.length - 1].date;
+    const nextStart = format(addDays(parseISO(lastDate), 1), 'yyyy-MM-dd');
+    const nextEnd = format(addDays(parseISO(lastDate), PAGE_SIZE), 'yyyy-MM-dd');
+    startLoadMore(async () => {
+      const result = await getDaySummaries(nextStart, nextEnd);
+      if (result.success) setSummaries((prev) => [...prev, ...result.data]);
+    });
+  }
+
+  if (initialLoading && summaries.length === 0) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-14 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {summaries.map((summary) => (
+        <AgendaDayRow
+          key={summary.date}
+          summary={summary}
+          today={today}
+          isExpanded={expandedDate === summary.date}
+          onToggle={() =>
+            setExpandedDate((prev) =>
+              prev === summary.date ? null : summary.date
+            )
+          }
+          onSummaryChanged={(patch) => handleSummaryChanged(summary.date, patch)}
+        />
+      ))}
+
+      <div className="pt-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={loadMore}
+          disabled={loadingMore || summaries.length === 0}
+        >
+          {loadingMore ? 'Loading…' : t('loadMore')}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AgendaDayRow
+// ---------------------------------------------------------------------------
+
+type RowProps = {
+  summary: DaySummary;
+  today: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onSummaryChanged: (patch: Partial<DaySummary>) => void;
+};
+
+function AgendaDayRow({
+  summary,
+  today,
+  isExpanded,
+  onToggle,
+  onSummaryChanged,
+}: RowProps) {
+  const ts = useTranslations('Tenant.sidebar');
+  const [expandedData, setExpandedData] = useState<ExpandedData | null>(null);
+  const [dataLoading, startDataLoad] = useTransition();
+  const hasLoaded = useRef(false);
+
+  // Activity modal
+  const [activityOpen, setActivityOpen] = useState(false);
+  const [reservationOpen, setReservationOpen] = useState(false);
+  const [breakfastOpen, setBreakfastOpen] = useState(false);
+
+  // Lazy-load day data on first expand
+  useEffect(() => {
+    if (!isExpanded || hasLoaded.current) return;
+    hasLoaded.current = true;
+    startDataLoad(async () => {
+      const [activitiesRes, reservationsRes, bfRes, pocsRes, venuesRes] =
+        await Promise.all([
+          getActivitiesForDay(summary.dayId),
+          getReservationsForDay(summary.dayId),
+          getBreakfastConfigurationsForDay(summary.dayId),
+          getAllPOCs(),
+          getAllVenueTypes(),
+        ]);
+      setExpandedData({
+        activities: (activitiesRes.success
+          ? activitiesRes.data
+          : []) as ActivityWithRelations[],
+        reservations: reservationsRes.success ? reservationsRes.data : [],
+        breakfastConfigs: bfRes.success ? bfRes.data : [],
+        pocs: pocsRes.success ? pocsRes.data : [],
+        venueTypes: venuesRes.success ? venuesRes.data : [],
+      });
+    });
+  }, [isExpanded, summary.dayId]);
+
+  const isToday = summary.date === today;
+  const formattedDate = format(parseISO(summary.date), 'EEEE d MMMM');
+
+  const countParts: string[] = [];
+  if (summary.golfCount > 0)
+    countParts.push(
+      `${summary.golfCount} ${summary.golfCount === 1 ? 'activity' : 'activities'}`
+    );
+  if (summary.reservationCount > 0)
+    countParts.push(
+      `${summary.reservationCount} ${summary.reservationCount === 1 ? 'reservation' : 'reservations'}`
+    );
+  if (summary.breakfastCount > 0)
+    countParts.push(
+      `${summary.breakfastCount} breakfast ${summary.breakfastCount === 1 ? 'cover' : 'covers'}`
+    );
+
+  return (
+    <>
+      <div className={cn('rounded-lg border bg-card', isToday && 'border-primary/60')}>
+        {/* Row header — always visible */}
+        <button
+          className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-accent/50 transition-colors rounded-lg"
+          onClick={onToggle}
+        >
+          <div className="min-w-0">
+            <span
+              className={cn(
+                'font-medium text-sm',
+                isToday && 'text-primary'
+              )}
+            >
+              {formattedDate}
+            </span>
+            {countParts.length > 0 ? (
+              <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                {countParts.join(' · ')}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground mt-0.5">Nothing scheduled</p>
+            )}
+          </div>
+          {isExpanded ? (
+            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground ml-2" />
+          ) : (
+            <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground ml-2" />
+          )}
+        </button>
+
+        {/* Expanded content */}
+        {isExpanded && (
+          <div className="px-4 pb-4 space-y-4 border-t">
+            {dataLoading && !expandedData && (
+              <div className="space-y-2 pt-3">
+                <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-3 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            )}
+
+            {expandedData && (
+              <>
+                {/* Quick actions */}
+                <div className="flex flex-wrap gap-2 pt-3">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    onClick={() => setActivityOpen(true)}
+                  >
+                    <Plus className="h-3 w-3 mr-1" /> {ts('activity')}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    onClick={() => setReservationOpen(true)}
+                  >
+                    <Plus className="h-3 w-3 mr-1" /> {ts('reservation')}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    onClick={() => setBreakfastOpen(true)}
+                  >
+                    <Plus className="h-3 w-3 mr-1" /> {ts('breakfast')}
+                  </Button>
+                </div>
+
+                {/* Breakfast */}
+                {expandedData.breakfastConfigs.length > 0 && (
+                  <InlineSection title={ts('breakfast')}>
+                    {expandedData.breakfastConfigs.map((item) => (
+                      <div
+                        key={item.id}
+                        className="flex items-baseline justify-between gap-2 text-sm"
+                      >
+                        <span className="truncate flex-1">
+                          {item.group_name ?? 'Unnamed'}
+                        </span>
+                        {item.total_guests > 0 && (
+                          <span className="text-muted-foreground shrink-0">
+                            {item.total_guests} guests
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </InlineSection>
+                )}
+
+                {/* Activities */}
+                {expandedData.activities.length > 0 && (
+                  <InlineSection title={ts('activities')}>
+                    {expandedData.activities.map((item) => (
+                      <div
+                        key={item.id}
+                        className="flex items-baseline gap-2 text-sm"
+                      >
+                        <span className="truncate flex-1">{item.title}</span>
+                        {item.start_time && (
+                          <span className="text-muted-foreground shrink-0">
+                            {item.start_time.slice(0, 5)}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </InlineSection>
+                )}
+
+                {/* Reservations */}
+                {expandedData.reservations.length > 0 && (
+                  <InlineSection title={ts('reservations')}>
+                    {expandedData.reservations.map((item) => (
+                      <div
+                        key={item.id}
+                        className="flex items-baseline justify-between gap-2 text-sm"
+                      >
+                        <span className="truncate flex-1">
+                          {item.guest_name ?? 'Guest'}
+                        </span>
+                        {item.start_time && (
+                          <span className="text-muted-foreground shrink-0">
+                            {item.start_time.slice(0, 5)}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </InlineSection>
+                )}
+
+                <Separator />
+
+                <Button asChild size="sm" variant="outline" className="w-full">
+                  <Link href={`/day/${summary.date}`}>
+                    {ts('openDayView')} <ArrowRight className="ml-1 h-4 w-4" />
+                  </Link>
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Forms — rendered outside the card to avoid stacking-context issues */}
+      {expandedData && (
+        <>
+          <ActivityForm
+            isOpen={activityOpen}
+            onClose={() => setActivityOpen(false)}
+            date={summary.date}
+            dayId={summary.dayId}
+            pocs={expandedData.pocs}
+            venueTypes={expandedData.venueTypes}
+            editItem={null}
+            onSuccess={(item: Activity) => {
+              setExpandedData((prev) =>
+                prev
+                  ? {
+                      ...prev,
+                      activities: [
+                        ...prev.activities,
+                        item as ActivityWithRelations,
+                      ],
+                    }
+                  : prev
+              );
+              onSummaryChanged({ golfCount: summary.golfCount + 1 });
+            }}
+          />
+          <ReservationForm
+            isOpen={reservationOpen}
+            onClose={() => setReservationOpen(false)}
+            dayId={summary.dayId}
+            editItem={null}
+            onSuccess={(item: Reservation) => {
+              setExpandedData((prev) =>
+                prev
+                  ? { ...prev, reservations: [...prev.reservations, item] }
+                  : prev
+              );
+              onSummaryChanged({
+                reservationCount: summary.reservationCount + 1,
+              });
+            }}
+          />
+          <BreakfastForm
+            isOpen={breakfastOpen}
+            onClose={() => setBreakfastOpen(false)}
+            dayId={summary.dayId}
+            editItem={null}
+            onSuccess={(item: BreakfastConfiguration) => {
+              setExpandedData((prev) =>
+                prev
+                  ? {
+                      ...prev,
+                      breakfastConfigs: [...prev.breakfastConfigs, item],
+                    }
+                  : prev
+              );
+              onSummaryChanged({
+                breakfastCount: summary.breakfastCount + item.total_guests,
+              });
+            }}
+          />
+        </>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// InlineSection
+// ---------------------------------------------------------------------------
+
+function InlineSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-muted-foreground">{title}</p>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { format, getDay, addMonths, subMonths } from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { CalendarDaySidebar } from '@/components/CalendarDaySidebar';
+import { AgendaView } from '@/components/AgendaView';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+
+const VIEW_PREF_KEY = 'editor-home-view-preference';
+type ViewMode = 'calendar' | 'agenda';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,6 +43,18 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
   const t = useTranslations('Tenant.home');
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [days, setDays] = useState<DaySummary[]>(initialDays);
+  const [viewMode, setViewMode] = useState<ViewMode>('calendar');
+
+  // Restore view preference from localStorage (client-only)
+  useEffect(() => {
+    const saved = localStorage.getItem(VIEW_PREF_KEY);
+    if (saved === 'agenda' || saved === 'calendar') setViewMode(saved);
+  }, []);
+
+  function changeViewMode(mode: ViewMode) {
+    setViewMode(mode);
+    localStorage.setItem(VIEW_PREF_KEY, mode);
+  }
 
   const dayMap = new Map(days.map((d) => [d.date, d]));
 
@@ -72,43 +88,75 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
 
   return (
     <div className="max-w-5xl mx-auto px-6 py-8">
-      {/* Month heading + navigation */}
+      {/* Heading row */}
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-xl font-semibold">
-          {format(firstOfMonth, 'MMMM yyyy')}
-        </h1>
-        <div className="flex items-center gap-1">
-          {!isCurrentMonth && (
+        {viewMode === 'calendar' ? (
+          <h1 className="text-xl font-semibold">
+            {format(firstOfMonth, 'MMMM yyyy')}
+          </h1>
+        ) : (
+          <h1 className="text-xl font-semibold">{t('agenda')}</h1>
+        )}
+        <div className="flex items-center gap-2">
+          {/* View toggle */}
+          <div className="flex rounded-md border overflow-hidden">
             <Button
-              variant="ghost"
+              variant={viewMode === 'calendar' ? 'secondary' : 'ghost'}
               size="sm"
-              onClick={() => navigate(todayMonth)}
+              className="rounded-none border-0 h-8 px-3"
+              onClick={() => changeViewMode('calendar')}
             >
-              {t('today')}
+              {t('calendar')}
             </Button>
+            <Button
+              variant={viewMode === 'agenda' ? 'secondary' : 'ghost'}
+              size="sm"
+              className="rounded-none border-0 border-l h-8 px-3"
+              onClick={() => changeViewMode('agenda')}
+            >
+              {t('agenda')}
+            </Button>
+          </div>
+
+          {/* Calendar navigation — only in calendar mode */}
+          {viewMode === 'calendar' && (
+            <div className="flex items-center gap-1">
+              {!isCurrentMonth && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => navigate(todayMonth)}
+                >
+                  {t('today')}
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled={isPrevDisabled}
+                onClick={() => navigate(prevMonthStr)}
+                aria-label={t('previousMonth')}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled={isNextDisabled}
+                onClick={() => navigate(nextMonthStr)}
+                aria-label={t('nextMonth')}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
           )}
-          <Button
-            variant="ghost"
-            size="icon"
-            disabled={isPrevDisabled}
-            onClick={() => navigate(prevMonthStr)}
-            aria-label={t('previousMonth')}
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            disabled={isNextDisabled}
-            onClick={() => navigate(nextMonthStr)}
-            aria-label={t('nextMonth')}
-          >
-            <ChevronRight className="h-4 w-4" />
-          </Button>
         </div>
       </div>
 
-      <div className={cn('flex gap-6', selectedDate && 'lg:gap-8')}>
+      {/* Agenda view */}
+      {viewMode === 'agenda' && <AgendaView today={today} />}
+
+      {viewMode === 'calendar' && <div className={cn('flex gap-6', selectedDate && 'lg:gap-8')}>
         {/* Calendar grid */}
         <div className="flex-1 min-w-0">
           {/* Day-of-week header */}
@@ -191,14 +239,16 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
             onSummaryChanged={handleSummaryChanged}
           />
         )}
-      </div>
+      </div>}
 
-      {/* Legend */}
-      <div className="mt-4 flex flex-wrap gap-3 text-xs text-muted-foreground">
-        <LegendItem color="emerald" label={t('legendActivity')} />
-        <LegendItem color="amber" label={t('legendReservation')} />
-        <LegendItem color="blue" label={t('legendBreakfast')} />
-      </div>
+      {/* Legend — calendar mode only */}
+      {viewMode === 'calendar' && (
+        <div className="mt-4 flex flex-wrap gap-3 text-xs text-muted-foreground">
+          <LegendItem color="emerald" label={t('legendActivity')} />
+          <LegendItem color="amber" label={t('legendReservation')} />
+          <LegendItem color="blue" label={t('legendBreakfast')} />
+        </div>
+      )}
     </div>
   );
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -73,7 +73,10 @@
       "dowSun": "Sun",
       "legendActivity": "Activity (A)",
       "legendReservation": "Reservation (R)",
-      "legendBreakfast": "Breakfast (B)"
+      "legendBreakfast": "Breakfast (B)",
+      "calendar": "Calendar",
+      "agenda": "Agenda",
+      "loadMore": "Load more"
     },
     "day": {
       "previousDay": "Previous day",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -73,7 +73,10 @@
       "dowSun": "Dim",
       "legendActivity": "Activité (A)",
       "legendReservation": "Réservation (R)",
-      "legendBreakfast": "Petit-déjeuner (B)"
+      "legendBreakfast": "Petit-déjeuner (B)",
+      "calendar": "Calendrier",
+      "agenda": "Agenda",
+      "loadMore": "Charger plus"
     },
     "day": {
       "previousDay": "Jour précédent",


### PR DESCRIPTION
## Summary
- New `getDaySummaries(start, end)` server action — upserts Day rows and returns aggregated activity/reservation/breakfast counts per date
- New `AgendaView` component renders a scrollable list of upcoming days with expandable rows:
  - Collapsed: date + weekday + compact count string ("3 activities · 5 reservations · 12 breakfast covers")
  - Expanded: lazy-loaded full data, quick-add "+ Activity / Reservation / Breakfast" buttons, "Open full day view" link
  - "Load more" button appends the next 14 days
- `HomeClient` gains a **Calendar | Agenda** view toggle, persisted to `localStorage` under `editor-home-view-preference`
- Calendar navigation and legend hidden in agenda mode
- New i18n keys: `home.calendar`, `home.agenda`, `home.loadMore` in en + fr

## Test plan
- [ ] Calendar | Agenda toggle appears on editor home page
- [ ] Switching to Agenda renders the 14-day list
- [ ] Preference persists across reloads
- [ ] Collapsed rows show correct counts
- [ ] Expanding a row loads and shows activities, reservations, breakfast configs
- [ ] Quick-add buttons open correct forms; new items appear inline and counts update
- [ ] "Load more" appends another 14 days
- [ ] "Open full day view" links to the correct day
- [ ] Switching back to Calendar shows the month grid normally
- [ ] Mobile layout (375px) is usable
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)