### PR TITLE
T-26: Copy & template day schedules

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1070,7 +1070,7 @@ Forecast in day view via Open-Meteo; Redis cache.
 
 ## Ticket 26: Copy & Template Day Schedules
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** done.
 
 **Priority:** P2  
 **Scope:** `supabase/migrations/`, `app/actions/schedule-templates.ts` (new), `app/[tenant]/day/[date]/DayViewClient.tsx`  

--- a/app/[tenant]/admin/settings/client.tsx
+++ b/app/[tenant]/admin/settings/client.tsx
@@ -8,10 +8,11 @@ import { VenueTypeManagement } from '@/components/venue-type-management';
 import { ActivityTagManagement } from '@/components/activity-tag-management';
 import { MemberManagement } from '@/components/member-management';
 import { FeatureRequestManagement } from '@/components/feature-request-management';
+import { ScheduleTemplateManagement } from '@/components/schedule-template-management';
 import { SettingsForm } from './settings-form';
 import { LanguageSettings } from './language-settings';
 
-const TABS = ['poc', 'venue-types', 'activity-tags', 'branding', 'language', 'members', 'feedback'] as const;
+const TABS = ['poc', 'venue-types', 'activity-tags', 'branding', 'language', 'members', 'templates', 'feedback'] as const;
 type Tab = (typeof TABS)[number];
 
 function isValidTab(v: string | null): v is Tab {
@@ -54,6 +55,7 @@ export function SettingsClient({ tenantId, currentUserId, initialAccentColor, in
             <TabsTrigger value="branding">{t('tabBranding')}</TabsTrigger>
             <TabsTrigger value="language">{t('tabLanguage')}</TabsTrigger>
             <TabsTrigger value="members">{t('tabMembers')}</TabsTrigger>
+            <TabsTrigger value="templates">{t('tabTemplates')}</TabsTrigger>
             <TabsTrigger value="feedback">{t('tabFeedback')}</TabsTrigger>
           </TabsList>
         </div>
@@ -86,6 +88,10 @@ export function SettingsClient({ tenantId, currentUserId, initialAccentColor, in
 
         <TabsContent value="members">
           <MemberManagement currentUserId={currentUserId} />
+        </TabsContent>
+
+        <TabsContent value="templates">
+          <ScheduleTemplateManagement />
         </TabsContent>
 
         <TabsContent value="feedback">

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Plus } from 'lucide-react';
+import { Plus, Copy, LayoutTemplate } from 'lucide-react';
 import { DayNav } from '@/components/day-nav';
 import { DaySummaryCard } from '@/components/day-summary-card';
 import { ViewerDayDashboard } from '@/components/viewer-day-dashboard';
@@ -14,6 +14,8 @@ import { BreakfastForm } from '@/components/breakfast-form';
 import { BreakfastCard } from '@/components/breakfast-card';
 import { DayNotes } from '@/components/day-notes';
 import { WeatherCard } from '@/components/weather-card';
+import { CopyDayDialog } from '@/components/copy-day-dialog';
+import { TemplateDialog } from '@/components/template-dialog';
 import { Button } from '@/components/ui/button';
 import { useFeatureFlag } from '@/lib/feature-flags-context';
 import type {
@@ -61,6 +63,10 @@ export function DayViewClient({
   // Breakfast modal state
   const [breakfastModalOpen, setBreakfastModalOpen] = useState(false);
   const [editBreakfast, setEditBreakfast] = useState<BreakfastConfiguration | null>(null);
+
+  // Copy / template modal state
+  const [copyDayOpen, setCopyDayOpen] = useState(false);
+  const [templateOpen, setTemplateOpen] = useState(false);
 
   // ---------- Activity handlers ----------
 
@@ -225,12 +231,20 @@ export function DayViewClient({
       {/* Activities */}
       {showActivities && (
         <section className="space-y-3">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-2">
             <h2 className="font-semibold">{t('activities')}</h2>
             {authState.isEditor && (
-              <Button size="sm" onClick={openAddActivity}>
-                <Plus className="w-4 h-4 mr-1" /> {t('addActivity')}
-              </Button>
+              <div className="flex items-center gap-1.5 shrink-0">
+                <Button size="sm" variant="outline" onClick={() => setCopyDayOpen(true)}>
+                  <Copy className="w-3.5 h-3.5 mr-1" /> {t('copyDay')}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setTemplateOpen(true)}>
+                  <LayoutTemplate className="w-3.5 h-3.5 mr-1" /> {t('templates')}
+                </Button>
+                <Button size="sm" onClick={openAddActivity}>
+                  <Plus className="w-4 h-4 mr-1" /> {t('addActivity')}
+                </Button>
+              </div>
             )}
           </div>
           {activities.length === 0 ? (
@@ -305,6 +319,29 @@ export function DayViewClient({
         dayId={dayId}
         editItem={editBreakfast}
         onSuccess={handleBreakfastSaved}
+      />
+
+      <CopyDayDialog
+        isOpen={copyDayOpen}
+        onClose={() => setCopyDayOpen(false)}
+        sourceDayId={dayId}
+        today={today}
+      />
+
+      <TemplateDialog
+        isOpen={templateOpen}
+        onClose={() => setTemplateOpen(false)}
+        dayId={dayId}
+        currentItems={activities.map((a) => ({
+          title: a.title,
+          start_time: a.start_time ?? null,
+          end_time: a.end_time ?? null,
+          expected_covers: a.expected_covers ?? null,
+          venue_type_id: a.venue_type_id ?? null,
+          poc_id: a.poc_id ?? null,
+          notes: a.notes ?? null,
+        }))}
+        onApplied={() => window.location.reload()}
       />
     </div>
   );

--- a/app/actions/schedule-templates.ts
+++ b/app/actions/schedule-templates.ts
@@ -1,0 +1,176 @@
+'use server';
+
+import { createTenantClient } from '@/lib/supabase-server';
+import { getTenantId } from '@/lib/tenant';
+import { requireEditor } from '@/lib/membership';
+import { ensureDayExists } from '@/app/actions/days';
+import type { ActionResponse } from '@/types/actions';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TemplateItem = {
+  title: string;
+  start_time: string | null;
+  end_time: string | null;
+  expected_covers: number | null;
+  venue_type_id: string | null;
+  poc_id: string | null;
+  notes: string | null;
+};
+
+export type ScheduleTemplate = {
+  id: string;
+  tenant_id: string;
+  name: string;
+  items: TemplateItem[];
+  created_at: string;
+  updated_at: string;
+};
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export async function getTemplates(): Promise<ActionResponse<ScheduleTemplate[]>> {
+  const tenantId = await getTenantId();
+  const { supabase } = await createTenantClient();
+
+  const { data, error } = await supabase
+    .from('schedule_templates')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .order('name');
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as ScheduleTemplate[] };
+}
+
+export async function saveTemplate(
+  name: string,
+  items: TemplateItem[]
+): Promise<ActionResponse<ScheduleTemplate>> {
+  const trimmed = name.trim();
+  if (!trimmed) return { success: false, error: 'Template name is required.' };
+
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { data, error } = await supabase
+    .from('schedule_templates')
+    .insert({ tenant_id: tenantId, name: trimmed, items })
+    .select()
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: data as ScheduleTemplate };
+}
+
+export async function deleteTemplate(id: string): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+  const { error } = await supabase
+    .from('schedule_templates')
+    .delete()
+    .eq('id', id)
+    .eq('tenant_id', tenantId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: undefined };
+}
+
+export async function applyTemplate(
+  dayId: string,
+  templateId: string,
+  mode: 'replace' | 'merge'
+): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+
+  const { data: template, error: tErr } = await supabase
+    .from('schedule_templates')
+    .select('items')
+    .eq('id', templateId)
+    .eq('tenant_id', tenantId)
+    .single();
+
+  if (tErr || !template) return { success: false, error: 'Template not found.' };
+
+  const items = (template as { items: TemplateItem[] }).items;
+  if (!items.length) return { success: true, data: undefined };
+
+  if (mode === 'replace') {
+    const { error: delErr } = await supabase
+      .from('activity')
+      .delete()
+      .eq('day_id', dayId)
+      .eq('tenant_id', tenantId);
+    if (delErr) return { success: false, error: delErr.message };
+  }
+
+  const rows = items.map((item) => ({
+    tenant_id: tenantId,
+    day_id: dayId,
+    title: item.title,
+    start_time: item.start_time,
+    end_time: item.end_time,
+    expected_covers: item.expected_covers,
+    venue_type_id: item.venue_type_id,
+    poc_id: item.poc_id,
+    notes: item.notes,
+    is_recurring: false,
+  }));
+
+  const { error: insErr } = await supabase.from('activity').insert(rows);
+  if (insErr) return { success: false, error: insErr.message };
+
+  return { success: true, data: undefined };
+}
+
+export async function copyDayActivities(
+  sourceDayId: string,
+  targetDate: string
+): Promise<ActionResponse> {
+  const tenantId = await getTenantId();
+  await requireEditor(tenantId);
+
+  const { supabase } = await createTenantClient();
+
+  const { data: sourceActivities, error: fetchErr } = await supabase
+    .from('activity')
+    .select('title, start_time, end_time, expected_covers, venue_type_id, poc_id, notes')
+    .eq('day_id', sourceDayId)
+    .eq('tenant_id', tenantId);
+
+  if (fetchErr) return { success: false, error: fetchErr.message };
+  if (!sourceActivities?.length) return { success: true, data: undefined };
+
+  const dayResult = await ensureDayExists(targetDate);
+  if (!dayResult.success) return { success: false, error: 'Could not create target day.' };
+
+  const targetDayId = dayResult.data.id;
+
+  const rows = (sourceActivities as TemplateItem[]).map((a) => ({
+    tenant_id: tenantId,
+    day_id: targetDayId,
+    title: a.title,
+    start_time: a.start_time,
+    end_time: a.end_time,
+    expected_covers: a.expected_covers,
+    venue_type_id: a.venue_type_id,
+    poc_id: a.poc_id,
+    notes: a.notes,
+    is_recurring: false,
+  }));
+
+  const { error: insErr } = await supabase.from('activity').insert(rows);
+  if (insErr) return { success: false, error: insErr.message };
+
+  return { success: true, data: undefined };
+}

--- a/components/copy-day-dialog.tsx
+++ b/components/copy-day-dialog.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { copyDayActivities } from '@/app/actions/schedule-templates';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerFooter,
+} from '@/components/ui/drawer';
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 639px)');
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return isMobile;
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  sourceDayId: string;
+  today: string;
+}
+
+export function CopyDayDialog({ isOpen, onClose, sourceDayId, today }: Props) {
+  const isMobile = useIsMobile();
+  const router = useRouter();
+  const [targetDate, setTargetDate] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function handleSubmit() {
+    if (!targetDate) return;
+    setSaving(true);
+    try {
+      const result = await copyDayActivities(sourceDayId, targetDate);
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success('Activities copied.');
+      onClose();
+      router.push(`/day/${targetDate}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const body = (
+    <div className="space-y-4 py-2">
+      <div className="space-y-1.5">
+        <Label htmlFor="copy-target-date">Target date</Label>
+        <Input
+          id="copy-target-date"
+          type="date"
+          min={today}
+          value={targetDate}
+          onChange={(e) => setTargetDate(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+
+  const footer = (
+    <>
+      <Button variant="outline" onClick={onClose} disabled={saving}>
+        Cancel
+      </Button>
+      <Button onClick={handleSubmit} disabled={saving || !targetDate}>
+        {saving ? 'Copying…' : 'Copy'}
+      </Button>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={isOpen} onOpenChange={(o) => !o && onClose()}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Copy activities to another day</DrawerTitle>
+          </DrawerHeader>
+          <div className="px-4">{body}</div>
+          <DrawerFooter className="flex-row justify-end gap-2">{footer}</DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Copy activities to another day</DialogTitle>
+        </DialogHeader>
+        {body}
+        <DialogFooter>{footer}</DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/schedule-template-management.tsx
+++ b/components/schedule-template-management.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { toast } from 'sonner';
+import { getTemplates, deleteTemplate } from '@/app/actions/schedule-templates';
+import type { ScheduleTemplate } from '@/app/actions/schedule-templates';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+export function ScheduleTemplateManagement() {
+  const [templates, setTemplates] = useState<ScheduleTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const result = await getTemplates();
+    if (result.success) setTemplates(result.data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function handleDelete(id: string) {
+    setDeleting(id);
+    const result = await deleteTemplate(id);
+    if (!result.success) {
+      toast.error(result.error);
+    } else {
+      toast.success('Template deleted.');
+      setTemplates((prev) => prev.filter((t) => t.id !== id));
+    }
+    setDeleting(null);
+  }
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+
+  if (templates.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No templates yet. Save a day&rsquo;s activities as a template from the day view.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {templates.map((t) => (
+        <div
+          key={t.id}
+          className="flex items-center justify-between rounded-lg border bg-card px-4 py-3"
+        >
+          <div>
+            <p className="font-medium">{t.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {t.items.length} {t.items.length === 1 ? 'activity' : 'activities'}
+            </p>
+          </div>
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="ghost" size="sm" disabled={deleting === t.id}>
+                {deleting === t.id ? 'Deleting…' : 'Delete'}
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete template?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  &ldquo;{t.name}&rdquo; will be permanently deleted.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={() => handleDelete(t.id)}>Delete</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/template-dialog.tsx
+++ b/components/template-dialog.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
+import { getTemplates, saveTemplate, applyTemplate } from '@/app/actions/schedule-templates';
+import type { ScheduleTemplate, TemplateItem } from '@/app/actions/schedule-templates';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 639px)');
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return isMobile;
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  dayId: string;
+  currentItems: TemplateItem[];
+  onApplied: () => void;
+}
+
+export function TemplateDialog({ isOpen, onClose, dayId, currentItems, onApplied }: Props) {
+  const isMobile = useIsMobile();
+  const [templates, setTemplates] = useState<ScheduleTemplate[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // Save tab state
+  const [saveName, setSaveName] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  // Apply tab state
+  const [selectedId, setSelectedId] = useState('');
+  const [applyMode, setApplyMode] = useState<'merge' | 'replace'>('merge');
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoading(true);
+    getTemplates().then((r) => {
+      if (r.success) setTemplates(r.data);
+      setLoading(false);
+    });
+  }, [isOpen]);
+
+  async function handleSave() {
+    if (!saveName.trim()) return;
+    setSaving(true);
+    try {
+      const result = await saveTemplate(saveName.trim(), currentItems);
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success('Template saved.');
+      setSaveName('');
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleApply() {
+    if (!selectedId) return;
+    setApplying(true);
+    try {
+      const result = await applyTemplate(dayId, selectedId, applyMode);
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success('Template applied.');
+      onApplied();
+      onClose();
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  const inner = (
+    <Tabs defaultValue="apply" className="mt-4">
+      <TabsList className="w-full">
+        <TabsTrigger value="apply" className="flex-1">Apply template</TabsTrigger>
+        <TabsTrigger value="save" className="flex-1">Save as template</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="apply" className="space-y-4 pt-4">
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : templates.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No saved templates yet.</p>
+        ) : (
+          <>
+            <div className="space-y-1.5">
+              <Label>Template</Label>
+              <select
+                value={selectedId}
+                onChange={(e) => setSelectedId(e.target.value)}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              >
+                <option value="">Select a template…</option>
+                {templates.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name} ({t.items.length} {t.items.length === 1 ? 'activity' : 'activities'})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Mode</Label>
+              <div className="flex gap-3">
+                <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                  <input
+                    type="radio"
+                    value="merge"
+                    checked={applyMode === 'merge'}
+                    onChange={() => setApplyMode('merge')}
+                  />
+                  Merge (add to existing)
+                </label>
+                <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                  <input
+                    type="radio"
+                    value="replace"
+                    checked={applyMode === 'replace'}
+                    onChange={() => setApplyMode('replace')}
+                  />
+                  Replace all
+                </label>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={onClose} disabled={applying}>Cancel</Button>
+              <Button onClick={handleApply} disabled={applying || !selectedId}>
+                {applying ? 'Applying…' : 'Apply'}
+              </Button>
+            </div>
+          </>
+        )}
+      </TabsContent>
+
+      <TabsContent value="save" className="space-y-4 pt-4">
+        {currentItems.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No activities to save as template.</p>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Saving {currentItems.length} {currentItems.length === 1 ? 'activity' : 'activities'} as a template.
+            </p>
+            <div className="space-y-1.5">
+              <Label htmlFor="template-name">Template name</Label>
+              <Input
+                id="template-name"
+                value={saveName}
+                onChange={(e) => setSaveName(e.target.value)}
+                placeholder="e.g. Weekend schedule"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={onClose} disabled={saving}>Cancel</Button>
+              <Button onClick={handleSave} disabled={saving || !saveName.trim()}>
+                {saving ? 'Saving…' : 'Save template'}
+              </Button>
+            </div>
+          </>
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={isOpen} onOpenChange={(o) => !o && onClose()}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Schedule templates</DrawerTitle>
+          </DrawerHeader>
+          <div className="px-4 pb-6">{inner}</div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Schedule templates</DialogTitle>
+        </DialogHeader>
+        {inner}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -90,7 +90,9 @@
       "noReservations": "No reservations yet.",
       "addBreakfast": "Add breakfast",
       "addActivity": "Activity",
-      "addReservation": "Add reservation"
+      "addReservation": "Add reservation",
+      "copyDay": "Copy",
+      "templates": "Templates"
     },
     "summary": {
       "breakfast": "Breakfasts",
@@ -241,6 +243,7 @@
       "tabBranding": "Branding",
       "tabLanguage": "Language",
       "tabMembers": "Team",
+      "tabTemplates": "Templates",
       "tabFeedback": "Feedback",
       "languageTitle": "Venue language",
       "languageDescription": "This language will be used for all members of your venue.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -90,7 +90,9 @@
       "noReservations": "Aucune réservation pour l'instant.",
       "addBreakfast": "Ajouter petit-déjeuner",
       "addActivity": "Activité",
-      "addReservation": "Ajouter une réservation"
+      "addReservation": "Ajouter une réservation",
+      "copyDay": "Copier",
+      "templates": "Modèles"
     },
     "summary": {
       "breakfast": "Petits-déjeuners",
@@ -241,6 +243,7 @@
       "tabBranding": "Image de marque",
       "tabLanguage": "Langue",
       "tabMembers": "Équipe",
+      "tabTemplates": "Modèles",
       "tabFeedback": "Retours",
       "languageTitle": "Langue de l'établissement",
       "languageDescription": "Cette langue sera utilisée pour tous les membres de votre établissement.",

--- a/supabase/migrations/00024_schedule_templates.sql
+++ b/supabase/migrations/00024_schedule_templates.sql
@@ -1,0 +1,21 @@
+-- Schedule templates: reusable activity blueprints per tenant
+CREATE TABLE schedule_templates (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   uuid        NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  name        text        NOT NULL,
+  items       jsonb       NOT NULL DEFAULT '[]'::jsonb,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ON schedule_templates(tenant_id);
+
+ALTER TABLE schedule_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "members can read templates"
+  ON schedule_templates FOR SELECT
+  USING (is_tenant_member(tenant_id));
+
+CREATE POLICY "editors can manage templates"
+  ON schedule_templates FOR ALL
+  USING (is_tenant_editor(tenant_id));


### PR DESCRIPTION
## Summary
- New `schedule_templates` table (migration `00024`) with JSONB activity items + RLS
- New `app/actions/schedule-templates.ts` — `getTemplates`, `saveTemplate`, `deleteTemplate`, `applyTemplate`, `copyDayActivities`
- **Day view** (editor): Copy and Templates buttons in Activities section header
  - **Copy**: copies all activities to a chosen future date, navigates there
  - **Templates**: save current activities as named template, or apply an existing template (merge / replace)
- **Settings → Templates tab**: list and delete saved templates
- i18n keys added to `en.json` and `fr.json`

## Test plan
- [ ] Day view → Activities → Copy → pick date → activities appear on target day
- [ ] Day view → Activities → Templates → Save as template → name it → saved
- [ ] Day view → Activities → Templates → Apply → merge mode → existing activities preserved + template added
- [ ] Day view → Activities → Templates → Apply → replace mode → existing activities gone
- [ ] Settings → Templates tab → template listed → delete → gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)