### PR TITLE
T-19: Tenant onboarding wizard

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -905,7 +905,7 @@ Enable/disable features per tenant for tiered rollout.
 
 ## Ticket 19: Tenant Onboarding Wizard
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P1  
 **Scope:** `app/[tenant]/admin/onboarding/page.tsx` (new), `supabase/migrations/`, `app/actions/tenants.ts`, `app/[tenant]/page.tsx`  

--- a/app/(platform)/new/new-tenant-form.tsx
+++ b/app/(platform)/new/new-tenant-form.tsx
@@ -49,7 +49,7 @@ export function NewTenantForm() {
         return;
       }
       if (!result.data.requiresConfirmation) {
-        window.location.href = `${protocol}://${slug}.${rootDomain}/`;
+        window.location.href = `${protocol}://${slug}.${rootDomain}/admin/onboarding`;
       } else {
         setCreatedSlug(slug);
       }

--- a/app/[tenant]/admin/onboarding/onboarding-wizard.tsx
+++ b/app/[tenant]/admin/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { Check } from 'lucide-react';
+import { completeOnboarding } from '@/app/actions/tenants';
+import { SettingsForm } from '@/app/[tenant]/admin/settings/settings-form';
+import { LanguageSettings } from '@/app/[tenant]/admin/settings/language-settings';
+import { VenueTypeManagement } from '@/components/venue-type-management';
+import { PocManagement } from '@/components/poc-management';
+import { MemberManagement } from '@/components/member-management';
+import { Button } from '@/components/ui/button';
+
+const STEPS = ['branding', 'language', 'venueTypes', 'poc', 'team'] as const;
+type Step = (typeof STEPS)[number];
+
+interface OnboardingWizardProps {
+  tenantId: string;
+  currentUserId: string;
+  initialAccentColor: string | null;
+  initialLogoUrl: string | null;
+}
+
+export function OnboardingWizard({
+  tenantId,
+  currentUserId,
+  initialAccentColor,
+  initialLogoUrl,
+}: OnboardingWizardProps) {
+  const t = useTranslations('Tenant.onboarding');
+  const router = useRouter();
+  const [currentStep, setCurrentStep] = useState(0);
+  const [isPending, startTransition] = useTransition();
+
+  const totalSteps = STEPS.length;
+  const isLast = currentStep === totalSteps - 1;
+
+  async function finish() {
+    startTransition(async () => {
+      await completeOnboarding(tenantId);
+      router.push('/');
+    });
+  }
+
+  function handleNext() {
+    if (isLast) {
+      finish();
+    } else {
+      setCurrentStep((s) => s + 1);
+    }
+  }
+
+  function handleSkipAll() {
+    finish();
+  }
+
+  const stepLabels: Record<Step, string> = {
+    branding: t('stepBranding'),
+    language: t('stepLanguage'),
+    venueTypes: t('stepVenueTypes'),
+    poc: t('stepPoc'),
+    team: t('stepTeam'),
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-10 space-y-8">
+      {/* Header */}
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </div>
+
+      {/* Stepper */}
+      <div className="flex items-center gap-0">
+        {STEPS.map((step, i) => {
+          const done = i < currentStep;
+          const active = i === currentStep;
+          return (
+            <div key={step} className="flex items-center flex-1 min-w-0">
+              <div className="flex flex-col items-center gap-1 flex-shrink-0">
+                <div
+                  className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium border-2 transition-colors ${
+                    done
+                      ? 'bg-primary border-primary text-primary-foreground'
+                      : active
+                        ? 'border-primary text-primary bg-background'
+                        : 'border-muted-foreground/30 text-muted-foreground/50 bg-background'
+                  }`}
+                >
+                  {done ? <Check className="h-4 w-4" /> : i + 1}
+                </div>
+                <span
+                  className={`text-xs whitespace-nowrap hidden sm:block ${
+                    active ? 'text-foreground font-medium' : 'text-muted-foreground'
+                  }`}
+                >
+                  {stepLabels[step]}
+                </span>
+              </div>
+              {i < totalSteps - 1 && (
+                <div
+                  className={`flex-1 h-0.5 mx-2 transition-colors ${
+                    done ? 'bg-primary' : 'bg-muted-foreground/20'
+                  }`}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Step label for mobile */}
+      <p className="text-sm font-medium sm:hidden">
+        {t('stepOf', { current: currentStep + 1, total: totalSteps })}
+        {' · '}
+        {stepLabels[STEPS[currentStep]]}
+      </p>
+
+      {/* Step content */}
+      <div className="min-h-48">
+        {STEPS[currentStep] === 'branding' && (
+          <SettingsForm
+            tenantId={tenantId}
+            initialAccentColor={initialAccentColor}
+            initialLogoUrl={initialLogoUrl}
+          />
+        )}
+        {STEPS[currentStep] === 'language' && <LanguageSettings />}
+        {STEPS[currentStep] === 'venueTypes' && <VenueTypeManagement />}
+        {STEPS[currentStep] === 'poc' && <PocManagement />}
+        {STEPS[currentStep] === 'team' && (
+          <MemberManagement currentUserId={currentUserId} />
+        )}
+      </div>
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between pt-4 border-t">
+        <div className="flex gap-2">
+          {currentStep > 0 && (
+            <Button
+              variant="ghost"
+              onClick={() => setCurrentStep((s) => s - 1)}
+              disabled={isPending}
+            >
+              {t('back')}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            onClick={handleSkipAll}
+            disabled={isPending}
+            className="text-muted-foreground"
+          >
+            {t('skipAll')}
+          </Button>
+        </div>
+        <Button onClick={handleNext} disabled={isPending}>
+          {isPending
+            ? t('finishing')
+            : isLast
+              ? t('done')
+              : t('next')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/[tenant]/admin/onboarding/page.tsx
+++ b/app/[tenant]/admin/onboarding/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from 'next/navigation';
+import { requireTenantEditor } from '@/lib/guards';
+import { getTenantFromHeaders } from '@/lib/tenant';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { OnboardingWizard } from './onboarding-wizard';
+
+export default async function OnboardingPage() {
+  const { user } = await requireTenantEditor();
+  const tenant = await getTenantFromHeaders();
+
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('tenants')
+    .select('onboarding_completed, accent_color, logo_url')
+    .eq('id', tenant.id)
+    .single();
+
+  const row = data as {
+    onboarding_completed?: boolean | null;
+    accent_color?: string | null;
+    logo_url?: string | null;
+  } | null;
+
+  if (row?.onboarding_completed) {
+    redirect('/');
+  }
+
+  return (
+    <OnboardingWizard
+      tenantId={tenant.id}
+      currentUserId={user.id}
+      initialAccentColor={row?.accent_color ?? null}
+      initialLogoUrl={row?.logo_url ?? null}
+    />
+  );
+}

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -10,6 +10,7 @@ import {
   getBreakfastConfigsForMonth,
 } from './month-queries';
 import { HomeClient } from '@/components/HomeClient';
+import { OnboardingBanner } from '@/components/onboarding-banner';
 import type { DaySummary } from '@/components/HomeClient';
 import type { Day } from '@/types/index';
 
@@ -23,14 +24,16 @@ export default async function TenantHomePage({
   const tenant = await getTenantFromHeaders();
   const { role } = await requireTenantMember();
 
-  // Fetch tenant timezone
+  // Fetch tenant timezone + onboarding status
   const supabase = await createSupabaseServerClient();
   const { data: tenantRow } = await supabase
     .from('tenants')
-    .select('timezone')
+    .select('timezone, onboarding_completed')
     .eq('id', tenant.id)
     .single();
-  const timezone = tenantRow?.timezone ?? 'UTC';
+  const timezone = (tenantRow as { timezone?: string | null } | null)?.timezone ?? 'UTC';
+  const onboardingCompleted =
+    (tenantRow as { onboarding_completed?: boolean | null } | null)?.onboarding_completed ?? true;
 
   const today = getTenantToday(timezone);
 
@@ -98,10 +101,13 @@ export default async function TenantHomePage({
   const days = [...summaryMap.values()].sort((a, b) => a.date.localeCompare(b.date));
 
   return (
-    <HomeClient
-      month={month}
-      today={today}
-      days={days}
-    />
+    <>
+      {!onboardingCompleted && <OnboardingBanner />}
+      <HomeClient
+        month={month}
+        today={today}
+        days={days}
+      />
+    </>
   );
 }

--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -180,6 +180,22 @@ export async function updateTenant(
 }
 
 // ---------------------------------------------------------------------------
+// completeOnboarding
+// ---------------------------------------------------------------------------
+export async function completeOnboarding(tenantId: string): Promise<ActionResponse> {
+  const serviceClient = createSupabaseServiceClient();
+  const { error } = await serviceClient
+    .from('tenants')
+    .update({ onboarding_completed: true } as Record<string, unknown>)
+    .eq('id', tenantId);
+
+  if (error) {
+    return { success: false, error: 'Failed to complete onboarding.' };
+  }
+  return { success: true, data: undefined };
+}
+
+// ---------------------------------------------------------------------------
 // deleteTenant
 // ---------------------------------------------------------------------------
 export async function deleteTenant(id: string): Promise<ActionResponse> {

--- a/components/onboarding-banner.tsx
+++ b/components/onboarding-banner.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const DISMISSED_KEY = 'onboarding-banner-dismissed';
+
+export function OnboardingBanner() {
+  const t = useTranslations('Tenant.onboarding');
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem(DISMISSED_KEY);
+    if (!dismissed) setVisible(true);
+  }, []);
+
+  function dismiss() {
+    localStorage.setItem(DISMISSED_KEY, '1');
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div className="bg-primary/10 border-b border-primary/20 px-6 py-3 flex items-center justify-between gap-4">
+      <p className="text-sm">
+        {t('bannerText')}{' '}
+        <Link href="/admin/onboarding" className="font-medium underline underline-offset-2">
+          {t('bannerLink')}
+        </Link>
+      </p>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6 shrink-0"
+        onClick={dismiss}
+        aria-label={t('bannerDismiss')}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -312,6 +312,24 @@
       "statusRejected": "Rejected",
       "statusShipped": "Shipped"
     },
+    "onboarding": {
+      "title": "Set up your venue",
+      "subtitle": "Complete these steps to get your team up and running. You can always change these later in settings.",
+      "stepBranding": "Branding",
+      "stepLanguage": "Language",
+      "stepVenueTypes": "Venue Types",
+      "stepPoc": "Contacts",
+      "stepTeam": "Team",
+      "stepOf": "Step {current} of {total}",
+      "back": "Back",
+      "next": "Next",
+      "done": "Finish setup",
+      "finishing": "Finishing\u2026",
+      "skipAll": "Skip setup",
+      "bannerText": "Your venue isn\u2019t fully set up yet.",
+      "bannerLink": "Complete setup",
+      "bannerDismiss": "Dismiss"
+    },
     "venueType": {
       "title": "Venue Types",
       "add": "Add",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -312,6 +312,24 @@
       "statusRejected": "Refusée",
       "statusShipped": "Livrée"
     },
+    "onboarding": {
+      "title": "Configurer votre établissement",
+      "subtitle": "Suivez ces étapes pour préparer votre équipe. Vous pourrez toujours modifier ces paramètres plus tard dans les réglages.",
+      "stepBranding": "Identité",
+      "stepLanguage": "Langue",
+      "stepVenueTypes": "Types de lieu",
+      "stepPoc": "Contacts",
+      "stepTeam": "Équipe",
+      "stepOf": "Étape {current} sur {total}",
+      "back": "Retour",
+      "next": "Suivant",
+      "done": "Terminer la configuration",
+      "finishing": "Finalisation\u2026",
+      "skipAll": "Passer la configuration",
+      "bannerText": "Votre établissement n\u2019est pas encore entièrement configuré.",
+      "bannerLink": "Terminer la configuration",
+      "bannerDismiss": "Ignorer"
+    },
     "venueType": {
       "title": "Types de lieu",
       "add": "Ajouter",

--- a/supabase/migrations/00021_onboarding_completed.sql
+++ b/supabase/migrations/00021_onboarding_completed.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS onboarding_completed boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary

- Adds `onboarding_completed` boolean column to `tenants` (migration 00021, default `false`)
- New `completeOnboarding()` server action in `app/actions/tenants.ts`
- 5-step wizard at `/[tenant]/admin/onboarding` — Branding → Language → Venue Types → Contacts → Team
- Each step embeds the existing settings management components (no duplication)
- Back navigation, Skip all, and Finish buttons; marks `onboarding_completed = true` and redirects to home
- `/new` now redirects to `/admin/onboarding` instead of tenant home after account creation
- Dismissible banner on tenant home when `onboarding_completed = false` (dismiss state stored in localStorage)
- i18n keys added to `en.json` and `fr.json`

## Test plan

- [ ] Create a new venue via `/new` → confirm redirect lands on `/admin/onboarding`
- [ ] Step through all 5 wizard steps; verify Back/Next work and data saves within each step
- [ ] Click "Skip setup" → marks complete, redirects to home, banner does not reappear
- [ ] Click "Finish setup" on step 5 → same as above
- [ ] On tenant home with `onboarding_completed = false`, confirm banner is visible with "Complete setup" link
- [ ] Dismiss banner → confirm it's gone and stays gone on reload (localStorage)
- [ ] Visiting `/admin/onboarding` when already complete → redirects to `/`
- [ ] `pnpm build` passes ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)