### PR TITLE
T-25: Weather integration

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1052,7 +1052,7 @@ Day-level internal notes.
 
 ## Ticket 25: Weather Integration
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** done.
 
 **Priority:** P2  
 **Scope:** `app/[tenant]/day/[date]/DayViewClient.tsx`, `app/actions/weather.ts` (new), `supabase/migrations/`, `app/[tenant]/admin/settings/`  

--- a/app/[tenant]/admin/onboarding/onboarding-wizard.tsx
+++ b/app/[tenant]/admin/onboarding/onboarding-wizard.tsx
@@ -124,6 +124,8 @@ export function OnboardingWizard({
             tenantId={tenantId}
             initialAccentColor={initialAccentColor}
             initialLogoUrl={initialLogoUrl}
+            initialLatitude={null}
+            initialLongitude={null}
           />
         )}
         {STEPS[currentStep] === 'language' && <LanguageSettings />}

--- a/app/[tenant]/admin/settings/client.tsx
+++ b/app/[tenant]/admin/settings/client.tsx
@@ -23,9 +23,11 @@ interface SettingsClientProps {
   currentUserId: string;
   initialAccentColor: string | null;
   initialLogoUrl: string | null;
+  initialLatitude: number | null;
+  initialLongitude: number | null;
 }
 
