### PR TITLE
T-22: Notifications system

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -981,7 +981,7 @@ In-app feature requests for tenants and triage for superadmins.
 
 ## Ticket 22: Notifications System
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P2  
 **Scope:** `supabase/migrations/`, `app/actions/notifications.ts` (new), `lib/notifications.ts` (new), `components/notification-bell.tsx` (new), `app/[tenant]/layout.tsx`  

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -18,6 +18,8 @@ import { PwaInstallPrompt } from '@/components/pwa-install-prompt';
 import { FeatureFlagProvider } from '@/lib/feature-flags-context';
 import { getFeatureFlags } from '@/app/actions/feature-flags';
 import { MobileNav } from '@/components/mobile-nav';
+import { NotificationBell } from '@/components/notification-bell';
+import { getUnreadCount } from '@/app/actions/notifications';
 import { getTenantToday } from '@/lib/day-utils';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -86,9 +88,10 @@ export default async function TenantLayout({
     ? ({ '--tenant-accent': accentColor } as React.CSSProperties)
     : undefined;
 
-  const [editor, t] = await Promise.all([
+  const [editor, t, unreadCount] = await Promise.all([
     isEditor(tenant.id),
     getTranslations('Tenant.nav'),
+    getUnreadCount(),
   ]);
 
   return (
@@ -109,6 +112,7 @@ export default async function TenantLayout({
                     <Settings className="h-4 w-4" />
                   </Link>
                 )}
+                <NotificationBell initialCount={unreadCount} />
                 {user && <UserMenu user={user} signOutLabel={t('signOut')} />}
               </div>
             </header>

--- a/app/actions/activities.ts
+++ b/app/actions/activities.ts
@@ -7,6 +7,7 @@ import { getUserRole, requireEditor } from '@/lib/membership';
 import { generateRecurrenceDates } from '@/lib/day-utils';
 import { activitySchema } from '@/lib/program-item-schema';
 import { ensureDayExists } from '@/app/actions/days';
+import { notifyTenantMembers, getDayDate } from '@/lib/notifications';
 import type { ActionResponse } from '@/types/actions';
 import type { Activity, ActivityWithRelations } from '@/types/index';
 import type { ActivityFormData } from '@/lib/program-item-schema';
@@ -68,7 +69,7 @@ export async function createActivity(
   }
 
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
   const data = parsed.data;
@@ -88,6 +89,12 @@ export async function createActivity(
       const tagErr = await assignTags(supabase, (row as Activity).id, tagIds);
       if (tagErr) return { success: false, error: tagErr };
     }
+
+    Promise.allSettled([
+      getDayDate(data.dayId).then((date) =>
+        notifyTenantMembers(tenantId, user.id, `Activity added: ${data.title}`, undefined, date ? `/day/${date}` : undefined)
+      ),
+    ]);
 
     return { success: true, data: row as Activity };
   }
@@ -147,6 +154,12 @@ export async function createActivity(
     if (tagErr) return { success: false, error: tagErr };
   }
 
+  Promise.allSettled([
+    getDayDate(data.dayId).then((date) =>
+      notifyTenantMembers(tenantId, user.id, `Activity added: ${data.title}`, undefined, date ? `/day/${date}` : undefined)
+    ),
+  ]);
+
   return { success: true, data: inserted as Activity };
 }
 
@@ -160,7 +173,7 @@ export async function updateActivity(
   }
 
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
   const data = parsed.data;
@@ -188,14 +201,28 @@ export async function updateActivity(
   const tagErr = await assignTags(supabase, id, data.tagIds ?? []);
   if (tagErr) return { success: false, error: tagErr };
 
+  Promise.allSettled([
+    getDayDate(data.dayId).then((date) =>
+      notifyTenantMembers(tenantId, user.id, `Activity updated: ${data.title}`, undefined, date ? `/day/${date}` : undefined)
+    ),
+  ]);
+
   return { success: true, data: row as Activity };
 }
 
 export async function deleteActivity(id: string): Promise<ActionResponse> {
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
+
+  const { data: existing } = await supabase
+    .from('activity')
+    .select('title, day_id')
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .maybeSingle();
+
   const { error } = await supabase
     .from('activity')
     .delete()
@@ -203,6 +230,16 @@ export async function deleteActivity(id: string): Promise<ActionResponse> {
     .eq('tenant_id', tenantId);
 
   if (error) return { success: false, error: error.message };
+
+  if (existing) {
+    const { title, day_id } = existing as { title: string; day_id: string };
+    Promise.allSettled([
+      getDayDate(day_id).then((date) =>
+        notifyTenantMembers(tenantId, user.id, `Activity removed: ${title}`, undefined, date ? `/day/${date}` : undefined)
+      ),
+    ]);
+  }
+
   return { success: true, data: undefined };
 }
 

--- a/app/actions/breakfast.ts
+++ b/app/actions/breakfast.ts
@@ -4,6 +4,7 @@ import { createTenantClient } from '@/lib/supabase-server';
 import { getTenantId } from '@/lib/tenant';
 import { requireEditor, getUserRole } from '@/lib/membership';
 import { createBreakfastSchema, updateBreakfastSchema } from '@/lib/breakfast-schema';
+import { notifyTenantMembers, getDayDate } from '@/lib/notifications';
 import type { CreateBreakfastFormData, UpdateBreakfastFormData } from '@/lib/breakfast-schema';
 import type { ActionResponse } from '@/types/actions';
 import type { BreakfastConfiguration } from '@/types/index';
@@ -24,7 +25,7 @@ export async function createBreakfastConfiguration(
   }
 
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
   const d = parsed.data;
@@ -54,6 +55,12 @@ export async function createBreakfastConfiguration(
     .single();
 
   if (error) return { success: false, error: error.message };
+
+  const label = d.groupName?.trim() || 'Unnamed group';
+  Promise.allSettled([
+    notifyTenantMembers(tenantId, user.id, `Breakfast added: ${label}`, undefined, `/day/${(dayRow as { date_iso: string }).date_iso}`),
+  ]);
+
   return { success: true, data: data as BreakfastConfiguration };
 }
 
@@ -67,7 +74,7 @@ export async function updateBreakfastConfiguration(
   }
 
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
   const d = parsed.data;
@@ -88,14 +95,31 @@ export async function updateBreakfastConfiguration(
     .single();
 
   if (error) return { success: false, error: error.message };
-  return { success: true, data: data as BreakfastConfiguration };
+
+  const row = data as BreakfastConfiguration;
+  const label = d.groupName?.trim() || 'Unnamed group';
+  Promise.allSettled([
+    getDayDate(row.day_id).then((date) =>
+      notifyTenantMembers(tenantId, user.id, `Breakfast updated: ${label}`, undefined, date ? `/day/${date}` : undefined)
+    ),
+  ]);
+
+  return { success: true, data: row };
 }
 
 export async function deleteBreakfastConfiguration(id: string): Promise<ActionResponse> {
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
+
+  const { data: existing } = await supabase
+    .from('breakfast_configuration')
+    .select('group_name, day_id')
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .maybeSingle();
+
   const { error } = await supabase
     .from('breakfast_configuration')
     .delete()
@@ -103,6 +127,17 @@ export async function deleteBreakfastConfiguration(id: string): Promise<ActionRe
     .eq('tenant_id', tenantId);
 
   if (error) return { success: false, error: error.message };
+
+  if (existing) {
+    const { group_name, day_id } = existing as { group_name: string | null; day_id: string };
+    const label = group_name?.trim() || 'Unnamed group';
+    Promise.allSettled([
+      getDayDate(day_id).then((date) =>
+        notifyTenantMembers(tenantId, user.id, `Breakfast removed: ${label}`, undefined, date ? `/day/${date}` : undefined)
+      ),
+    ]);
+  }
+
   return { success: true, data: undefined };
 }
 

--- a/app/actions/reservations.ts
+++ b/app/actions/reservations.ts
@@ -4,6 +4,7 @@ import { createTenantClient } from '@/lib/supabase-server';
 import { getTenantId } from '@/lib/tenant';
 import { getUserRole, requireEditor } from '@/lib/membership';
 import { reservationSchema } from '@/lib/reservation-schema';
+import { notifyTenantMembers, getDayDate } from '@/lib/notifications';
 import type { ReservationFormData } from '@/lib/reservation-schema';
 import type { ActionResponse } from '@/types/actions';
 import type { Reservation } from '@/types/index';
@@ -17,7 +18,7 @@ export async function createReservation(
   }
 
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
   const d = parsed.data;
@@ -38,6 +39,14 @@ export async function createReservation(
     .single();
 
   if (error) return { success: false, error: error.message };
+
+  const name = d.guestName?.trim() || 'Guest';
+  Promise.allSettled([
+    getDayDate(d.dayId).then((date) =>
+      notifyTenantMembers(tenantId, user.id, `Reservation added: ${name}`, undefined, date ? `/day/${date}` : undefined)
+    ),
+  ]);
+
   return { success: true, data: data as Reservation };
 }
 
@@ -51,7 +60,7 @@ export async function updateReservation(
   }
 
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
   const d = parsed.data;
@@ -73,14 +82,30 @@ export async function updateReservation(
     .single();
 
   if (error) return { success: false, error: error.message };
+
+  const name = d.guestName?.trim() || 'Guest';
+  Promise.allSettled([
+    getDayDate(d.dayId).then((date) =>
+      notifyTenantMembers(tenantId, user.id, `Reservation updated: ${name}`, undefined, date ? `/day/${date}` : undefined)
+    ),
+  ]);
+
   return { success: true, data: data as Reservation };
 }
 
 export async function deleteReservation(id: string): Promise<ActionResponse> {
   const tenantId = await getTenantId();
-  await requireEditor(tenantId);
+  const user = await requireEditor(tenantId);
 
   const { supabase } = await createTenantClient();
+
+  const { data: existing } = await supabase
+    .from('reservation')
+    .select('guest_name, day_id')
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .maybeSingle();
+
   const { error } = await supabase
     .from('reservation')
     .delete()
@@ -88,6 +113,17 @@ export async function deleteReservation(id: string): Promise<ActionResponse> {
     .eq('tenant_id', tenantId);
 
   if (error) return { success: false, error: error.message };
+
+  if (existing) {
+    const { guest_name, day_id } = existing as { guest_name: string | null; day_id: string };
+    const name = guest_name?.trim() || 'Guest';
+    Promise.allSettled([
+      getDayDate(day_id).then((date) =>
+        notifyTenantMembers(tenantId, user.id, `Reservation removed: ${name}`, undefined, date ? `/day/${date}` : undefined)
+      ),
+    ]);
+  }
+
   return { success: true, data: undefined };
 }
 


### PR DESCRIPTION
## Summary

The migration, actions file, \`lib/notifications.ts\`, and \`NotificationBell\` component were already in the repo. This PR completes the wiring:

- **Bell in layout**: \`NotificationBell\` added to tenant header; initial unread count fetched server-side on each page load
- **Mutation hooks**: \`notifyTenantMembers\` called fire-and-forget (\`Promise.allSettled\`) from all 9 mutating actions:
  - \`createActivity\`, \`updateActivity\`, \`deleteActivity\`
  - \`createReservation\`, \`updateReservation\`, \`deleteReservation\`
  - \`createBreakfastConfiguration\`, \`updateBreakfastConfiguration\`, \`deleteBreakfastConfiguration\`
- Notifications include a deep-link to \`/day/{date}\` resolved via \`getDayDate\`
- Delete actions fetch the record before deletion to populate the notification title

## Test plan

- [ ] Create an activity as editor A → editor B sees badge on bell within 30s poll
- [ ] Open bell popover → notification shows title and link
- [ ] Click notification → marks read, navigates to day view
- [ ] "Mark all read" clears the badge
- [ ] Update and delete mutations also produce notifications
- [ ] Reservation and breakfast mutations produce notifications
- [ ] \`pnpm build\` passes ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)