### PR TITLE
T-30: Rate limiting, schema bounds, and security headers

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1147,7 +1147,7 @@ Full audit + **es**/**de** locales after overhaul strings (Ticket 14).
 
 ## Ticket 30: Rate Limiting & Security
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** pending — set to `[x]` when done.
 
 **Priority:** P3  
 **Scope:** `app/actions/auth.ts`, `app/actions/`, `middleware.ts`, `next.config.ts`  

--- a/app/actions/activities.ts
+++ b/app/actions/activities.ts
@@ -8,6 +8,7 @@ import { generateRecurrenceDates } from '@/lib/day-utils';
 import { activitySchema } from '@/lib/program-item-schema';
 import { ensureDayExists } from '@/app/actions/days';
 import { notifyTenantMembers, getDayDate } from '@/lib/notifications';
+import { mutationRateLimit } from '@/lib/rate-limit';
 import type { ActionResponse } from '@/types/actions';
 import type { Activity, ActivityWithRelations } from '@/types/index';
 import type { ActivityFormData } from '@/lib/program-item-schema';
@@ -72,6 +73,9 @@ export async function createActivity(
 
   const tenantId = await getTenantId();
   const user = await requireEditor(tenantId);
+
+  const rl = await mutationRateLimit(user.id);
+  if (!rl.success) return { success: false, error: 'Too many requests. Please slow down.' };
 
   const { supabase } = await createTenantClient();
   const data = parsed.data;

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -5,8 +5,12 @@ import { createSupabaseServerClient, createSupabaseServiceClient } from '@/lib/s
 import { getTenantId } from '@/lib/tenant';
 import { getUserRole } from '@/lib/membership';
 import { protocol, rootDomain } from '@/lib/utils';
+import { authRateLimit } from '@/lib/rate-limit';
 
 export async function signIn(_prevState: unknown, formData: FormData) {
+  const rl = await authRateLimit();
+  if (!rl.success) return { error: 'Too many attempts. Please wait and try again.' };
+
   const email = formData.get('email') as string;
   const password = formData.get('password') as string;
   const redirectTo = (formData.get('redirectTo') as string) || '/';
@@ -22,6 +26,9 @@ export async function signIn(_prevState: unknown, formData: FormData) {
 }
 
 export async function signUp(_prevState: unknown, formData: FormData) {
+  const rl = await authRateLimit();
+  if (!rl.success) return { error: 'Too many attempts. Please wait and try again.' };
+
   const email = formData.get('email') as string;
   const password = formData.get('password') as string;
 
@@ -67,6 +74,9 @@ export async function requireUser() {
  * and redirects to their course subdomain.
  */
 export async function platformSignIn(_prevState: unknown, formData: FormData) {
+  const rl = await authRateLimit();
+  if (!rl.success) return { error: 'Too many attempts. Please wait and try again.' };
+
   const email = formData.get('email') as string;
   const password = formData.get('password') as string;
 

--- a/lib/activity-tag-schema.ts
+++ b/lib/activity-tag-schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const activityTagSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
+  name: z.string().min(1, 'Name is required').max(100),
 });
 
 export type ActivityTagFormData = z.infer<typeof activityTagSchema>;

--- a/lib/breakfast-schema.ts
+++ b/lib/breakfast-schema.ts
@@ -2,19 +2,19 @@ import { z } from 'zod';
 
 export const createBreakfastSchema = z.object({
   dayId: z.string().uuid('Day ID is required'),
-  groupName: z.string().optional(),
-  guestCount: z.number().int().min(1).optional(),
-  tableBreakdown: z.array(z.number().int().min(1)).optional(),
+  groupName: z.string().max(200).optional(),
+  guestCount: z.number().int().min(1).max(9999).optional(),
+  tableBreakdown: z.array(z.number().int().min(1).max(999)).max(100).optional(),
   startTime: z.string().optional(),
-  notes: z.string().optional(),
+  notes: z.string().max(2000).optional(),
 });
 
 export const updateBreakfastSchema = z.object({
-  groupName: z.string().optional(),
-  guestCount: z.number().int().min(1).optional(),
-  tableBreakdown: z.array(z.number().int().min(1)).optional(),
+  groupName: z.string().max(200).optional(),
+  guestCount: z.number().int().min(1).max(9999).optional(),
+  tableBreakdown: z.array(z.number().int().min(1).max(999)).max(100).optional(),
   startTime: z.string().optional(),
-  notes: z.string().optional(),
+  notes: z.string().max(2000).optional(),
 });
 
 export type CreateBreakfastFormData = z.infer<typeof createBreakfastSchema>;

--- a/lib/poc-schema.ts
+++ b/lib/poc-schema.ts
@@ -1,13 +1,14 @@
 import { z } from 'zod';
 
 export const pocSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
+  name: z.string().min(1, 'Name is required').max(200),
   email: z
     .string()
     .email('Invalid email address')
+    .max(254)
     .optional()
     .or(z.literal('')),
-  phone: z.string().optional().or(z.literal('')),
+  phone: z.string().max(50).optional().or(z.literal('')),
 });
 
 export type PocFormData = z.infer<typeof pocSchema>;

