### PR TITLE
T-24: Day notes & comments

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1032,7 +1032,7 @@ Stronger recurrence for **activities** (formerly program items).
 
 ## Ticket 24: Day Notes & Comments
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** completed.
 
 **Priority:** P2  
 **Scope:** `supabase/migrations/`, `app/actions/day-notes.ts` (new), `app/[tenant]/day/[date]/DayViewClient.tsx`, `app/[tenant]/day/[date]/queries.ts`  

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -12,6 +12,7 @@ import { ReservationForm } from '@/components/reservation-form';
 import { ReservationCard } from '@/components/reservation-card';
 import { BreakfastForm } from '@/components/breakfast-form';
 import { BreakfastCard } from '@/components/breakfast-card';
+import { DayNotes } from '@/components/day-notes';
 import { Button } from '@/components/ui/button';
 import { useFeatureFlag } from '@/lib/feature-flags-context';
 import type {
@@ -29,6 +30,7 @@ export function DayViewClient({
   activities: initialActivities,
   reservations: initialReservations,
   breakfastConfigs: initialBreakfastConfigs,
+  dayNotes,
   pocs,
   venueTypes,
   authState,
@@ -164,6 +166,7 @@ export function DayViewClient({
         activities={activities}
         reservations={reservations}
         breakfastConfigs={breakfastConfigs}
+        dayNotes={dayNotes}
       />
     );
   }
@@ -171,6 +174,13 @@ export function DayViewClient({
   return (
     <div className="max-w-3xl mx-auto px-3 sm:px-6 py-4 sm:py-8 space-y-6">
       <DayNav date={date} today={today} />
+
+      <DayNotes
+        dayId={dayId}
+        initialNotes={dayNotes}
+        isEditor={authState.isEditor}
+        currentUserId={authState.user?.id}
+      />
 
       <DaySummaryCard
         activities={activities}

--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -11,6 +11,7 @@ import {
   getProgramItemsForDay,
   getReservationsForDay,
   getBreakfastConfigsForDay,
+  getDayNotesForDay,
 } from './queries';
 import { DayViewClient } from './DayViewClient';
 import type {
@@ -21,6 +22,7 @@ import type {
   VenueType,
 } from '@/types/index';
 import type { AuthState } from '@/types/actions';
+import type { DayNote } from '@/app/actions/day-notes';
 
 export type DayViewProps = {
   date: string;
@@ -29,6 +31,7 @@ export type DayViewProps = {
   activities: Activity[];
   reservations: Reservation[];
   breakfastConfigs: BreakfastConfiguration[];
+  dayNotes: DayNote[];
   pocs: PointOfContact[];
   venueTypes: VenueType[];
   authState: AuthState;
@@ -75,6 +78,7 @@ export default async function DayPage({
     activities,
     reservations,
     breakfastConfigs,
+    dayNotes,
     pocsResult,
     venueTypesResult,
     authState,
@@ -82,6 +86,7 @@ export default async function DayPage({
     getProgramItemsForDay(tenant.id, day.id),
     getReservationsForDay(tenant.id, day.id),
     getBreakfastConfigsForDay(tenant.id, day.id),
+    getDayNotesForDay(tenant.id, day.id),
     getAllPOCs(),
     getAllVenueTypes(),
     getAuthState(),
@@ -95,6 +100,7 @@ export default async function DayPage({
       activities={activities}
       reservations={reservations}
       breakfastConfigs={breakfastConfigs}
+      dayNotes={dayNotes}
       pocs={pocsResult.success ? pocsResult.data : []}
       venueTypes={venueTypesResult.success ? venueTypesResult.data : []}
       authState={authState}

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -1,5 +1,6 @@
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index';
+import type { DayNote } from '@/app/actions/day-notes';
 
 export async function getProgramItemsForDay(
   tenantId: string,
@@ -41,4 +42,18 @@ export async function getBreakfastConfigsForDay(
     .eq('day_id', dayId)
     .order('start_time', { nullsFirst: true });
   return (data ?? []) as unknown as BreakfastConfiguration[];
+}
+
+export async function getDayNotesForDay(
+  tenantId: string,
+  dayId: string
+): Promise<DayNote[]> {
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('day_notes')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .order('created_at', { ascending: true });
+  return (data ?? []) as unknown as DayNote[];
 }

--- a/app/actions/day-notes.ts
+++ b/app/actions/day-notes.ts
@@ -1,0 +1,108 @@
+'use server';
+
+import { createTenantClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { getUserRole, requireEditor } from '@/lib/membership';
+import type { ActionResponse } from '@/types/actions';
+
+const MAX_LEN = 2000;
+
+export interface DayNote {
+  id: string;
+  tenant_id: string;
+  day_id: string;
+  user_id: string;
+  author_name: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getDayNotes(dayId: string): Promise<ActionResponse<DayNote[]>> {
+  const tenantId = await getTenantId();
+  const role = await getUserRole(tenantId);
+  if (!role) return { success: false, error: 'Not authorized.' };
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('day_notes')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .order('created_at', { ascending: true });
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: (data ?? []) as DayNote[] };
+}
+
+export async function createDayNote(
+  dayId: string,
+  content: string
+): Promise<ActionResponse<DayNote>> {
+  const trimmed = content.trim();
+  if (!trimmed || trimmed.length > MAX_LEN) {
+    return { success: false, error: `Note must be 1–${MAX_LEN} characters.` };
+  }
+
+  const tenantId = await getTenantId();
+  const user = await requireEditor(tenantId);
+  const authorName = user.email ?? user.id;
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('day_notes')
+    .insert({
+      tenant_id: tenantId,
+      day_id: dayId,
+      user_id: user.id,
+      author_name: authorName,
+      content: trimmed,
+    })
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as DayNote };
+}
+
+export async function updateDayNote(
+  id: string,
+  content: string
+): Promise<ActionResponse<DayNote>> {
+  const trimmed = content.trim();
+  if (!trimmed || trimmed.length > MAX_LEN) {
+    return { success: false, error: `Note must be 1–${MAX_LEN} characters.` };
+  }
+
+  const tenantId = await getTenantId();
+  const user = await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('day_notes')
+    .update({ content: trimmed, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .eq('user_id', user.id)
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as DayNote };
+}
+
+export async function deleteDayNote(id: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  const user = await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { error } = await supabase
+    .from('day_notes')
+    .delete()
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .eq('user_id', user.id);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}

--- a/components/day-notes.tsx
+++ b/components/day-notes.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+import { Pencil, Trash2, Check, X } from 'lucide-react';
+import { createDayNote, updateDayNote, deleteDayNote } from '@/app/actions/day-notes';
+import type { DayNote } from '@/app/actions/day-notes';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+
+const MAX_LEN = 2000;
+
+interface DayNotesProps {
+  dayId: string;
+  initialNotes: DayNote[];
+  isEditor: boolean;
+  currentUserId: string | undefined;
+}
+
+export function DayNotes({ dayId, initialNotes, isEditor, currentUserId }: DayNotesProps) {
+  const [notes, setNotes] = useState<DayNote[]>(initialNotes);
+  const [draft, setDraft] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState('');
+  const [isSaving, startSaveTransition] = useTransition();
+  const [isDeleting, startDeleteTransition] = useTransition();
+
+  function handleAdd() {
+    if (!draft.trim()) return;
+    startSaveTransition(async () => {
+      const result = await createDayNote(dayId, draft);
+      if (!result.success) { toast.error(result.error); return; }
+      setNotes((prev) => [...prev, result.data]);
+      setDraft('');
+      toast.success('Note added.');
+    });
+  }
+
+  function startEdit(note: DayNote) {
+    setEditingId(note.id);
+    setEditDraft(note.content);
+  }
+
+  function handleUpdate(id: string) {
+    if (!editDraft.trim()) return;
+    startSaveTransition(async () => {
+      const result = await updateDayNote(id, editDraft);
+      if (!result.success) { toast.error(result.error); return; }
+      setNotes((prev) => prev.map((n) => (n.id === id ? result.data : n)));
+      setEditingId(null);
+      toast.success('Note updated.');
+    });
+  }
+
+  function handleDelete(id: string) {
+    startDeleteTransition(async () => {
+      const result = await deleteDayNote(id);
+      if (!result.success) { toast.error(result.error); return; }
+      setNotes((prev) => prev.filter((n) => n.id !== id));
+      toast.success('Note deleted.');
+    });
+  }
+
+  if (notes.length === 0 && !isEditor) return null;
+
+  return (
+    <section className="space-y-3">
+      <h2 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">
+        Notes
+      </h2>
+
+      {notes.length > 0 && (
+        <div className="space-y-2">
+          {notes.map((note) => {
+            const isOwn = note.user_id === currentUserId;
+            const isEditing = editingId === note.id;
+
+            return (
+              <div
+                key={note.id}
+                className="rounded-md border bg-muted/30 px-4 py-3 space-y-1.5"
+              >
+                {isEditing ? (
+                  <div className="space-y-2">
+                    <Textarea
+                      value={editDraft}
+                      onChange={(e) => setEditDraft(e.target.value)}
+                      rows={3}
+                      maxLength={MAX_LEN}
+                      autoFocus
+                      className="text-sm"
+                    />
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setEditingId(null)}
+                        disabled={isSaving}
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        onClick={() => handleUpdate(note.id)}
+                        disabled={isSaving || !editDraft.trim()}
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <p className="text-sm whitespace-pre-wrap">{note.content}</p>
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-xs text-muted-foreground">
+                        {note.author_name} · {formatDate(note.created_at)}
+                        {note.updated_at !== note.created_at && ' (edited)'}
+                      </p>
+                      {isEditor && isOwn && (
+                        <div className="flex gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6"
+                            onClick={() => startEdit(note)}
+                            disabled={isDeleting}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 text-destructive hover:text-destructive"
+                            onClick={() => handleDelete(note.id)}
+                            disabled={isDeleting}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {isEditor && (
+        <div className="space-y-2">
+          <Textarea
+            placeholder="Add a note for this day…"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={2}
+            maxLength={MAX_LEN}
+            className="text-sm"
+          />
+          <div className="flex justify-between items-center">
+            <span className="text-xs text-muted-foreground">
+              {draft.length}/{MAX_LEN}
+            </span>
+            <Button
+              size="sm"
+              onClick={handleAdd}
+              disabled={isSaving || !draft.trim()}
+            >
+              Add note
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/components/viewer-day-dashboard.tsx
+++ b/components/viewer-day-dashboard.tsx
@@ -2,8 +2,10 @@
 
 import { useTranslations } from 'next-intl';
 import { DayNav } from '@/components/day-nav';
+import { DayNotes } from '@/components/day-notes';
 import { TableBreakdownDisplay } from '@/components/table-breakdown-display';
 import type { ActivityWithRelations, Reservation, BreakfastConfiguration } from '@/types/index';
+import type { DayNote } from '@/app/actions/day-notes';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -15,6 +17,7 @@ type Props = {
   activities: ActivityWithRelations[];
   reservations: Reservation[];
   breakfastConfigs: BreakfastConfiguration[];
+  dayNotes: DayNote[];
 };
 
 // ---------------------------------------------------------------------------
@@ -27,6 +30,7 @@ export function ViewerDayDashboard({
   activities,
   reservations,
   breakfastConfigs,
+  dayNotes,
 }: Props) {
   const td = useTranslations('Tenant.day');
   const ts = useTranslations('Tenant.summary');
@@ -40,6 +44,13 @@ export function ViewerDayDashboard({
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 py-6 space-y-6">
       <DayNav date={date} today={today} />
+
+      <DayNotes
+        dayId={date}
+        initialNotes={dayNotes}
+        isEditor={false}
+        currentUserId={undefined}
+      />
 
       {/* Summary — large numbers for at-a-glance reading */}
       <div className="grid grid-cols-3 gap-3">

--- a/supabase/migrations/00022_day_notes.sql
+++ b/supabase/migrations/00022_day_notes.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- Migration 00022: Day notes
+-- =============================================================================
+
+CREATE TABLE day_notes (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  day_id      uuid NOT NULL REFERENCES day(id) ON DELETE CASCADE,
+  user_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  author_name text NOT NULL,
+  content     text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX day_notes_day_idx ON day_notes (day_id, created_at);
+
+ALTER TABLE day_notes ENABLE ROW LEVEL SECURITY;
+
+-- Any tenant member can read notes
+CREATE POLICY "day_notes: members can select"
+  ON day_notes FOR SELECT TO authenticated
+  USING (is_tenant_member(tenant_id));
+
+-- Editors can insert their own notes
+CREATE POLICY "day_notes: editors can insert"
+  ON day_notes FOR INSERT TO authenticated
+  WITH CHECK (is_tenant_editor(tenant_id) AND user_id = auth.uid());
+
+-- Editors can update only their own notes
+CREATE POLICY "day_notes: editors can update own"
+  ON day_notes FOR UPDATE TO authenticated
+  USING (is_tenant_editor(tenant_id) AND user_id = auth.uid())
+  WITH CHECK (is_tenant_editor(tenant_id) AND user_id = auth.uid());
+
+-- Editors can delete only their own notes
+CREATE POLICY "day_notes: editors can delete own"
+  ON day_notes FOR DELETE TO authenticated
+  USING (is_tenant_editor(tenant_id) AND user_id = auth.uid());


### PR DESCRIPTION
## Summary

- **Migration 00022**: \`day_notes\` table — \`tenant_id\`, \`day_id\`, \`user_id\`, \`author_name\` (denormalised), \`content\`, timestamps. RLS: editors full CRUD on own rows; all members SELECT.
- **\`app/actions/day-notes.ts\`**: \`getDayNotes\`, \`createDayNote\`, \`updateDayNote\`, \`deleteDayNote\` — content validated 1–2000 chars; update/delete scoped to own rows via \`user_id = auth.uid()\`.
- **\`components/day-notes.tsx\`**: inline note list at top of day view — editors add/edit/delete their own notes; viewers see read-only. Content renders with \`whitespace-pre-wrap\`. Shows author email, timestamp, and *(edited)* when updated.
- **\`queries.ts\`**: \`getDayNotesForDay\` fetched server-side.
- **\`page.tsx\`**: notes fetched in parallel with existing day data; passed via \`DayViewProps\`.
- **\`DayViewClient\`**: \`DayNotes\` rendered above the summary card for editors.
- **\`ViewerDayDashboard\`**: \`DayNotes\` rendered read-only above the summary stats.

## Test plan

- [ ] Editor adds a note → appears in list immediately
- [ ] Editor edits own note → content updates, shows *(edited)*
- [ ] Editor deletes own note → removed from list
- [ ] Editor cannot edit/delete another editor's note (buttons hidden)
- [ ] Viewer sees notes but has no add/edit/delete controls
- [ ] Content with newlines renders correctly (whitespace-pre-wrap)
- [ ] Empty note or note >2000 chars shows error
- [ ] \`pnpm build\` passes ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)