### PR TITLE
T-27: Dark mode refinement

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1089,7 +1089,7 @@ Copy day and save/apply templates for **activities**.
 
 ## Ticket 27: Dark Mode Refinement
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** done.
 
 **Priority:** P3  
 **Scope:** `app/globals.css`, `components/`, `app/[tenant]/day/[date]/DayViewClient.tsx`, `components/HomeClient.tsx`  

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -53,7 +53,7 @@ function TenantCard({
             size="icon"
             disabled={isDeleting}
             onClick={() => onDelete(tenant.id)}
-            className="text-gray-500 hover:text-gray-700 hover:bg-gray-50"
+            className="text-muted-foreground hover:text-foreground hover:bg-muted/50"
           >
             {isDeleting ? (
               <Loader2 className="h-5 w-5 animate-spin" />
@@ -64,9 +64,9 @@ function TenantCard({
         </div>
       </CardHeader>
       <CardContent>
-        <p className="text-sm text-gray-500">{tenant.slug}</p>
-        <p className="text-sm text-gray-500">Language: {tenant.language}</p>
-        <p className="text-sm text-gray-500 mt-1">
+        <p className="text-sm text-muted-foreground">{tenant.slug}</p>
+        <p className="text-sm text-muted-foreground">Language: {tenant.language}</p>
+        <p className="text-sm text-muted-foreground mt-1">
           Created: {new Date(tenant.created_at).toLocaleDateString()}
         </p>
         <div className="mt-3">
@@ -74,7 +74,7 @@ function TenantCard({
             href={`${protocol}://${tenant.slug}.${rootDomain}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-500 hover:underline text-sm"
+            className="text-primary hover:underline text-sm"
           >
             Visit tenant →
           </a>
@@ -84,7 +84,7 @@ function TenantCard({
         <div className="mt-4 border-t pt-3">
           <button
             type="button"
-            className="flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900"
+            className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground"
             onClick={() => setExpanded((v) => !v)}
           >
             Feature Flags
@@ -146,7 +146,7 @@ export function AdminDashboard({
         <h1 className="text-3xl font-bold">Tenant Management</h1>
         <Link
           href={`${protocol}://${rootDomain}`}
-          className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           {rootDomain}
         </Link>
@@ -155,7 +155,7 @@ export function AdminDashboard({
       {list.length === 0 ? (
         <Card>
           <CardContent className="py-8 text-center">
-            <p className="text-gray-500">No tenants yet.</p>
+            <p className="text-muted-foreground">No tenants yet.</p>
           </CardContent>
         </Card>
       ) : (

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -23,7 +23,7 @@ export default async function AdminPage() {
   const flagsByTenant = await getFeatureFlagsByTenants(tenantList.map((t) => t.id));
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4 md:p-8 space-y-12">
+    <div className="min-h-screen bg-background p-4 md:p-8 space-y-12">
       <AdminDashboard tenants={tenantList} flagsByTenant={flagsByTenant} />
 
       <div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -128,16 +128,16 @@
 }
 
 .emoji-picker-container .epr-body::-webkit-scrollbar-track {
-  background: hsl(var(--background));
+  background: var(--background);
 }
 
 .emoji-picker-container .epr-body::-webkit-scrollbar-thumb {
-  background-color: hsl(var(--muted));
+  background-color: var(--muted);
   border-radius: 20px;
 }
 
 .emoji-picker-container .epr-body::-webkit-scrollbar-thumb:hover {
-  background-color: hsl(var(--muted-foreground) / 0.5);
+  background-color: color-mix(in oklch, var(--muted-foreground) 50%, transparent);
 }
 
 .emoji-picker-container .epr-category-nav {
@@ -145,27 +145,27 @@
 }
 
 .emoji-picker-container .epr-header {
-  border-bottom: 1px solid hsl(var(--border));
+  border-bottom: 1px solid var(--border);
 }
 
 .emoji-picker-container .epr-emoji-category-label {
-  background-color: hsl(var(--background));
+  background-color: var(--background);
   font-size: 0.875rem;
-  color: hsl(var(--muted-foreground));
+  color: var(--muted-foreground);
   padding: 4px 8px;
 }
 
 .emoji-picker-container .epr-search {
   margin: 8px;
   border-radius: var(--radius);
-  border: 1px solid hsl(var(--input));
-  background-color: hsl(var(--background));
+  border: 1px solid var(--input);
+  background-color: var(--background);
 }
 
 .emoji-picker-container .epr-search input {
   border-radius: var(--radius);
   background-color: transparent;
-  color: hsl(var(--foreground));
+  color: var(--foreground);
 }
 
 .emoji-picker-container .epr-emoji-category-content {
@@ -185,7 +185,7 @@
 }
 
 .emoji-picker-container button.epr-emoji:hover {
-  background-color: hsl(var(--accent));
+  background-color: var(--accent);
 }
 
 .emoji-picker-container .epr-category-nav button {
@@ -198,4 +198,21 @@
 
 .emoji-picker-container .epr-category-nav button:hover {
   opacity: 0.8;
+}
+
+@media print {
+  :root {
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.141 0.005 285.823);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.141 0.005 285.823);
+    --muted: oklch(0.967 0.001 286.375);
+    --muted-foreground: oklch(0.552 0.016 285.938);
+    --border: oklch(0.92 0.004 286.32);
+  }
+
+  body {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
 }

--- a/components/admin-feature-requests.tsx
+++ b/components/admin-feature-requests.tsx
@@ -30,11 +30,11 @@ const STATUS_OPTIONS: FeatureRequestStatus[] = [
 ];
 
 const STATUS_CLASSES: Record<FeatureRequestStatus, string> = {
-  pending: 'bg-gray-100 text-gray-700',
-  reviewing: 'bg-blue-100 text-blue-700',
-  accepted: 'bg-green-100 text-green-700',
-  rejected: 'bg-red-100 text-red-700',
-  shipped: 'bg-purple-100 text-purple-700',
+  pending: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  reviewing: 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300',
+  accepted: 'bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300',
+  rejected: 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300',
+  shipped: 'bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300',
 };
 
 const STATUS_LABELS: Record<FeatureRequestStatus, string> = {
@@ -132,11 +132,11 @@ export function AdminFeatureRequests({
   }, []);
 
   if (loading) {
-    return <p className="text-sm text-gray-500">Loading feature requests…</p>;
+    return <p className="text-sm text-muted-foreground">Loading feature requests…</p>;
   }
 
   if (requests.length === 0) {
-    return <p className="text-sm text-gray-500">No feature requests yet.</p>;
+    return <p className="text-sm text-muted-foreground">No feature requests yet.</p>;
   }
 
   return (

--- a/components/feature-request-management.tsx
+++ b/components/feature-request-management.tsx
@@ -23,11 +23,11 @@ import { cn } from '@/lib/utils';
 // ---------------------------------------------------------------------------
 
 const STATUS_CLASSES: Record<FeatureRequestStatus, string> = {
-  pending: 'bg-gray-100 text-gray-700',
-  reviewing: 'bg-blue-100 text-blue-700',
-  accepted: 'bg-green-100 text-green-700',
-  rejected: 'bg-red-100 text-red-700',
-  shipped: 'bg-purple-100 text-purple-700',
+  pending: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  reviewing: 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300',
+  accepted: 'bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300',
+  rejected: 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300',
+  shipped: 'bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300',
 };
 
 function StatusBadge({ status, label }: { status: FeatureRequestStatus; label: string }) {


### PR DESCRIPTION
## Summary
- Fixes emoji picker CSS: `hsl(var(--...))` → `var(--...)` since variables are in oklch format, not hsl
- Adds `@media print` block that forces light-mode CSS variables
- Status badges in feature request views now have `dark:` variants
- Admin page/dashboard: replaces `text-gray-*`, `bg-gray-*`, `text-blue-500` with semantic tokens (`text-muted-foreground`, `text-foreground`, `bg-muted/50`, `text-primary`)

## Test plan
- [ ] Toggle dark mode — feature request status badges render correctly
- [ ] Admin dashboard looks correct in dark mode (no gray blobs)
- [ ] Print the day view — renders in light mode regardless of system preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)