### PR TITLE
T-28: Tenant-specific PWA manifest and icon

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1108,7 +1108,7 @@ Theme-aware colors across custom UI; print styles; accent contrast.
 
 ## Ticket 28: PWA Enhancement
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** done.
 
 **Priority:** P3  
 **Scope:** `public/sw.js`, `public/manifest.webmanifest`, `components/pwa-register.tsx`, `components/pwa-install-prompt.tsx`, `next.config.ts`  

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -34,27 +34,27 @@ export async function generateMetadata(): Promise<Metadata> {
     const name = data?.name as string | undefined;
     return {
       title: name ? `${name} · Courseday` : 'Courseday',
-      manifest: '/manifest.webmanifest',
+      manifest: '/pwa/manifest',
       appleWebApp: {
         capable: true,
         statusBarStyle: 'default',
         title: name ?? 'Courseday',
       },
       icons: {
-        apple: '/icon.svg',
+        apple: '/pwa/icon',
       },
     };
   } catch {
     return {
       title: 'Courseday',
-      manifest: '/manifest.webmanifest',
+      manifest: '/pwa/manifest',
       appleWebApp: {
         capable: true,
         statusBarStyle: 'default',
         title: 'Courseday',
       },
       icons: {
-        apple: '/icon.svg',
+        apple: '/pwa/icon',
       },
     };
   }

--- a/app/[tenant]/pwa/icon/route.ts
+++ b/app/[tenant]/pwa/icon/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { getTenantFromHeaders } from '@/lib/tenant';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0].toUpperCase())
+    .join('');
+}
+
+function isLightHex(hex: string): boolean {
+  const h = hex.replace('#', '');
+  if (h.length < 6) return true;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000 > 128;
+}
+
+function buildSvg(initials: string, bg: string, fg: string): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="${bg}"/>
+  <text x="256" y="256" text-anchor="middle" dominant-baseline="central"
+    font-family="system-ui,-apple-system,sans-serif" font-size="${initials.length > 1 ? 196 : 240}"
+    font-weight="700" fill="${fg}">${initials}</text>
+</svg>`;
+}
+
+export async function GET() {
+  try {
+    const tenant = await getTenantFromHeaders();
+    const supabase = await createSupabaseServerClient();
+
+    const { data } = await supabase
+      .from('tenants')
+      .select('name, accent_color, logo_url')
+      .eq('id', tenant.id)
+      .single();
+
+    const logoUrl = data?.logo_url as string | null;
+    if (logoUrl) {
+      return NextResponse.redirect(logoUrl, { status: 302 });
+    }
+
+    const name = (data?.name as string | null) ?? 'C';
+    const accent = (data?.accent_color as string | null) ?? '#e5e7eb';
+    const bg = accent.startsWith('#') ? accent : '#e5e7eb';
+    const fg = isLightHex(bg) ? '#1a1a1a' : '#ffffff';
+    const initials = getInitials(name) || name[0].toUpperCase();
+
+    return new NextResponse(buildSvg(initials, bg, fg), {
+      headers: {
+        'Content-Type': 'image/svg+xml',
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      },
+    });
+  } catch {
+    const fallback = buildSvg('C', '#e5e7eb', '#1a1a1a');
+    return new NextResponse(fallback, {
+      headers: { 'Content-Type': 'image/svg+xml' },
+    });
+  }
+}

--- a/app/[tenant]/pwa/manifest/route.ts
+++ b/app/[tenant]/pwa/manifest/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { getTenantFromHeaders } from '@/lib/tenant';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+
+export async function GET() {
+  try {
+    const tenant = await getTenantFromHeaders();
+    const supabase = await createSupabaseServerClient();
+
+    const { data } = await supabase
+      .from('tenants')
+      .select('name, accent_color, logo_url')
+      .eq('id', tenant.id)
+      .single();
+
+    const name = (data?.name as string | null) ?? 'Courseday';
+    const accentColor = (data?.accent_color as string | null) ?? '#e5e7eb';
+
+    const manifest = {
+      name: `${name} · Courseday`,
+      short_name: name,
+      description: 'Daily operations and team communication for golf venues.',
+      start_url: '/',
+      display: 'standalone',
+      orientation: 'portrait',
+      background_color: '#ffffff',
+      theme_color: accentColor,
+      icons: [
+        {
+          src: '/pwa/icon',
+          sizes: 'any',
+          type: 'image/svg+xml',
+          purpose: 'any',
+        },
+        {
+          src: '/pwa/icon',
+          sizes: 'any',
+          type: 'image/svg+xml',
+          purpose: 'maskable',
+        },
+      ],
+    };
+
+    return NextResponse.json(manifest, {
+      headers: {
+        'Content-Type': 'application/manifest+json',
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      {
+        name: 'Courseday',
+        short_name: 'Courseday',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        theme_color: '#e5e7eb',
+        icons: [{ src: '/icon.svg', sizes: 'any', type: 'image/svg+xml' }],
+      },
+      { headers: { 'Content-Type': 'application/manifest+json' } }
+    );
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -92,7 +92,8 @@ export async function middleware(request: NextRequest) {
   const isPublicPath =
     pathname === '/auth/sign-in' ||
     pathname === '/auth/sign-up' ||
-    pathname.startsWith('/auth/');
+    pathname.startsWith('/auth/') ||
+    pathname.startsWith('/pwa/');
 
   if (!user && !isPublicPath) {
     const signInUrl = new URL('/auth/sign-in', request.url);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,7 @@
-const CACHE_NAME = 'golf-schedule-v1';
+const CACHE_NAME = 'courseday-v2';
+
+// Never cache these paths
+const SKIP_PREFIXES = ['/auth/', '/api/'];
 
 self.addEventListener('install', () => {
   self.skipWaiting();
@@ -19,6 +22,9 @@ self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
 
   const url = new URL(event.request.url);
+
+  // Never cache auth routes or API calls
+  if (SKIP_PREFIXES.some((p) => url.pathname.startsWith(p))) return;
 
   // Cache-first for Next.js static assets (immutable, content-hashed)
   if (url.pathname.startsWith('/_next/static/')) {


### PR DESCRIPTION
## Summary
- New `app/[tenant]/pwa/manifest/route.ts` — dynamic web app manifest per tenant
  - `name`: `{tenant name} · Courseday`
  - `theme_color`: tenant accent color, fallback `#e5e7eb` (light grey)
  - `icons`: points to `/pwa/icon`
- New `app/[tenant]/pwa/icon/route.ts` — dynamic icon
  - Redirects to tenant logo URL if set
  - Otherwise generates SVG: initials (up to 2 words) on accent-color background, auto text contrast
- Middleware: `/pwa/*` added to public paths (no auth required — browsers fetch manifest before login)
- `app/[tenant]/layout.tsx`: manifest and apple-touch-icon now point to `/pwa/manifest` and `/pwa/icon`
- `public/sw.js`: bumped cache version, skips caching `/auth/*` and `/api/*` routes

## Test plan
- [ ] Install PWA on a tenant subdomain — app name shows `{Tenant} · Courseday`
- [ ] Address bar / splash screen uses tenant accent color
- [ ] Tenant with logo → logo used as PWA icon
- [ ] Tenant without logo → initials SVG icon with correct background/text contrast
- [ ] No accent color set → grey fallback (`#e5e7eb`)
- [ ] Visiting `/pwa/manifest` while logged out returns JSON (not a redirect to sign-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)