### PR TITLE
T-17: Feature flags system

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -848,7 +848,7 @@ The `/admin` route must not be public. Protect it with a superadmin role and cur
 
 ## Ticket 17: Feature Flags System
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P1  
 **Scope:** `supabase/migrations/`, `app/actions/`, `lib/`, `app/[tenant]/`, `app/admin/`  

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -13,6 +13,7 @@ import { ReservationCard } from '@/components/reservation-card';
 import { BreakfastForm } from '@/components/breakfast-form';
 import { BreakfastCard } from '@/components/breakfast-card';
 import { Button } from '@/components/ui/button';
+import { useFeatureFlag } from '@/lib/feature-flags-context';
 import type {
   Activity,
   ActivityWithRelations,
@@ -33,6 +34,9 @@ export function DayViewClient({
   authState,
 }: DayViewProps) {
   const t = useTranslations('Tenant.day');
+  const showActivities = useFeatureFlag('activities');
+  const showReservations = useFeatureFlag('reservations');
+  const showBreakfast = useFeatureFlag('breakfast_config');
 
   const [activities, setActivities] = useState(
     initialActivities as ActivityWithRelations[]
@@ -175,85 +179,91 @@ export function DayViewClient({
       />
 
       {/* Breakfast */}
-      <section className="space-y-3">
-        <div className="flex items-center justify-between">
-          <h2 className="font-semibold">{t('breakfast')}</h2>
-          {authState.isEditor && (
-            <Button size="sm" onClick={openAddBreakfast}>
-              <Plus className="w-4 h-4 mr-1" /> {t('addBreakfast')}
-            </Button>
-          )}
-        </div>
-        {breakfastConfigs.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t('noBreakfasts')}</p>
-        ) : (
-          <div className="space-y-2">
-            {breakfastConfigs.map((item) => (
-              <BreakfastCard
-                key={item.id}
-                item={item}
-                isEditor={authState.isEditor}
-                onEdit={openEditBreakfast}
-                onDeleted={handleBreakfastDeleted}
-              />
-            ))}
+      {showBreakfast && (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold">{t('breakfast')}</h2>
+            {authState.isEditor && (
+              <Button size="sm" onClick={openAddBreakfast}>
+                <Plus className="w-4 h-4 mr-1" /> {t('addBreakfast')}
+              </Button>
+            )}
           </div>
-        )}
-      </section>
+          {breakfastConfigs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t('noBreakfasts')}</p>
+          ) : (
+            <div className="space-y-2">
+              {breakfastConfigs.map((item) => (
+                <BreakfastCard
+                  key={item.id}
+                  item={item}
+                  isEditor={authState.isEditor}
+                  onEdit={openEditBreakfast}
+                  onDeleted={handleBreakfastDeleted}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
 
       {/* Activities */}
-      <section className="space-y-3">
-        <div className="flex items-center justify-between">
-          <h2 className="font-semibold">{t('activities')}</h2>
-          {authState.isEditor && (
-            <Button size="sm" onClick={openAddActivity}>
-              <Plus className="w-4 h-4 mr-1" /> {t('addActivity')}
-            </Button>
-          )}
-        </div>
-        {activities.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t('noEntries')}</p>
-        ) : (
-          <div className="space-y-2">
-            {activities.map((item) => (
-              <ActivityCard
-                key={item.id}
-                item={item}
-                isEditor={authState.isEditor}
-                onEdit={openEditActivity}
-                onDeleted={handleActivityDeleted}
-              />
-            ))}
+      {showActivities && (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold">{t('activities')}</h2>
+            {authState.isEditor && (
+              <Button size="sm" onClick={openAddActivity}>
+                <Plus className="w-4 h-4 mr-1" /> {t('addActivity')}
+              </Button>
+            )}
           </div>
-        )}
-      </section>
+          {activities.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t('noEntries')}</p>
+          ) : (
+            <div className="space-y-2">
+              {activities.map((item) => (
+                <ActivityCard
+                  key={item.id}
+                  item={item}
+                  isEditor={authState.isEditor}
+                  onEdit={openEditActivity}
+                  onDeleted={handleActivityDeleted}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
 
       {/* Reservations */}
-      <section className="space-y-3">
-        <div className="flex items-center justify-between">
-          <h2 className="font-semibold">{t('reservations')}</h2>
-          {authState.isEditor && (
-            <Button size="sm" onClick={openAddReservation}>
-              <Plus className="w-4 h-4 mr-1" /> {t('addReservation')}
-            </Button>
-          )}
-        </div>
-        {reservations.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t('noReservations')}</p>
-        ) : (
-          <div className="space-y-2">
-            {reservations.map((item) => (
-              <ReservationCard
-                key={item.id}
-                item={item}
-                isEditor={authState.isEditor}
-                onEdit={openEditReservation}
-                onDeleted={handleReservationDeleted}
-              />
-            ))}
+      {showReservations && (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold">{t('reservations')}</h2>
+            {authState.isEditor && (
+              <Button size="sm" onClick={openAddReservation}>
+                <Plus className="w-4 h-4 mr-1" /> {t('addReservation')}
+              </Button>
+            )}
           </div>
-        )}
-      </section>
+          {reservations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t('noReservations')}</p>
+          ) : (
+            <div className="space-y-2">
+              {reservations.map((item) => (
+                <ReservationCard
+                  key={item.id}
+                  item={item}
+                  isEditor={authState.isEditor}
+                  onEdit={openEditReservation}
+                  onDeleted={handleReservationDeleted}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
 
       <ActivityForm
         isOpen={activityModalOpen}

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -15,6 +15,8 @@ import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { isEditor } from '@/lib/membership';
 import { PwaRegister } from '@/components/pwa-register';
 import { PwaInstallPrompt } from '@/components/pwa-install-prompt';
+import { FeatureFlagProvider } from '@/lib/feature-flags-context';
+import { getFeatureFlags } from '@/app/actions/feature-flags';
 
 export async function generateMetadata(): Promise<Metadata> {
   try {
@@ -66,6 +68,8 @@ export default async function TenantLayout({
     getMessages(),
   ]);
 
+  const featureFlags = await getFeatureFlags(tenant.id);
+
   const supabase = await createSupabaseServerClient();
   const { data: tenantRow } = await supabase
     .from('tenants')
@@ -86,6 +90,7 @@ export default async function TenantLayout({
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
+      <FeatureFlagProvider flags={featureFlags}>
       <TenantProvider tenantId={tenant.id} tenantSlug={tenant.slug}>
         <AuthProvider>
           <div className="min-h-screen flex flex-col" style={accentStyle}>
@@ -112,6 +117,7 @@ export default async function TenantLayout({
           <PwaInstallPrompt />
         </AuthProvider>
       </TenantProvider>
+      </FeatureFlagProvider>
     </NextIntlClientProvider>
   );
 }

--- a/app/actions/feature-flags.ts
+++ b/app/actions/feature-flags.ts
@@ -1,0 +1,81 @@
+'use server';
+
+import { createSupabaseServiceClient } from '@/lib/supabase-server';
+import { getSuperadminStatus } from '@/lib/superadmin';
+import { KNOWN_FLAGS } from '@/lib/feature-flags';
+import type { FlagKey, FlagMap } from '@/lib/feature-flags';
+import type { ActionResponse } from '@/types/actions';
+
+/**
+ * Returns the feature flag map for a tenant.
+ * Rows missing from the DB are defaulted to enabled=true.
+ * Safe to call from server components — uses the service client.
+ */
+export async function getFeatureFlags(tenantId: string): Promise<FlagMap> {
+  const serviceClient = createSupabaseServiceClient();
+  const { data } = await serviceClient
+    .from('feature_flags')
+    .select('flag_key, enabled')
+    .eq('tenant_id', tenantId);
+
+  const map: FlagMap = {} as FlagMap;
+  for (const key of KNOWN_FLAGS) {
+    const row = data?.find((r) => r.flag_key === key);
+    map[key] = row ? row.enabled : true;
+  }
+  return map;
+}
+
+/**
+ * Returns feature flag maps for multiple tenants at once (admin use).
+ * Returns a map keyed by tenantId.
+ */
+export async function getFeatureFlagsByTenants(
+  tenantIds: string[]
+): Promise<Record<string, FlagMap>> {
+  if (!tenantIds.length) return {};
+
+  const serviceClient = createSupabaseServiceClient();
+  const { data } = await serviceClient
+    .from('feature_flags')
+    .select('tenant_id, flag_key, enabled')
+    .in('tenant_id', tenantIds);
+
+  const result: Record<string, FlagMap> = {};
+  for (const tenantId of tenantIds) {
+    const map: FlagMap = {} as FlagMap;
+    for (const key of KNOWN_FLAGS) {
+      const row = data?.find((r) => r.tenant_id === tenantId && r.flag_key === key);
+      map[key] = row ? row.enabled : true;
+    }
+    result[tenantId] = map;
+  }
+  return result;
+}
+
+/**
+ * Sets a feature flag for a tenant. Superadmin only.
+ */
+export async function setFeatureFlag(
+  tenantId: string,
+  key: FlagKey,
+  enabled: boolean
+): Promise<ActionResponse> {
+  const ok = await getSuperadminStatus();
+  if (!ok) return { success: false, error: 'Not authorized.' };
+
+  if (!(KNOWN_FLAGS as readonly string[]).includes(key)) {
+    return { success: false, error: 'Unknown flag key.' };
+  }
+
+  const serviceClient = createSupabaseServiceClient();
+  const { error } = await serviceClient
+    .from('feature_flags')
+    .upsert(
+      { tenant_id: tenantId, flag_key: key, enabled, updated_at: new Date().toISOString() },
+      { onConflict: 'tenant_id,flag_key' }
+    );
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -3,9 +3,14 @@
 import { useState, useTransition } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Trash2, Loader2 } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Trash2, Loader2, ChevronDown, ChevronUp } from 'lucide-react';
 import Link from 'next/link';
 import { deleteTenant } from '@/app/actions/tenants';
+import { setFeatureFlag } from '@/app/actions/feature-flags';
+import { KNOWN_FLAGS, FLAG_LABELS } from '@/lib/feature-flags';
+import type { FlagMap } from '@/lib/feature-flags';
 import { rootDomain, protocol } from '@/lib/utils';
 
 type Tenant = {
@@ -16,7 +21,110 @@ type Tenant = {
   created_at: string;
 };
 
-export function AdminDashboard({ tenants }: { tenants: Tenant[] }) {
+function TenantCard({
+  tenant,
+  initialFlags,
+  onDelete,
+  isDeleting,
+}: {
+  tenant: Tenant;
+  initialFlags: FlagMap;
+  onDelete: (id: string) => void;
+  isDeleting: boolean;
+}) {
+  const [flags, setFlags] = useState(initialFlags);
+  const [expanded, setExpanded] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function handleFlagChange(key: (typeof KNOWN_FLAGS)[number], enabled: boolean) {
+    setFlags((prev) => ({ ...prev, [key]: enabled }));
+    startTransition(async () => {
+      await setFeatureFlag(tenant.id, key, enabled);
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-xl">{tenant.name}</CardTitle>
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled={isDeleting}
+            onClick={() => onDelete(tenant.id)}
+            className="text-gray-500 hover:text-gray-700 hover:bg-gray-50"
+          >
+            {isDeleting ? (
+              <Loader2 className="h-5 w-5 animate-spin" />
+            ) : (
+              <Trash2 className="h-5 w-5" />
+            )}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-gray-500">{tenant.slug}</p>
+        <p className="text-sm text-gray-500">Language: {tenant.language}</p>
+        <p className="text-sm text-gray-500 mt-1">
+          Created: {new Date(tenant.created_at).toLocaleDateString()}
+        </p>
+        <div className="mt-3">
+          <a
+            href={`${protocol}://${tenant.slug}.${rootDomain}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:underline text-sm"
+          >
+            Visit tenant →
+          </a>
+        </div>
+
+        {/* Feature flags */}
+        <div className="mt-4 border-t pt-3">
+          <button
+            type="button"
+            className="flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            Feature Flags
+            {expanded ? (
+              <ChevronUp className="w-4 h-4" />
+            ) : (
+              <ChevronDown className="w-4 h-4" />
+            )}
+          </button>
+
+          {expanded && (
+            <div className="mt-3 space-y-2">
+              {KNOWN_FLAGS.map((key) => (
+                <div key={key} className="flex items-center justify-between">
+                  <Label htmlFor={`flag-${tenant.id}-${key}`} className="text-sm">
+                    {FLAG_LABELS[key]}
+                  </Label>
+                  <Switch
+                    id={`flag-${tenant.id}-${key}`}
+                    checked={flags[key]}
+                    disabled={isPending}
+                    onCheckedChange={(checked) => handleFlagChange(key, checked)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AdminDashboard({
+  tenants,
+  flagsByTenant,
+}: {
+  tenants: Tenant[];
+  flagsByTenant: Record<string, FlagMap>;
+}) {
   const [list, setList] = useState(tenants);
   const [isPending, startTransition] = useTransition();
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -53,45 +161,13 @@ export function AdminDashboard({ tenants }: { tenants: Tenant[] }) {
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {list.map((tenant) => (
-            <Card key={tenant.id}>
-              <CardHeader className="pb-2">
-                <div className="flex items-center justify-between">
-                  <CardTitle className="text-xl">{tenant.name}</CardTitle>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    disabled={isPending}
-                    onClick={() => handleDelete(tenant.id)}
-                    className="text-gray-500 hover:text-gray-700 hover:bg-gray-50"
-                  >
-                    {deletingId === tenant.id ? (
-                      <Loader2 className="h-5 w-5 animate-spin" />
-                    ) : (
-                      <Trash2 className="h-5 w-5" />
-                    )}
-                  </Button>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-gray-500">{tenant.slug}</p>
-                <p className="text-sm text-gray-500">
-                  Language: {tenant.language}
-                </p>
-                <p className="text-sm text-gray-500 mt-1">
-                  Created: {new Date(tenant.created_at).toLocaleDateString()}
-                </p>
-                <div className="mt-3">
-                  <a
-                    href={`${protocol}://${tenant.slug}.${rootDomain}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-500 hover:underline text-sm"
-                  >
-                    Visit tenant →
-                  </a>
-                </div>
-              </CardContent>
-            </Card>
+            <TenantCard
+              key={tenant.id}
+              tenant={tenant}
+              initialFlags={flagsByTenant[tenant.id]}
+              onDelete={handleDelete}
+              isDeleting={deletingId === tenant.id && isPending}
+            />
           ))}
         </div>
       )}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { createSupabaseServiceClient } from '@/lib/supabase-server';
 import { requireSuperadmin } from '@/lib/superadmin';
+import { getFeatureFlagsByTenants } from '@/app/actions/feature-flags';
 import { AdminDashboard } from './dashboard';
 import { rootDomain } from '@/lib/utils';
 
@@ -17,9 +18,12 @@ export default async function AdminPage() {
     .select('id, name, slug, language, created_at')
     .order('created_at', { ascending: false });
 
+  const tenantList = tenants ?? [];
+  const flagsByTenant = await getFeatureFlagsByTenants(tenantList.map((t) => t.id));
+
   return (
     <div className="min-h-screen bg-gray-50 p-4 md:p-8">
-      <AdminDashboard tenants={tenants ?? []} />
+      <AdminDashboard tenants={tenantList} flagsByTenant={flagsByTenant} />
     </div>
   );
 }

--- a/lib/feature-flags-context.tsx
+++ b/lib/feature-flags-context.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import type { FlagKey, FlagMap } from '@/lib/feature-flags';
+import { KNOWN_FLAGS } from '@/lib/feature-flags';
+
+const defaultFlags: FlagMap = Object.fromEntries(
+  KNOWN_FLAGS.map((k) => [k, true])
+) as FlagMap;
+
+const FeatureFlagContext = createContext<FlagMap>(defaultFlags);
+
+export function FeatureFlagProvider({
+  flags,
+  children,
+}: {
+  flags: FlagMap;
+  children: React.ReactNode;
+}) {
+  const merged: FlagMap = { ...defaultFlags, ...flags };
+  return (
+    <FeatureFlagContext.Provider value={merged}>
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+}
+
+export function useFeatureFlag(key: FlagKey): boolean {
+  const flags = useContext(FeatureFlagContext);
+  return flags[key] ?? true;
+}

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,16 @@
+export const KNOWN_FLAGS = [
+  'activities',
+  'reservations',
+  'breakfast_config',
+  'points_of_contact',
+] as const;
+
+export type FlagKey = (typeof KNOWN_FLAGS)[number];
+export type FlagMap = Record<FlagKey, boolean>;
+
+export const FLAG_LABELS: Record<FlagKey, string> = {
+  activities: 'Activities',
+  reservations: 'Reservations',
+  breakfast_config: 'Breakfast',
+  points_of_contact: 'Points of Contact',
+};

--- a/supabase/migrations/00018_feature_flags.sql
+++ b/supabase/migrations/00018_feature_flags.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- Migration 00018: Feature flags per tenant
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- feature_flags
+-- Stores per-tenant feature toggles. When no row exists for a (tenant, key)
+-- pair the application defaults to enabled=true.
+-- ---------------------------------------------------------------------------
+CREATE TABLE feature_flags (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id  uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  flag_key   text NOT NULL,
+  enabled    boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, flag_key)
+);
+
+ALTER TABLE feature_flags ENABLE ROW LEVEL SECURITY;
+
+-- Tenant members can read their own tenant's flags.
+CREATE POLICY "feature_flags: members can read"
+  ON feature_flags FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM memberships
+      WHERE memberships.tenant_id = feature_flags.tenant_id
+        AND memberships.user_id = auth.uid()
+    )
+  );
+
+-- INSERT / UPDATE / DELETE are intentionally not exposed to end users.
+-- Superadmin writes go through the service-role client.


### PR DESCRIPTION
## Summary

- `feature_flags` table with RLS — tenant members read their own flags; superadmin writes go through the service-role client
- `getFeatureFlags(tenantId)` and `getFeatureFlagsByTenants(ids[])` helpers; `setFeatureFlag(tenantId, key, enabled)` server action (superadmin only)
- `FeatureFlagProvider` (client context) + `useFeatureFlag(key)` hook in `lib/feature-flags-context.tsx`
- Flags fetched server-side in `[tenant]/layout.tsx` and injected into provider — zero client round-trips
- `DayViewClient` wraps breakfast, activities, and reservations sections with `useFeatureFlag` checks
- Admin dashboard: expandable feature flag toggles per tenant card with optimistic Switch UI
- Known flags: `activities`, `reservations`, `breakfast_config`, `points_of_contact`

## Test plan

- [ ] Tenant page loads — all three sections visible by default (all flags enabled)
- [ ] In admin dashboard, expand flags for a tenant → four toggles shown
- [ ] Disable `activities` → reload tenant day view → Activities section hidden
- [ ] Re-enable `activities` → section reappears
- [ ] Same test for `reservations` and `breakfast_config`
- [ ] Viewer (non-superadmin) calling `setFeatureFlag` returns "Not authorized."
- [ ] Build passes cleanly: `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)