--- a/lib/program-item-schema.ts
+++ b/lib/program-item-schema.ts
@@ -1,16 +1,16 @@
 import { z } from 'zod';
 
 export const activitySchema = z.object({
-  title: z.string().min(1, 'Title is required'),
+  title: z.string().min(1, 'Title is required').max(200),
   dayId: z.string().uuid('Day ID is required'),
-  description: z.string().optional(),
+  description: z.string().max(2000).optional(),
   startTime: z.string().optional(),
   endTime: z.string().optional(),
-  expectedCovers: z.number().int().min(0).optional(),
+  expectedCovers: z.number().int().min(0).max(9999).optional(),
   venueTypeId: z.string().uuid().optional().nullable(),
   pocId: z.string().uuid().optional().nullable(),
-  tagIds: z.array(z.string().uuid()).optional(),
-  notes: z.string().optional(),
+  tagIds: z.array(z.string().uuid()).max(20).optional(),
+  notes: z.string().max(2000).optional(),
   isRecurring: z.boolean().optional(),
   recurrenceFrequency: z
     .enum(['weekly', 'biweekly', 'monthly', 'yearly'])

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,58 @@
+import { headers } from 'next/headers';
+import { redis } from './redis';
+
+// ---------------------------------------------------------------------------
+// Core
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed-window rate limiter backed by ioredis.
+ * On Redis failure, allows the request through (fail-open).
+ */
+async function checkLimit(
+  key: string,
+  limit: number,
+  windowSeconds: number
+): Promise<{ success: boolean }> {
+  const windowSlot = Math.floor(Date.now() / (windowSeconds * 1000));
+  const redisKey = `rl:${key}:${windowSlot}`;
+
+  try {
+    const count = await redis.incr(redisKey);
+    if (count === 1) {
+      await redis.expire(redisKey, windowSeconds);
+    }
+    return { success: count <= limit };
+  } catch {
+    // Redis unavailable — fail open so the app stays usable
+    return { success: true };
+  }
+}
+
+async function getClientIP(): Promise<string> {
+  const h = await headers();
+  return (
+    h.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    h.get('x-real-ip') ??
+    'unknown'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Presets
+// ---------------------------------------------------------------------------
+
+/**
+ * Auth actions (sign-in, sign-up): 10 attempts per 15 minutes per IP.
+ */
+export async function authRateLimit(): Promise<{ success: boolean }> {
+  const ip = await getClientIP();
+  return checkLimit(`auth:${ip}`, 10, 900);
+}
+
+/**
+ * Mutation actions (create/update/delete): 120 per minute per user.
+ */
+export async function mutationRateLimit(userId: string): Promise<{ success: boolean }> {
+  return checkLimit(`mutation:${userId}`, 120, 60);
+}

--- a/lib/reservation-schema.ts
+++ b/lib/reservation-schema.ts
@@ -2,12 +2,12 @@ import { z } from 'zod';
 
 export const reservationSchema = z.object({
   dayId: z.string().uuid('Day ID is required'),
-  guestName: z.string().optional(),
-  guestCount: z.number().int().min(1).optional(),
+  guestName: z.string().max(200).optional(),
+  guestCount: z.number().int().min(1).max(9999).optional(),
   startTime: z.string().optional(),
   endTime: z.string().optional(),
-  notes: z.string().optional(),
-  tableBreakdown: z.array(z.number().int().min(1)).optional(),
+  notes: z.string().max(2000).optional(),
+  tableBreakdown: z.array(z.number().int().min(1).max(999)).max(100).optional(),
 });
 
 export type ReservationFormData = z.infer<typeof reservationSchema>;

--- a/lib/venue-type-schema.ts
+++ b/lib/venue-type-schema.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const venueTypeSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  code: z.string().optional().or(z.literal('')),
+  name: z.string().min(1, 'Name is required').max(200),
+  code: z.string().max(50).optional().or(z.literal('')),
 });
 
 export type VenueTypeFormData = z.infer<typeof venueTypeSchema>;

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,25 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https://*.supabase.co",
+      "font-src 'self'",
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.upstash.io",
+      "frame-ancestors 'self'",
+    ].join('; '),
+  },
+];
+
 const nextConfig: NextConfig = {
   experimental: {
     // Required to use ioredis (Node.js TCP sockets) inside middleware.
@@ -19,6 +38,14 @@ const nextConfig: NextConfig = {
         pathname: '/storage/v1/object/public/**',
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## Summary
- Fixed-window rate limiter (`lib/rate-limit.ts`) using Redis INCR/EXPIRE: auth 10 req/15 min per IP, mutations 120 req/min per user
- Auth rate limits applied to `signIn`, `signUp`, `platformSignIn`
- Mutation rate limit applied to `createActivity`
- Zod max bounds audited and added to all schemas (activities, reservations, breakfasts, POC, venue types, tags)
- Security headers added to `next.config.ts`: `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, starter CSP

## Test plan
- [ ] Sign in repeatedly to hit auth rate limit (returns "Too many attempts" error)
- [ ] Create activities rapidly to hit mutation limit (returns "Too many requests" error)
- [ ] Submit form values exceeding max bounds — Zod rejects them
- [ ] Check response headers include `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, etc.
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)