### PR TITLE
T-32: Accessibility audit and WCAG 2.1 AA fixes

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1183,7 +1183,7 @@ SDK setup, `withSentryConfig`, context in `[tenant]` layout and actions, error b
 
 ## Ticket 32: Accessibility Audit & Fixes
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** pending — set to `[x]` when done.
 
 **Priority:** P3  
 **Scope:** `components/`, `app/[tenant]/layout.tsx`, `app/globals.css`  

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -103,6 +103,12 @@ export default async function TenantLayout({
       <FeatureFlagProvider flags={featureFlags}>
       <TenantProvider tenantId={tenant.id} tenantSlug={tenant.slug}>
         <AuthProvider>
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:rounded focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:ring-2 focus:ring-ring"
+          >
+            {t('skipToContent')}
+          </a>
           <div className="min-h-screen flex flex-col" dir={dir} style={accentStyle}>
             <header className="border-b px-6 h-14 flex items-center justify-between">
               <Logo logoUrl={row?.logo_url} tenantName={row?.name} />
@@ -120,7 +126,7 @@ export default async function TenantLayout({
                 {user && <UserMenu user={user} signOutLabel={t('signOut')} />}
               </div>
             </header>
-            <main className="flex-1 pb-16 sm:pb-0">{children}</main>
+            <main id="main-content" className="flex-1 pb-16 sm:pb-0">{children}</main>
           </div>
           <MobileNav today={today} isEditor={editor} />
           <AdminIndicator />

--- a/components/CalendarDaySidebar.tsx
+++ b/components/CalendarDaySidebar.tsx
@@ -124,7 +124,7 @@ export function CalendarDaySidebar({ date, onClose, onSummaryChanged }: Props) {
   const formattedDate = format(parseISO(date), 'EEEE d MMMM');
 
   return (
-    <aside className="w-72 shrink-0">
+    <aside className="w-72 shrink-0" aria-label={formattedDate}>
       <div className="sticky top-6 space-y-4 rounded-lg border bg-card p-4">
         {/* Header */}
         <div className="flex items-start justify-between gap-2">
@@ -132,8 +132,8 @@ export function CalendarDaySidebar({ date, onClose, onSummaryChanged }: Props) {
             <p className="text-xs text-muted-foreground uppercase tracking-wide">{t('selectedDay')}</p>
             <p className="font-semibold">{formattedDate}</p>
           </div>
-          <Button variant="ghost" size="icon" className="-mr-1 -mt-1 h-7 w-7" onClick={onClose}>
-            <X className="h-4 w-4" />
+          <Button variant="ghost" size="icon" className="-mr-1 -mt-1 h-7 w-7" onClick={onClose} aria-label={t('close')}>
+            <X className="h-4 w-4" aria-hidden="true" />
           </Button>
         </div>
 

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { format, getDay, addMonths, subMonths } from 'date-fns';
+import { format, getDay, addMonths, subMonths, parseISO } from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -99,12 +99,13 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
         )}
         <div className="flex items-center gap-2">
           {/* View toggle */}
-          <div className="flex rounded-md border overflow-hidden">
+          <div className="flex rounded-md border overflow-hidden" role="group" aria-label="View mode">
             <Button
               variant={viewMode === 'calendar' ? 'secondary' : 'ghost'}
               size="sm"
               className="rounded-none border-0 h-8 px-3"
               onClick={() => changeViewMode('calendar')}
+              aria-pressed={viewMode === 'calendar'}
             >
               {t('calendar')}
             </Button>
@@ -113,6 +114,7 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
               size="sm"
               className="rounded-none border-0 border-l h-8 px-3"
               onClick={() => changeViewMode('agenda')}
+              aria-pressed={viewMode === 'agenda'}
             >
               {t('agenda')}
             </Button>
@@ -162,10 +164,11 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
         {/* Calendar grid */}
         <div className="flex-1 min-w-0">
           {/* Day-of-week header */}
-          <div className="grid grid-cols-7 mb-1">
+          <div className="grid grid-cols-7 mb-1" role="row">
             {DOW_KEYS.map((key) => (
               <div
                 key={key}
+                role="columnheader"
                 className="text-center text-xs font-medium text-muted-foreground py-1"
               >
                 {t(key)}
@@ -174,7 +177,7 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
           </div>
 
           {/* Day cells */}
-          <div className="grid grid-cols-7 border-l border-t">
+          <div className="grid grid-cols-7 border-l border-t" role="grid" aria-label={format(firstOfMonth, 'MMMM yyyy')}>
             {/* Leading empty cells */}
             {Array.from({ length: startPadding }).map((_, i) => (
               <div
@@ -191,10 +194,22 @@ export function HomeClient({ month, today, days: initialDays }: Props) {
               const isToday = dateStr === today;
               const isSelected = dateStr === selectedDate;
 
+              const cellLabel = [
+                format(parseISO(dateStr), 'EEEE, MMMM d'),
+                ...(summary ? [
+                  summary.golfCount > 0 ? `${summary.golfCount} activities` : '',
+                  summary.reservationCount > 0 ? `${summary.reservationCount} reservations` : '',
+                  summary.breakfastCount > 0 ? `${summary.breakfastCount} breakfast covers` : '',
+                ].filter(Boolean) : []),
+              ].join(', ');
+
               return (
                 <button
                   key={dateStr}
                   onClick={() => setSelectedDate(isSelected ? null : dateStr)}
+                  aria-pressed={isSelected}
+                  aria-current={isToday ? 'date' : undefined}
+                  aria-label={cellLabel}
                   className={cn(
                     'border-r border-b min-h-[60px] sm:min-h-[80px] p-1 sm:p-1.5 text-left transition-colors',
                     'hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',

--- a/components/activity-card.tsx
+++ b/components/activity-card.tsx
@@ -117,11 +117,11 @@ export function ActivityCard({ item, isEditor, onEdit, onDeleted }: Props) {
             {/* Right: actions */}
             {isEditor && (
               <div className="flex gap-1 shrink-0">
-                <Button variant="ghost" size="icon" onClick={() => onEdit(item)}>
-                  <Pencil className="h-4 w-4" />
+                <Button variant="ghost" size="icon" onClick={() => onEdit(item)} aria-label={`Edit: ${item.title}`}>
+                  <Pencil className="h-4 w-4" aria-hidden="true" />
                 </Button>
-                <Button variant="ghost" size="icon" onClick={() => setDeleteOpen(true)}>
-                  <Trash2 className="h-4 w-4" />
+                <Button variant="ghost" size="icon" onClick={() => setDeleteOpen(true)} aria-label={`Delete: ${item.title}`}>
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </Button>
               </div>
             )}

--- a/components/breakfast-card.tsx
+++ b/components/breakfast-card.tsx
@@ -87,11 +87,11 @@ export function BreakfastCard({ item, isEditor, onEdit, onDeleted }: Props) {
 
             {isEditor && (
               <div className="flex gap-1 shrink-0">
-                <Button variant="ghost" size="icon" onClick={() => onEdit(item)}>
-                  <Pencil className="h-4 w-4" />
+                <Button variant="ghost" size="icon" onClick={() => onEdit(item)} aria-label={`Edit: ${item.group_name ?? t('unnamedGroup')}`}>
+                  <Pencil className="h-4 w-4" aria-hidden="true" />
                 </Button>
-                <Button variant="ghost" size="icon" onClick={() => setDeleteOpen(true)}>
-                  <Trash2 className="h-4 w-4" />
+                <Button variant="ghost" size="icon" onClick={() => setDeleteOpen(true)} aria-label={`Delete: ${item.group_name ?? t('unnamedGroup')}`}>
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </Button>
               </div>
             )}

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -22,18 +22,19 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
   ];
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background sm:hidden">
+    <nav aria-label="Main navigation" className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background sm:hidden">
       <div className="flex h-16">
         {items.map(({ href, label, icon: Icon, active }) => (
           <Link
             key={href}
             href={href}
+            aria-current={active ? 'page' : undefined}
             className={cn(
               'flex flex-1 flex-col items-center justify-center gap-1 text-[11px] font-medium transition-colors',
               active ? 'text-foreground' : 'text-muted-foreground'
             )}
           >
-            <Icon className={cn('h-5 w-5', active && 'stroke-[2.5]')} />
+            <Icon className={cn('h-5 w-5', active && 'stroke-[2.5]')} aria-hidden="true" />
             {label}
           </Link>
         ))}

--- a/components/reservation-card.tsx
+++ b/components/reservation-card.tsx
@@ -87,11 +87,11 @@ export function ReservationCard({ item, isEditor, onEdit, onDeleted }: Props) {
 
             {isEditor && (
               <div className="flex gap-1 shrink-0">
-                <Button variant="ghost" size="icon" onClick={() => onEdit(item)}>
-                  <Pencil className="h-4 w-4" />
+                <Button variant="ghost" size="icon" onClick={() => onEdit(item)} aria-label={`Edit: ${item.guest_name ?? t('fallbackName')}`}>
+                  <Pencil className="h-4 w-4" aria-hidden="true" />
                 </Button>
-                <Button variant="ghost" size="icon" onClick={() => setDeleteOpen(true)}>
-                  <Trash2 className="h-4 w-4" />
+                <Button variant="ghost" size="icon" onClick={() => setDeleteOpen(true)} aria-label={`Delete: ${item.guest_name ?? t('fallbackName')}`}>
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </Button>
               </div>
             )}

--- a/messages/de.json
+++ b/messages/de.json
@@ -58,7 +58,8 @@
   },
   "Tenant": {
     "nav": {
-      "signOut": "Abmelden"
+      "signOut": "Abmelden",
+      "skipToContent": "Zum Hauptinhalt springen"
     },
     "home": {
       "today": "Heute",
@@ -113,7 +114,8 @@
       "activityCount": "{count, plural, one {# Aktivität} other {# Aktivitäten}}",
       "reservationCount": "{count, plural, one {# Reservierung} other {# Reservierungen}}",
       "breakfastCoverCount": "{count, plural, one {# Frühstücksgedeck} other {# Frühstücksgedecke}}",
-      "loading": "Laden\u2026"
+      "loading": "Laden\u2026",
+      "close": "Schlie\u00dfen"
     },
     "entry": {
       "deleteTitle": "Aktivität löschen?",

--- a/messages/en.json
+++ b/messages/en.json
@@ -58,7 +58,8 @@
   },
   "Tenant": {
     "nav": {
-      "signOut": "Sign out"
+      "signOut": "Sign out",
+      "skipToContent": "Skip to main content"
     },
     "home": {
       "today": "Today",
@@ -113,7 +114,8 @@
       "activityCount": "{count, plural, one {# activity} other {# activities}}",
       "reservationCount": "{count, plural, one {# reservation} other {# reservations}}",
       "breakfastCoverCount": "{count, plural, one {# breakfast cover} other {# breakfast covers}}",
-      "loading": "Loading\u2026"
+      "loading": "Loading\u2026",
+      "close": "Close"
     },
     "entry": {
       "deleteTitle": "Delete activity?",

--- a/messages/es.json
+++ b/messages/es.json
@@ -58,7 +58,8 @@
   },
   "Tenant": {
     "nav": {
-      "signOut": "Cerrar sesión"
+      "signOut": "Cerrar sesión",
+      "skipToContent": "Saltar al contenido principal"
     },
     "home": {
       "today": "Hoy",
@@ -113,7 +114,8 @@
       "activityCount": "{count, plural, one {# actividad} other {# actividades}}",
       "reservationCount": "{count, plural, one {# reserva} other {# reservas}}",
       "breakfastCoverCount": "{count, plural, one {# cubierto de desayuno} other {# cubiertos de desayuno}}",
-      "loading": "Cargando\u2026"
+      "loading": "Cargando\u2026",
+      "close": "Cerrar"
     },
     "entry": {
       "deleteTitle": "¿Eliminar actividad?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -58,7 +58,8 @@
   },
   "Tenant": {
     "nav": {
-      "signOut": "Se déconnecter"
+      "signOut": "Se déconnecter",
+      "skipToContent": "Aller au contenu principal"
     },
     "home": {
       "today": "Aujourd'hui",
@@ -113,7 +114,8 @@
       "activityCount": "{count, plural, one {# activité} other {# activités}}",
       "reservationCount": "{count, plural, one {# réservation} other {# réservations}}",
       "breakfastCoverCount": "{count, plural, one {# couvert petit-déjeuner} other {# couverts petit-déjeuner}}",
-      "loading": "Chargement\u2026"
+      "loading": "Chargement\u2026",
+      "close": "Fermer"
     },
     "entry": {
       "deleteTitle": "Supprimer l'activité ?",


### PR DESCRIPTION
## Summary
- Skip link (`Skip to main content`) at top of `[tenant]/layout.tsx`, targeting `#main-content` on `<main>`
- `aria-label` on all icon-only buttons (edit/delete) across `ActivityCard`, `ReservationCard`, `BreakfastCard`
- `aria-hidden="true"` on all decorative icons
- `CalendarDaySidebar`: `<aside aria-label={date}>`, close button with `aria-label={t('close')}`
- `HomeClient`: `aria-pressed` on calendar/agenda view toggle; calendar grid has `role="grid"`, headers have `role="columnheader"`, day cells have `aria-pressed`, `aria-current="date"` (today), and descriptive `aria-label` with counts
- `MobileNav`: `aria-label="Main navigation"` on `<nav>`, `aria-current="page"` on active link
- Translation keys `skipToContent` and `close` added to all 4 locales (en, fr, es, de)

## Test plan
- [ ] Tab to page — skip link appears visually on focus, activates and jumps to main content
- [ ] Screen reader on calendar: day cells announce date + summary counts
- [ ] Screen reader on cards: edit/delete buttons announce action + item name
- [ ] Screen reader on nav: announces "Main navigation", active link has "current"
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)