### PR TITLE
T-21: Feature request form

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -960,7 +960,7 @@ Staff use phones on the floor; desktop-first UI is hard to use.
 
 ## Ticket 21: Feature Request Form
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P2  
 **Scope:** `supabase/migrations/`, `app/actions/feature-requests.ts` (new), `app/[tenant]/admin/settings/`, `app/admin/`  

--- a/app/[tenant]/admin/settings/client.tsx
+++ b/app/[tenant]/admin/settings/client.tsx
@@ -7,10 +7,11 @@ import { PocManagement } from '@/components/poc-management';
 import { VenueTypeManagement } from '@/components/venue-type-management';
 import { ActivityTagManagement } from '@/components/activity-tag-management';
 import { MemberManagement } from '@/components/member-management';
+import { FeatureRequestManagement } from '@/components/feature-request-management';
 import { SettingsForm } from './settings-form';
 import { LanguageSettings } from './language-settings';
 
-const TABS = ['poc', 'venue-types', 'activity-tags', 'branding', 'language', 'members'] as const;
+const TABS = ['poc', 'venue-types', 'activity-tags', 'branding', 'language', 'members', 'feedback'] as const;
 type Tab = (typeof TABS)[number];
 
 function isValidTab(v: string | null): v is Tab {
@@ -51,6 +52,7 @@ export function SettingsClient({ tenantId, currentUserId, initialAccentColor, in
             <TabsTrigger value="branding">{t('tabBranding')}</TabsTrigger>
             <TabsTrigger value="language">{t('tabLanguage')}</TabsTrigger>
             <TabsTrigger value="members">{t('tabMembers')}</TabsTrigger>
+            <TabsTrigger value="feedback">{t('tabFeedback')}</TabsTrigger>
           </TabsList>
         </div>
 
@@ -80,6 +82,10 @@ export function SettingsClient({ tenantId, currentUserId, initialAccentColor, in
 
         <TabsContent value="members">
           <MemberManagement currentUserId={currentUserId} />
+        </TabsContent>
+
+        <TabsContent value="feedback">
+          <FeatureRequestManagement />
         </TabsContent>
       </Tabs>
     </div>

--- a/app/actions/feature-requests.ts
+++ b/app/actions/feature-requests.ts
@@ -1,0 +1,119 @@
+'use server';
+
+import { z } from 'zod';
+import { createTenantClient, createSupabaseServiceClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { getUserRole } from '@/lib/membership';
+import { getUser } from '@/app/actions/auth';
+import { getSuperadminStatus } from '@/lib/superadmin';
+import type { ActionResponse } from '@/types/actions';
+
+export type FeatureRequestStatus = 'pending' | 'reviewing' | 'accepted' | 'rejected' | 'shipped';
+
+export interface FeatureRequest {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  title: string;
+  description: string | null;
+  status: FeatureRequestStatus;
+  created_at: string;
+}
+
+export const featureRequestSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'Title is required.')
+    .max(100, 'Title must be 100 characters or fewer.'),
+  description: z
+    .string()
+    .max(1000, 'Description must be 1000 characters or fewer.')
+    .optional(),
+});
+
+export type FeatureRequestFormData = z.infer<typeof featureRequestSchema>;
+
+export async function createFeatureRequest(
+  raw: FeatureRequestFormData
+): Promise<ActionResponse<FeatureRequest>> {
+  const parsed = featureRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const user = await getUser();
+  if (!user) return { success: false, error: 'Not authenticated.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('feature_requests')
+    .insert({
+      tenant_id: tenantId,
+      user_id: user.id,
+      title: parsed.data.title.trim(),
+      description: parsed.data.description?.trim() || null,
+    })
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as FeatureRequest };
+}
+
+export async function getTenantFeatureRequests(): Promise<ActionResponse<FeatureRequest[]>> {
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('feature_requests')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .order('created_at', { ascending: false });
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: (data ?? []) as FeatureRequest[] };
+}
+
+export async function getAllFeatureRequests(): Promise<ActionResponse<FeatureRequest[]>> {
+  const ok = await getSuperadminStatus();
+  if (!ok) return { success: false, error: 'Not authorized.' };
+
+  const serviceClient = createSupabaseServiceClient();
+  const { data, error } = await serviceClient
+    .from('feature_requests')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: (data ?? []) as FeatureRequest[] };
+}
+
+export async function updateFeatureRequestStatus(
+  id: string,
+  status: FeatureRequestStatus
+): Promise<ActionResponse> {
+  const ok = await getSuperadminStatus();
+  if (!ok) return { success: false, error: 'Not authorized.' };
+
+  const validStatuses: FeatureRequestStatus[] = [
+    'pending', 'reviewing', 'accepted', 'rejected', 'shipped',
+  ];
+  if (!validStatuses.includes(status)) {
+    return { success: false, error: 'Invalid status.' };
+  }
+
+  const serviceClient = createSupabaseServiceClient();
+  const { error } = await serviceClient
+    .from('feature_requests')
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { createSupabaseServiceClient } from '@/lib/supabase-server';
 import { requireSuperadmin } from '@/lib/superadmin';
 import { getFeatureFlagsByTenants } from '@/app/actions/feature-flags';
 import { AdminDashboard } from './dashboard';
+import { AdminFeatureRequests } from '@/components/admin-feature-requests';
 import { rootDomain } from '@/lib/utils';
 
 export const metadata: Metadata = {
@@ -22,8 +23,13 @@ export default async function AdminPage() {
   const flagsByTenant = await getFeatureFlagsByTenants(tenantList.map((t) => t.id));
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+    <div className="min-h-screen bg-gray-50 p-4 md:p-8 space-y-12">
       <AdminDashboard tenants={tenantList} flagsByTenant={flagsByTenant} />
+
+      <div>
+        <h2 className="text-2xl font-bold mb-6">Feature Requests</h2>
+        <AdminFeatureRequests tenants={tenantList.map((t) => ({ id: t.id, name: t.name }))} />
+      </div>
     </div>
   );
 }

--- a/components/admin-feature-requests.tsx
+++ b/components/admin-feature-requests.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { toast } from 'sonner';
+import {
+  getAllFeatureRequests,
+  updateFeatureRequestStatus,
+} from '@/app/actions/feature-requests';
+import type { FeatureRequest, FeatureRequestStatus } from '@/app/actions/feature-requests';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+const STATUS_OPTIONS: FeatureRequestStatus[] = [
+  'pending', 'reviewing', 'accepted', 'rejected', 'shipped',
+];
+
+const STATUS_CLASSES: Record<FeatureRequestStatus, string> = {
+  pending: 'bg-gray-100 text-gray-700',
+  reviewing: 'bg-blue-100 text-blue-700',
+  accepted: 'bg-green-100 text-green-700',
+  rejected: 'bg-red-100 text-red-700',
+  shipped: 'bg-purple-100 text-purple-700',
+};
+
+const STATUS_LABELS: Record<FeatureRequestStatus, string> = {
+  pending: 'Pending',
+  reviewing: 'Reviewing',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+  shipped: 'Shipped',
+};
+
+function StatusBadge({ status }: { status: FeatureRequestStatus }) {
+  return (
+    <Badge variant="outline" className={cn('border-0', STATUS_CLASSES[status])}>
+      {STATUS_LABELS[status]}
+    </Badge>
+  );
+}
+
+function FeatureRequestRow({
+  request,
+  tenantName,
+}: {
+  request: FeatureRequest;
+  tenantName: string;
+}) {
+  const [status, setStatus] = useState(request.status);
+  const [isPending, startTransition] = useTransition();
+
+  function handleStatusChange(newStatus: FeatureRequestStatus) {
+    setStatus(newStatus);
+    startTransition(async () => {
+      const result = await updateFeatureRequestStatus(request.id, newStatus);
+      if (!result.success) {
+        toast.error(result.error);
+        setStatus(request.status);
+      }
+    });
+  }
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium text-sm max-w-xs">
+        <div>
+          <p className="font-medium">{request.title}</p>
+          {request.description && (
+            <p className="text-muted-foreground text-xs mt-0.5 line-clamp-2">
+              {request.description}
+            </p>
+          )}
+        </div>
+      </TableCell>
+      <TableCell className="text-sm text-muted-foreground">{tenantName}</TableCell>
+      <TableCell>
+        <Select
+          value={status}
+          onValueChange={(v) => handleStatusChange(v as FeatureRequestStatus)}
+          disabled={isPending}
+        >
+          <SelectTrigger className="w-32 h-8">
+            <SelectValue>
+              <StatusBadge status={status} />
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((s) => (
+              <SelectItem key={s} value={s}>
+                <StatusBadge status={s} />
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </TableCell>
+      <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
+        {new Date(request.created_at).toLocaleDateString()}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function AdminFeatureRequests({
+  tenants,
+}: {
+  tenants: { id: string; name: string }[];
+}) {
+  const [requests, setRequests] = useState<FeatureRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const tenantMap = new Map(tenants.map((t) => [t.id, t.name]));
+
+  useEffect(() => {
+    getAllFeatureRequests().then((result) => {
+      if (result.success) setRequests(result.data);
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) {
+    return <p className="text-sm text-gray-500">Loading feature requests…</p>;
+  }
+
+  if (requests.length === 0) {
+    return <p className="text-sm text-gray-500">No feature requests yet.</p>;
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Request</TableHead>
+          <TableHead>Tenant</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Submitted</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {requests.map((req) => (
+          <FeatureRequestRow
+            key={req.id}
+            request={req}
+            tenantName={tenantMap.get(req.tenant_id) ?? req.tenant_id}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/components/feature-request-management.tsx
+++ b/components/feature-request-management.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { useTranslations } from 'next-intl';
+import {
+  createFeatureRequest,
+  getTenantFeatureRequests,
+  featureRequestSchema,
+} from '@/app/actions/feature-requests';
+import type { FeatureRequest, FeatureRequestFormData, FeatureRequestStatus } from '@/app/actions/feature-requests';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+const STATUS_CLASSES: Record<FeatureRequestStatus, string> = {
+  pending: 'bg-gray-100 text-gray-700',
+  reviewing: 'bg-blue-100 text-blue-700',
+  accepted: 'bg-green-100 text-green-700',
+  rejected: 'bg-red-100 text-red-700',
+  shipped: 'bg-purple-100 text-purple-700',
+};
+
+function StatusBadge({ status, label }: { status: FeatureRequestStatus; label: string }) {
+  return (
+    <Badge variant="outline" className={cn('border-0', STATUS_CLASSES[status])}>
+      {label}
+    </Badge>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function FeatureRequestManagement() {
+  const t = useTranslations('Tenant.featureRequests');
+  const [requests, setRequests] = useState<FeatureRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FeatureRequestFormData>({
+    resolver: zodResolver(featureRequestSchema),
+    defaultValues: { title: '', description: '' },
+  });
+
+  useEffect(() => {
+    getTenantFeatureRequests().then((result) => {
+      if (result.success) setRequests(result.data);
+      setLoading(false);
+    });
+  }, []);
+
+  function onSubmit(data: FeatureRequestFormData) {
+    startTransition(async () => {
+      const result = await createFeatureRequest(data);
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(t('submitted'));
+      reset();
+      setRequests((prev) => [result.data, ...prev]);
+    });
+  }
+
+  const statusLabel = (status: FeatureRequestStatus) =>
+    t(`status${status.charAt(0).toUpperCase() + status.slice(1)}` as
+      'statusPending' | 'statusReviewing' | 'statusAccepted' | 'statusRejected' | 'statusShipped');
+
+  return (
+    <div className="space-y-8">
+      {/* Submit form */}
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <h2 className="text-lg font-semibold">{t('new')}</h2>
+
+        <div className="space-y-2">
+          <Label htmlFor="fr-title">{t('titleLabel')}</Label>
+          <Input
+            id="fr-title"
+            placeholder={t('titlePlaceholder')}
+            {...register('title')}
+          />
+          {errors.title && (
+            <p className="text-sm text-destructive">{errors.title.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fr-description">{t('descriptionLabel')}</Label>
+          <Textarea
+            id="fr-description"
+            placeholder={t('descriptionPlaceholder')}
+            rows={3}
+            {...register('description')}
+          />
+          {errors.description && (
+            <p className="text-sm text-destructive">{errors.description.message}</p>
+          )}
+        </div>
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? t('submitting') : t('submit')}
+        </Button>
+      </form>
+
+      {/* Existing requests */}
+      <div className="space-y-3">
+        <h3 className="text-base font-medium">{t('title')}</h3>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">{t('loading')}</p>
+        ) : requests.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('noRequests')}</p>
+        ) : (
+          <div className="space-y-3">
+            {requests.map((req) => (
+              <div
+                key={req.id}
+                className="rounded-lg border p-4 space-y-1"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="font-medium text-sm">{req.title}</p>
+                  <StatusBadge status={req.status} label={statusLabel(req.status)} />
+                </div>
+                {req.description && (
+                  <p className="text-sm text-muted-foreground">{req.description}</p>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  {new Date(req.created_at).toLocaleDateString()}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -239,6 +239,7 @@
       "tabBranding": "Branding",
       "tabLanguage": "Language",
       "tabMembers": "Team",
+      "tabFeedback": "Feedback",
       "languageTitle": "Venue language",
       "languageDescription": "This language will be used for all members of your venue.",
       "languageLabel": "Language",
@@ -292,6 +293,24 @@
       "removed": "Member removed.",
       "roleUpdated": "Role updated.",
       "loading": "Loading\u2026"
+    },
+    "featureRequests": {
+      "title": "Your requests",
+      "new": "Submit a feature request",
+      "titleLabel": "Title",
+      "titlePlaceholder": "What feature would you like?",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "More details (optional)",
+      "submit": "Submit",
+      "submitting": "Submitting\u2026",
+      "submitted": "Request submitted. Thank you!",
+      "noRequests": "No feature requests yet.",
+      "loading": "Loading\u2026",
+      "statusPending": "Pending",
+      "statusReviewing": "Reviewing",
+      "statusAccepted": "Accepted",
+      "statusRejected": "Rejected",
+      "statusShipped": "Shipped"
     },
     "venueType": {
       "title": "Venue Types",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -239,6 +239,7 @@
       "tabBranding": "Image de marque",
       "tabLanguage": "Langue",
       "tabMembers": "Équipe",
+      "tabFeedback": "Retours",
       "languageTitle": "Langue de l'établissement",
       "languageDescription": "Cette langue sera utilisée pour tous les membres de votre établissement.",
       "languageLabel": "Langue",
@@ -292,6 +293,24 @@
       "removed": "Membre retiré.",
       "roleUpdated": "Rôle mis à jour.",
       "loading": "Chargement\u2026"
+    },
+    "featureRequests": {
+      "title": "Vos demandes",
+      "new": "Soumettre une demande",
+      "titleLabel": "Titre",
+      "titlePlaceholder": "Quelle fonctionnalité souhaitez-vous ?",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Plus de détails (optionnel)",
+      "submit": "Envoyer",
+      "submitting": "Envoi\u2026",
+      "submitted": "Demande envoyée. Merci !",
+      "noRequests": "Aucune demande pour l'instant.",
+      "loading": "Chargement\u2026",
+      "statusPending": "En attente",
+      "statusReviewing": "En cours d'examen",
+      "statusAccepted": "Acceptée",
+      "statusRejected": "Refusée",
+      "statusShipped": "Livrée"
     },
     "venueType": {
       "title": "Types de lieu",

--- a/supabase/migrations/00019_feature_requests.sql
+++ b/supabase/migrations/00019_feature_requests.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- Migration 00019: Feature requests
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- feature_requests
+-- Submitted by tenant members; status managed by superadmins via service role.
+-- ---------------------------------------------------------------------------
+CREATE TABLE feature_requests (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  user_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title       text NOT NULL CHECK (char_length(title) BETWEEN 1 AND 100),
+  description text CHECK (char_length(description) <= 1000),
+  status      text NOT NULL DEFAULT 'pending'
+              CHECK (status IN ('pending', 'reviewing', 'accepted', 'rejected', 'shipped')),
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE feature_requests ENABLE ROW LEVEL SECURITY;
+
+-- Tenant members can read all requests for their tenant.
+CREATE POLICY "feature_requests: members can select"
+  ON feature_requests FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM memberships
+      WHERE memberships.tenant_id = feature_requests.tenant_id
+        AND memberships.user_id = auth.uid()
+    )
+  );
+
+-- Members can submit requests for their own tenant.
+CREATE POLICY "feature_requests: members can insert"
+  ON feature_requests FOR INSERT TO authenticated
+  WITH CHECK (
+    user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM memberships
+      WHERE memberships.tenant_id = feature_requests.tenant_id
+        AND memberships.user_id = auth.uid()
+    )
+  );
+
+-- UPDATE and DELETE are intentionally not exposed to end users.
+-- Superadmin status changes go through the service-role client.


### PR DESCRIPTION
## Summary

- `feature_requests` table with RLS — members can submit and read requests for their tenant; superadmin status updates go through the service-role client
- `createFeatureRequest`, `getTenantFeatureRequests`, `getAllFeatureRequests`, `updateFeatureRequestStatus` server actions with Zod validation (title ≤100 chars, description ≤1000 chars)
- `FeatureRequestManagement` component in tenant settings under a new **Feedback** tab — submit form + list of previous requests with coloured status badges
- `AdminFeatureRequests` component in `/admin` — full cross-tenant list with inline `Select` to update status per row
- Status colours: pending=gray, reviewing=blue, accepted=green, rejected=red, shipped=purple
- Full EN/FR translations under `Tenant.featureRequests` and `Tenant.settings.tabFeedback`

## Test plan

- [ ] Member opens Settings → Feedback tab, submits a request → appears in list with "Pending" badge
- [ ] Second submit from same tenant appears in list (oldest requests at bottom)
- [ ] Superadmin at `/admin` sees Feature Requests section below tenant grid
- [ ] Superadmin changes status via dropdown → badge updates immediately
- [ ] Non-superadmin calling `updateFeatureRequestStatus` returns "Not authorized."
- [ ] Title > 100 chars shows validation error; description > 1000 chars shows validation error
- [ ] `pnpm build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)