### PR TITLE
T-20: Mobile design optimization

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -931,7 +931,7 @@ Guide new tenants after `/new` through setup.
 
 ## Ticket 20: Mobile Design Optimization
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P1  
 **Scope:** `components/HomeClient.tsx`, `app/[tenant]/day/[date]/DayViewClient.tsx`, `components/activity-form.tsx`, `components/reservation-form.tsx`, `components/breakfast-form.tsx`, `app/[tenant]/admin/settings/client.tsx`, `app/[tenant]/layout.tsx`  

--- a/app/[tenant]/admin/settings/client.tsx
+++ b/app/[tenant]/admin/settings/client.tsx
@@ -43,14 +43,16 @@ export function SettingsClient({ tenantId, currentUserId, initialAccentColor, in
       <h1 className="text-2xl font-semibold mb-6">{t('title')}</h1>
 
       <Tabs value={activeTab} onValueChange={handleTabChange}>
-        <TabsList className="mb-6">
-          <TabsTrigger value="poc">{t('tabPoc')}</TabsTrigger>
-          <TabsTrigger value="venue-types">{t('tabVenueTypes')}</TabsTrigger>
-          <TabsTrigger value="activity-tags">{t('tabActivityTags')}</TabsTrigger>
-          <TabsTrigger value="branding">{t('tabBranding')}</TabsTrigger>
-          <TabsTrigger value="language">{t('tabLanguage')}</TabsTrigger>
-          <TabsTrigger value="members">{t('tabMembers')}</TabsTrigger>
-        </TabsList>
+        <div className="mb-6 overflow-x-auto -mx-6 px-6 sm:mx-0 sm:px-0">
+          <TabsList className="inline-flex w-max sm:w-auto">
+            <TabsTrigger value="poc">{t('tabPoc')}</TabsTrigger>
+            <TabsTrigger value="venue-types">{t('tabVenueTypes')}</TabsTrigger>
+            <TabsTrigger value="activity-tags">{t('tabActivityTags')}</TabsTrigger>
+            <TabsTrigger value="branding">{t('tabBranding')}</TabsTrigger>
+            <TabsTrigger value="language">{t('tabLanguage')}</TabsTrigger>
+            <TabsTrigger value="members">{t('tabMembers')}</TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="poc">
           <PocManagement />

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -169,7 +169,7 @@ export function DayViewClient({
   }
 
   return (
-    <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+    <div className="max-w-3xl mx-auto px-3 sm:px-6 py-4 sm:py-8 space-y-6">
       <DayNav date={date} today={today} />
 
       <DaySummaryCard

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -17,6 +17,8 @@ import { PwaRegister } from '@/components/pwa-register';
 import { PwaInstallPrompt } from '@/components/pwa-install-prompt';
 import { FeatureFlagProvider } from '@/lib/feature-flags-context';
 import { getFeatureFlags } from '@/app/actions/feature-flags';
+import { MobileNav } from '@/components/mobile-nav';
+import { getTenantToday } from '@/lib/day-utils';
 
 export async function generateMetadata(): Promise<Metadata> {
   try {
@@ -73,11 +75,12 @@ export default async function TenantLayout({
   const supabase = await createSupabaseServerClient();
   const { data: tenantRow } = await supabase
     .from('tenants')
-    .select('accent_color, logo_url, name')
+    .select('accent_color, logo_url, name, timezone')
     .eq('id', tenant.id)
     .single();
 
-  const row = tenantRow as { accent_color?: string | null; logo_url?: string | null; name?: string | null } | null;
+  const row = tenantRow as { accent_color?: string | null; logo_url?: string | null; name?: string | null; timezone?: string | null } | null;
+  const today = getTenantToday(row?.timezone ?? 'UTC');
   const accentColor = row?.accent_color;
   const accentStyle = accentColor
     ? ({ '--tenant-accent': accentColor } as React.CSSProperties)
@@ -109,8 +112,9 @@ export default async function TenantLayout({
                 {user && <UserMenu user={user} signOutLabel={t('signOut')} />}
               </div>
             </header>
-            <main className="flex-1">{children}</main>
+            <main className="flex-1 pb-16 sm:pb-0">{children}</main>
           </div>
+          <MobileNav today={today} isEditor={editor} />
           <AdminIndicator />
           <Toaster richColors closeButton />
           <PwaRegister />

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -87,7 +87,7 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
   }
 
   return (
-    <div className="max-w-5xl mx-auto px-6 py-8">
+    <div className="max-w-5xl mx-auto px-3 sm:px-6 py-4 sm:py-8">
       {/* Heading row */}
       <div className="flex items-center justify-between mb-6">
         {viewMode === 'calendar' ? (
@@ -136,6 +136,7 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
                 disabled={isPrevDisabled}
                 onClick={() => navigate(prevMonthStr)}
                 aria-label={t('previousMonth')}
+                className="h-11 w-11 sm:h-9 sm:w-9"
               >
                 <ChevronLeft className="h-4 w-4" />
               </Button>
@@ -145,6 +146,7 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
                 disabled={isNextDisabled}
                 onClick={() => navigate(nextMonthStr)}
                 aria-label={t('nextMonth')}
+                className="h-11 w-11 sm:h-9 sm:w-9"
               >
                 <ChevronRight className="h-4 w-4" />
               </Button>
@@ -177,7 +179,7 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
             {Array.from({ length: startPadding }).map((_, i) => (
               <div
                 key={`pad-${i}`}
-                className="border-r border-b min-h-[80px] bg-muted/20"
+                className="border-r border-b min-h-[60px] sm:min-h-[80px] bg-muted/20"
               />
             ))}
 
@@ -194,7 +196,7 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
                   key={dateStr}
                   onClick={() => setSelectedDate(isSelected ? null : dateStr)}
                   className={cn(
-                    'border-r border-b min-h-[80px] p-1.5 text-left transition-colors',
+                    'border-r border-b min-h-[60px] sm:min-h-[80px] p-1 sm:p-1.5 text-left transition-colors',
                     'hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
                     isSelected && 'bg-accent',
                     !isSelected && 'bg-background'

--- a/components/day-nav.tsx
+++ b/components/day-nav.tsx
@@ -39,13 +39,14 @@ export function DayNav({ date, today }: Props) {
         onClick={() => navigate(prevYmd)}
         disabled={prevYmd < today}
         aria-label={t('previousDay')}
+        className="h-11 w-11 sm:h-9 sm:w-9"
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
 
       <Popover open={calOpen} onOpenChange={setCalOpen}>
         <PopoverTrigger asChild>
-          <Button variant="outline" className="min-w-44 justify-start gap-2 font-normal">
+          <Button variant="outline" className="flex-1 sm:flex-none sm:min-w-44 justify-start gap-2 font-normal">
             <CalendarIcon className="h-4 w-4 text-muted-foreground" />
             {format(currentDate, 'EEE, d MMM yyyy')}
           </Button>
@@ -74,6 +75,7 @@ export function DayNav({ date, today }: Props) {
         onClick={() => navigate(nextYmd)}
         disabled={nextYmd > maxYmd}
         aria-label={t('nextDay')}
+        className="h-11 w-11 sm:h-9 sm:w-9"
       >
         <ChevronRight className="h-4 w-4" />
       </Button>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Home, CalendarDays, Settings } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface MobileNavProps {
+  today: string;
+  isEditor: boolean;
+}
+
+export function MobileNav({ today, isEditor }: MobileNavProps) {
+  const pathname = usePathname();
+
+  const items = [
+    { href: '/', label: 'Home', icon: Home, active: pathname === '/' },
+    { href: `/day/${today}`, label: 'Today', icon: CalendarDays, active: pathname.startsWith('/day/') },
+    ...(isEditor
+      ? [{ href: '/admin/settings', label: 'Settings', icon: Settings, active: pathname.startsWith('/admin/') }]
+      : []),
+  ];
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background sm:hidden">
+      <div className="flex h-16">
+        {items.map(({ href, label, icon: Icon, active }) => (
+          <Link
+            key={href}
+            href={href}
+            className={cn(
+              'flex flex-1 flex-col items-center justify-center gap-1 text-[11px] font-medium transition-colors',
+              active ? 'text-foreground' : 'text-muted-foreground'
+            )}
+          >
+            <Icon className={cn('h-5 w-5', active && 'stroke-[2.5]')} />
+            {label}
+          </Link>
+        ))}
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- **Sticky bottom nav** (`MobileNav`) on `<640px` with three links: Home, Today (today's day view), and Settings (editors only); hidden on desktop with `sm:hidden`
- `main` content gets `pb-16 sm:pb-0` to prevent overlap with the bottom nav
- **Settings page tabs** wrapped in a horizontally scrollable container on mobile — no more overflow clipping
- **Calendar cells** reduced from `min-h-[80px]` to `min-h-[60px]` on mobile (`sm:min-h-[80px]` preserved for desktop)
- **Prev/next nav buttons** raised from 36px to 44px on mobile (`h-11 w-11 sm:h-9 sm:w-9`) — applies to both monthly calendar nav and DayNav
- **DayNav date button** grows to fill remaining space on mobile (`flex-1 sm:flex-none`)
- **Container padding** tightened on mobile: `px-3 sm:px-6`, `py-4 sm:py-8` for both HomeClient and DayViewClient
- Layout fetches tenant timezone to compute `today` for the MobileNav Today link
- Activity/reservation/breakfast forms already had Dialog→Drawer responsive switching; no changes needed

## Test plan

- [ ] On viewport <640px: bottom nav bar appears with Home, Today, Settings (if editor)
- [ ] On viewport ≥640px: bottom nav hidden, no extra bottom padding
- [ ] Settings page tabs scroll horizontally on narrow screens
- [ ] Calendar cells readable at 375px; min-height respected
- [ ] Prev/next buttons on calendar and day view ≥44px touch target
- [ ] DayNav date button expands full width minus arrow buttons on mobile
- [ ] No content cut off behind bottom nav on day view or home

🤖 Generated with [Claude Code](https://claude.com/claude-code)