### PR TITLE
T-16: Superadmin role and auth guard for /admin

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -820,7 +820,7 @@ The codebase may still contain remnants from the original Vercel Platforms Start
 
 ## Ticket 16: Superadmin Role & Auth for /admin
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** complete
 
 **Priority:** P0  
 **Scope:** `supabase/migrations/`, `app/admin/page.tsx`, `app/admin/dashboard.tsx`, `middleware.ts`, `app/actions/tenants.ts`  

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { createSupabaseServiceClient } from '@/lib/supabase-server';
+import { requireSuperadmin } from '@/lib/superadmin';
 import { AdminDashboard } from './dashboard';
 import { rootDomain } from '@/lib/utils';
 
@@ -8,6 +9,8 @@ export const metadata: Metadata = {
 };
 
 export default async function AdminPage() {
+  await requireSuperadmin();
+
   const serviceClient = createSupabaseServiceClient();
   const { data: tenants } = await serviceClient
     .from('tenants')

--- a/lib/superadmin.ts
+++ b/lib/superadmin.ts
@@ -1,0 +1,30 @@
+import { redirect } from 'next/navigation';
+import { getUser } from '@/app/actions/auth';
+import { createSupabaseServiceClient } from '@/lib/supabase-server';
+
+/**
+ * Returns true if the currently authenticated user has a row in superadmins.
+ * Uses the service client so it works regardless of RLS policies.
+ */
+export async function getSuperadminStatus(): Promise<boolean> {
+  const user = await getUser();
+  if (!user) return false;
+
+  const serviceClient = createSupabaseServiceClient();
+  const { data } = await serviceClient
+    .from('superadmins')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  return !!data;
+}
+
+/**
+ * Redirects to /auth/sign-in unless the current user is a superadmin.
+ * Call at the top of any platform admin page.tsx.
+ */
+export async function requireSuperadmin(): Promise<void> {
+  const ok = await getSuperadminStatus();
+  if (!ok) redirect('/auth/sign-in');
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -66,6 +66,15 @@ export async function middleware(request: NextRequest) {
     return applyAuthCookies(NextResponse.redirect(url));
   }
 
+  // Block /admin (exactly) on tenant subdomains — platform admin is root-domain only.
+  // Note: /admin/settings is the tenant settings path and must not be blocked.
+  if (pathname === '/admin') {
+    const url = request.nextUrl.clone();
+    url.host = rootDomain;
+    url.pathname = '/';
+    return applyAuthCookies(NextResponse.redirect(url));
+  }
+
   // -------------------------------------------------------------------------
   // 3. Tenant resolution via Redis.
   // -------------------------------------------------------------------------

--- a/supabase/migrations/00016_superadmins.sql
+++ b/supabase/migrations/00016_superadmins.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- Migration 00016: Superadmins table
+-- =============================================================================
+-- Stores users with platform-wide administrative access.
+-- Access is only via the service client (bypasses RLS); no public policies
+-- are defined so the regular anon/authenticated roles cannot query this table.
+-- =============================================================================
+
+CREATE TABLE superadmins (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE superadmins ENABLE ROW LEVEL SECURITY;
+
+-- No user-facing RLS policies — all access is through the service role client.
+-- This prevents any authenticated user from discovering superadmin UUIDs.

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,3 +11,13 @@ VALUES (
   'Europe/Brussels'
 )
 ON CONFLICT (slug) DO NOTHING;
+
+-- Seed: superadmin
+-- To grant superadmin access in local dev, first create a user via
+--   supabase/auth (sign up at localhost:3000), then find the user UUID
+--   in the Supabase Studio (Authentication → Users) and replace the
+--   placeholder below.
+--
+-- INSERT INTO superadmins (user_id)
+-- VALUES ('your-user-uuid-here')
+-- ON CONFLICT (user_id) DO NOTHING;


### PR DESCRIPTION
## Summary

- New migration `00016_superadmins.sql`: creates `superadmins` table with RLS enabled and no public policies — only the service role client can query it
- New `lib/superadmin.ts`: `getSuperadminStatus()` checks if the current user has a row in `superadmins` via service client; `requireSuperadmin()` redirects to `/auth/sign-in` if not
- `app/admin/page.tsx`: guarded with `await requireSuperadmin()` — unauthenticated users and non-superadmins are redirected
- `middleware.ts`: explicit redirect of `/admin` (exact path) on tenant subdomains to the root domain home
- `supabase/seed.sql`: commented-out superadmin seed with instructions for granting access in local dev

## Test plan

- [ ] Visit `/admin` while unauthenticated → redirected to `/auth/sign-in`
- [ ] Sign in as a non-superadmin user and visit `/admin` → redirected to `/auth/sign-in`
- [ ] Insert a row into `superadmins` for a user, sign in as that user, visit `/admin` → page loads with tenant list
- [ ] On a tenant subdomain, visit `/admin` → redirected to root domain `/`
- [ ] On a tenant subdomain, visit `/admin/settings` → tenant settings page loads normally (not blocked)
- [ ] `pnpm build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)