-export function SettingsClient({ tenantId, currentUserId, initialAccentColor, initialLogoUrl }: SettingsClientProps) {
+export function SettingsClient({ tenantId, currentUserId, initialAccentColor, initialLogoUrl, initialLatitude, initialLongitude }: SettingsClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const t = useTranslations('Tenant.settings');
@@ -73,6 +75,8 @@ export function SettingsClient({ tenantId, currentUserId, initialAccentColor, in
             tenantId={tenantId}
             initialAccentColor={initialAccentColor}
             initialLogoUrl={initialLogoUrl}
+            initialLatitude={initialLatitude}
+            initialLongitude={initialLongitude}
           />
         </TabsContent>
 

--- a/app/[tenant]/admin/settings/page.tsx
+++ b/app/[tenant]/admin/settings/page.tsx
@@ -10,19 +10,25 @@ export default async function SettingsPage() {
   const supabase = await createSupabaseServerClient();
   const { data } = await supabase
     .from('tenants')
-    .select('accent_color, logo_url')
+    .select('accent_color, logo_url, latitude, longitude')
     .eq('id', tenant.id)
     .single();
 
-  const accentColor = (data as { accent_color?: string | null } | null)?.accent_color ?? null;
-  const logoUrl = (data as { logo_url?: string | null } | null)?.logo_url ?? null;
+  const row = data as {
+    accent_color?: string | null;
+    logo_url?: string | null;
+    latitude?: number | null;
+    longitude?: number | null;
+  } | null;
 
   return (
     <SettingsClient
       tenantId={tenant.id}
       currentUserId={user.id}
-      initialAccentColor={accentColor}
-      initialLogoUrl={logoUrl}
+      initialAccentColor={row?.accent_color ?? null}
+      initialLogoUrl={row?.logo_url ?? null}
+      initialLatitude={row?.latitude ?? null}
+      initialLongitude={row?.longitude ?? null}
     />
   );
 }

--- a/app/[tenant]/admin/settings/settings-form.tsx
+++ b/app/[tenant]/admin/settings/settings-form.tsx
@@ -14,11 +14,15 @@ interface SettingsFormProps {
   tenantId: string;
   initialAccentColor: string | null;
   initialLogoUrl: string | null;
+  initialLatitude: number | null;
+  initialLongitude: number | null;
 }
 
-export function SettingsForm({ tenantId, initialAccentColor, initialLogoUrl }: SettingsFormProps) {
+export function SettingsForm({ tenantId, initialAccentColor, initialLogoUrl, initialLatitude, initialLongitude }: SettingsFormProps) {
   const [accentColor, setAccentColor] = useState(initialAccentColor ?? '#1a1a1a');
   const [logoUrl, setLogoUrl] = useState(initialLogoUrl ?? '');
+  const [latitude, setLatitude] = useState(initialLatitude != null ? String(initialLatitude) : '');
+  const [longitude, setLongitude] = useState(initialLongitude != null ? String(initialLongitude) : '');
   const [uploading, setUploading] = useState(false);
   const [saving, setSaving] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -66,9 +70,14 @@ export function SettingsForm({ tenantId, initialAccentColor, initialLogoUrl }: S
   async function handleSave() {
     setSaving(true);
     try {
+      const lat = latitude.trim() ? parseFloat(latitude) : null;
+      const lon = longitude.trim() ? parseFloat(longitude) : null;
+
       const result = await updateTenant(tenantId, {
         accent_color: accentColor || null,
         logo_url: logoUrl || null,
+        latitude: lat != null && !isNaN(lat) ? lat : null,
+        longitude: lon != null && !isNaN(lon) ? lon : null,
       });
 
       if (!result.success) {
@@ -166,6 +175,50 @@ export function SettingsForm({ tenantId, initialAccentColor, initialLogoUrl }: S
               {uploading ? 'Uploading…' : logoUrl ? 'Replace logo' : 'Upload logo'}
             </Button>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Location */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Location</CardTitle>
+          <CardDescription>
+            Used to show weather forecasts on the day view.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="latitude">Latitude</Label>
+              <Input
+                id="latitude"
+                type="number"
+                step="any"
+                min={-90}
+                max={90}
+                placeholder="51.5074"
+                value={latitude}
+                onChange={(e) => setLatitude(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="longitude">Longitude</Label>
+              <Input
+                id="longitude"
+                type="number"
+                step="any"
+                min={-180}
+                max={180}
+                placeholder="-0.1278"
+                value={longitude}
+                onChange={(e) => setLongitude(e.target.value)}
+              />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Decimal degrees. Find your coordinates at{' '}
+            <span className="font-mono">maps.google.com</span> → right-click → &ldquo;What&rsquo;s here?&rdquo;
+          </p>
         </CardContent>
       </Card>
 

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -13,6 +13,7 @@ import { ReservationCard } from '@/components/reservation-card';
 import { BreakfastForm } from '@/components/breakfast-form';
 import { BreakfastCard } from '@/components/breakfast-card';
 import { DayNotes } from '@/components/day-notes';
+import { WeatherCard } from '@/components/weather-card';
 import { Button } from '@/components/ui/button';
 import { useFeatureFlag } from '@/lib/feature-flags-context';
 import type {
@@ -31,6 +32,7 @@ export function DayViewClient({
   reservations: initialReservations,
   breakfastConfigs: initialBreakfastConfigs,
   dayNotes,
+  weather,
   pocs,
   venueTypes,
   authState,
@@ -167,6 +169,7 @@ export function DayViewClient({
         reservations={reservations}
         breakfastConfigs={breakfastConfigs}
         dayNotes={dayNotes}
+        weather={weather}
       />
     );
   }
@@ -174,6 +177,8 @@ export function DayViewClient({
   return (
     <div className="max-w-3xl mx-auto px-3 sm:px-6 py-4 sm:py-8 space-y-6">
       <DayNav date={date} today={today} />
+
+      {weather && <WeatherCard weather={weather} />}
 
       <DayNotes
         dayId={dayId}

--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -23,6 +23,8 @@ import type {
 } from '@/types/index';
 import type { AuthState } from '@/types/actions';
 import type { DayNote } from '@/app/actions/day-notes';
+import { getWeatherForDay } from '@/app/actions/weather';
+import type { WeatherData } from '@/app/actions/weather';
 
 export type DayViewProps = {
   date: string;
@@ -32,6 +34,7 @@ export type DayViewProps = {
   reservations: Reservation[];
   breakfastConfigs: BreakfastConfiguration[];
   dayNotes: DayNote[];
+  weather: WeatherData | null;
   pocs: PointOfContact[];
   venueTypes: VenueType[];
   authState: AuthState;
@@ -79,6 +82,7 @@ export default async function DayPage({
     reservations,
     breakfastConfigs,
     dayNotes,
+    weather,
     pocsResult,
     venueTypesResult,
     authState,
@@ -87,6 +91,7 @@ export default async function DayPage({
     getReservationsForDay(tenant.id, day.id),
     getBreakfastConfigsForDay(tenant.id, day.id),
     getDayNotesForDay(tenant.id, day.id),
+    getWeatherForDay(date),
     getAllPOCs(),
     getAllVenueTypes(),
     getAuthState(),
@@ -101,6 +106,7 @@ export default async function DayPage({
       reservations={reservations}
       breakfastConfigs={breakfastConfigs}
       dayNotes={dayNotes}
+      weather={weather}
       pocs={pocsResult.success ? pocsResult.data : []}
       venueTypes={venueTypesResult.success ? venueTypesResult.data : []}
       authState={authState}

--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -129,7 +129,7 @@ export async function getTenantBySlug(
 // ---------------------------------------------------------------------------
 export async function updateTenant(
   id: string,
-  data: { name?: string; slug?: string; logo_url?: string | null; accent_color?: string | null; timezone?: string; language?: string }
+  data: { name?: string; slug?: string; logo_url?: string | null; accent_color?: string | null; timezone?: string; language?: string; latitude?: number | null; longitude?: number | null; onboarding_completed?: boolean }
 ): Promise<ActionResponse<TenantRedisData>> {
   const serviceClient = createSupabaseServiceClient();
 

--- a/app/actions/weather.ts
+++ b/app/actions/weather.ts
@@ -1,0 +1,107 @@
+'use server';
+
+import { redis } from '@/lib/redis';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getTenantFromHeaders } from '@/lib/tenant';
+
+const CACHE_TTL = 1800; // 30 minutes
+
+export interface WeatherData {
+  date: string;
+  weatherCode: number;
+  description: string;
+  tempMax: number;
+  tempMin: number;
+  precipitationProbability: number;
+  emoji: string;
+}
+
+export async function getWeatherForDay(date: string): Promise<WeatherData | null> {
+  const tenant = await getTenantFromHeaders();
+
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase
+    .from('tenants')
+    .select('latitude, longitude, timezone')
+    .eq('id', tenant.id)
+    .single();
+
+  const row = data as {
+    latitude?: number | null;
+    longitude?: number | null;
+    timezone?: string | null;
+  } | null;
+
+  if (!row?.latitude || !row?.longitude) return null;
+
+  const cacheKey = `weather:${tenant.id}:${date}`;
+
+  try {
+    const cached = await redis.get(cacheKey);
+    if (cached) return JSON.parse(cached) as WeatherData;
+  } catch {
+    // Redis failure — proceed to fetch
+  }
+
+  try {
+    const url = new URL('https://api.open-meteo.com/v1/forecast');
+    url.searchParams.set('latitude', String(row.latitude));
+    url.searchParams.set('longitude', String(row.longitude));
+    url.searchParams.set('daily', 'weathercode,temperature_2m_max,temperature_2m_min,precipitation_probability_max');
+    url.searchParams.set('timezone', row.timezone ?? 'UTC');
+    url.searchParams.set('start_date', date);
+    url.searchParams.set('end_date', date);
+
+    const res = await fetch(url.toString(), { cache: 'no-store' });
+    if (!res.ok) return null;
+
+    const json = await res.json();
+    const daily = json?.daily;
+    if (!daily?.time?.length) return null;
+
+    const code: number = daily.weathercode?.[0] ?? 0;
+    const weather: WeatherData = {
+      date,
+      weatherCode: code,
+      description: codeToDescription(code),
+      emoji: codeToEmoji(code),
+      tempMax: Math.round(daily.temperature_2m_max?.[0] ?? 0),
+      tempMin: Math.round(daily.temperature_2m_min?.[0] ?? 0),
+      precipitationProbability: daily.precipitation_probability_max?.[0] ?? 0,
+    };
+
+    try {
+      await redis.setex(cacheKey, CACHE_TTL, JSON.stringify(weather));
+    } catch {
+      // Redis write failure is non-fatal
+    }
+
+    return weather;
+  } catch {
+    return null;
+  }
+}
+
+function codeToDescription(code: number): string {
+  if (code === 0) return 'Clear sky';
+  if (code <= 3) return 'Partly cloudy';
+  if (code <= 48) return 'Foggy';
+  if (code <= 57) return 'Drizzle';
+  if (code <= 67) return 'Rain';
+  if (code <= 77) return 'Snow';
+  if (code <= 82) return 'Showers';
+  if (code <= 86) return 'Snow showers';
+  return 'Thunderstorm';
+}
+
+function codeToEmoji(code: number): string {
+  if (code === 0) return '☀️';
+  if (code <= 3) return '⛅';
+  if (code <= 48) return '🌫️';
+  if (code <= 57) return '🌦️';
+  if (code <= 67) return '🌧️';
+  if (code <= 77) return '❄️';
+  if (code <= 82) return '🌦️';
+  if (code <= 86) return '🌨️';
+  return '⛈️';
+}

--- a/components/viewer-day-dashboard.tsx
+++ b/components/viewer-day-dashboard.tsx
@@ -3,9 +3,11 @@
 import { useTranslations } from 'next-intl';
 import { DayNav } from '@/components/day-nav';
 import { DayNotes } from '@/components/day-notes';
+import { WeatherCard } from '@/components/weather-card';
 import { TableBreakdownDisplay } from '@/components/table-breakdown-display';
 import type { ActivityWithRelations, Reservation, BreakfastConfiguration } from '@/types/index';
 import type { DayNote } from '@/app/actions/day-notes';
+import type { WeatherData } from '@/app/actions/weather';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,6 +20,7 @@ type Props = {
   reservations: Reservation[];
   breakfastConfigs: BreakfastConfiguration[];
   dayNotes: DayNote[];
+  weather: WeatherData | null;
 };
 
 // ---------------------------------------------------------------------------
@@ -31,6 +34,7 @@ export function ViewerDayDashboard({
   reservations,
   breakfastConfigs,
   dayNotes,
+  weather,
 }: Props) {
   const td = useTranslations('Tenant.day');
   const ts = useTranslations('Tenant.summary');
@@ -44,6 +48,8 @@ export function ViewerDayDashboard({
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 py-6 space-y-6">
       <DayNav date={date} today={today} />
+
+      {weather && <WeatherCard weather={weather} />}
 
       <DayNotes
         dayId={date}

--- a/components/weather-card.tsx
+++ b/components/weather-card.tsx
@@ -1,0 +1,20 @@
+import type { WeatherData } from '@/app/actions/weather';
+
+export function WeatherCard({ weather }: { weather: WeatherData }) {
+  return (
+    <div className="flex items-center gap-4 rounded-lg border bg-muted/30 px-4 py-3">
+      <span className="text-3xl leading-none" aria-hidden="true">
+        {weather.emoji}
+      </span>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">{weather.description}</p>
+        <p className="text-xs text-muted-foreground">
+          {weather.tempMax}° / {weather.tempMin}°C
+          {weather.precipitationProbability > 0 && (
+            <> · {weather.precipitationProbability}% rain</>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/00023_tenant_coordinates.sql
+++ b/supabase/migrations/00023_tenant_coordinates.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS latitude  double precision,
+  ADD COLUMN IF NOT EXISTS longitude double precision;


### PR DESCRIPTION
## Summary
- Adds `latitude`/`longitude` columns to `tenants` table (migration `00023_tenant_coordinates.sql`)
- New `app/actions/weather.ts` — fetches Open-Meteo daily forecast, caches in Redis (30 min TTL)
- New `components/weather-card.tsx` — displays weather emoji, description, high/low temp, precipitation chance
- `WeatherCard` rendered on day view for both editor and viewer
- Tenant settings → Branding tab gains a Location card with lat/lon inputs
- Fixes onboarding wizard — passes `initialLatitude`/`initialLongitude` to `SettingsForm`

## Test plan
- [ ] Set lat/lon in Settings → Branding → save
- [ ] Open any day view — weather card appears above notes
- [ ] Viewer dashboard also shows weather card
- [ ] No lat/lon set → no weather card rendered (graceful null)
- [ ] Redis cache: second load fetches from cache (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)