### PR TITLE
T-33: Tenant suspension and lifecycle management

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1201,7 +1201,7 @@ Skip link, `aria-label`s, focus/aria-live, contrast, labels, keyboard calendar n
 
 ## Ticket 33: Tenant Suspension & Lifecycle Management
 
-- [ ] **Status:** pending — set to `[x]` when done.
+- [x] **Status:** pending — set to `[x]` when done.
 
 **Priority:** P3  
 **Scope:** `supabase/migrations/`, `middleware.ts`, `app/actions/tenants.ts`, `app/admin/dashboard.tsx`  

--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -9,11 +9,14 @@ import { isValidSlug } from '@/lib/tenant-validation';
 import { getUser } from '@/app/actions/auth';
 import type { ActionResponse } from '@/types/actions';
 
+export type TenantStatus = 'active' | 'suspended' | 'archived';
+
 export type TenantRedisData = {
   id: string;
   name: string;
   slug: string;
   language: string;
+  status: TenantStatus;
 };
 
 // ---------------------------------------------------------------------------
@@ -53,7 +56,7 @@ export async function createTenant(data: {
   const { data: tenant, error } = await serviceClient
     .from('tenants')
     .insert({ name: data.name, slug: data.slug })
-    .select('id, name, slug, language')
+    .select('id, name, slug, language, status')
     .single();
 
   if (error || !tenant) {
@@ -66,6 +69,7 @@ export async function createTenant(data: {
     name: tenant.name,
     slug: tenant.slug,
     language: (tenant as { language?: string }).language ?? 'en',
+    status: ((tenant as { status?: string }).status ?? 'active') as TenantStatus,
   };
   await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData));
 
@@ -104,7 +108,7 @@ export async function getTenantBySlug(
   const serviceClient = createSupabaseServiceClient();
   const { data: tenant } = await serviceClient
     .from('tenants')
-    .select('id, name, slug, language')
+    .select('id, name, slug, language, status')
     .eq('slug', slug)
     .maybeSingle();
 
@@ -118,6 +122,7 @@ export async function getTenantBySlug(
     name: tenant.name,
     slug: tenant.slug,
     language: (tenant as { language?: string }).language ?? 'en',
+    status: ((tenant as { status?: string }).status ?? 'active') as TenantStatus,
   };
   await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData));
 
@@ -143,7 +148,7 @@ export async function updateTenant(
   // Get current record so we can clean up Redis if slug changes
   const { data: current } = await serviceClient
     .from('tenants')
-    .select('id, name, slug, language')
+    .select('id, name, slug, language, status')
     .eq('id', id)
     .single();
 
@@ -155,7 +160,7 @@ export async function updateTenant(
     .from('tenants')
     .update({ ...data, updated_at: new Date().toISOString() })
     .eq('id', id)
-    .select('id, name, slug, language')
+    .select('id, name, slug, language, status')
     .single();
 
   if (error || !updated) {
@@ -173,6 +178,7 @@ export async function updateTenant(
     name: updated.name,
     slug: updated.slug,
     language: (updated as { language?: string }).language ?? 'en',
+    status: ((updated as { status?: string }).status ?? 'active') as TenantStatus,
   };
   await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData));
 
@@ -221,4 +227,46 @@ export async function deleteTenant(id: string): Promise<ActionResponse> {
   await redis.del(`subdomain:${tenant.slug}`);
 
   return { success: true, data: undefined };
+}
+
+// ---------------------------------------------------------------------------
+// setTenantStatus — shared helper for suspend/reactivate/archive
+// ---------------------------------------------------------------------------
+async function setTenantStatus(id: string, status: TenantStatus): Promise<ActionResponse> {
+  const serviceClient = createSupabaseServiceClient();
+
+  const { data: updated, error } = await serviceClient
+    .from('tenants')
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select('id, name, slug, language, status')
+    .single();
+
+  if (error || !updated) {
+    return { success: false, error: `Failed to update tenant status.` };
+  }
+
+  // Refresh Redis so middleware picks up the new status immediately
+  const redisData: TenantRedisData = {
+    id: updated.id,
+    name: updated.name,
+    slug: updated.slug,
+    language: (updated as { language?: string }).language ?? 'en',
+    status: ((updated as { status?: string }).status ?? 'active') as TenantStatus,
+  };
+  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData));
+
+  return { success: true, data: undefined };
+}
+
+export async function suspendTenant(id: string): Promise<ActionResponse> {
+  return setTenantStatus(id, 'suspended');
+}
+
+export async function reactivateTenant(id: string): Promise<ActionResponse> {
+  return setTenantStatus(id, 'active');
+}
+
+export async function archiveTenant(id: string): Promise<ActionResponse> {
+  return setTenantStatus(id, 'archived');
 }

--- a/app/admin/dashboard.tsx
+++ b/app/admin/dashboard.tsx
@@ -5,13 +5,25 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Trash2, Loader2, ChevronDown, ChevronUp } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog';
+import { Trash2, Loader2, ChevronDown, ChevronUp, PauseCircle, PlayCircle, Archive } from 'lucide-react';
 import Link from 'next/link';
-import { deleteTenant } from '@/app/actions/tenants';
+import { deleteTenant, suspendTenant, reactivateTenant, archiveTenant } from '@/app/actions/tenants';
 import { setFeatureFlag } from '@/app/actions/feature-flags';
 import { KNOWN_FLAGS, FLAG_LABELS } from '@/lib/feature-flags';
 import type { FlagMap } from '@/lib/feature-flags';
 import { rootDomain, protocol } from '@/lib/utils';
+import type { TenantStatus } from '@/app/actions/tenants';
 
 type Tenant = {
   id: string;
@@ -19,10 +31,64 @@ type Tenant = {
   slug: string;
   language: string;
   created_at: string;
+  status: TenantStatus;
 };
 
-function TenantCard({
+const STATUS_BADGE: Record<TenantStatus, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
+  active: { label: 'Active', variant: 'default' },
+  suspended: { label: 'Suspended', variant: 'destructive' },
+  archived: { label: 'Archived', variant: 'secondary' },
+};
+
+function DeleteConfirmDialog({
   tenant,
+  open,
+  onOpenChange,
+  onConfirm,
+  isDeleting,
+}: {
+  tenant: Tenant;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onConfirm: () => void;
+  isDeleting: boolean;
+}) {
+  const [typed, setTyped] = useState('');
+  const canDelete = typed === tenant.slug;
+
+  return (
+    <AlertDialog open={open} onOpenChange={(v) => { onOpenChange(v); if (!v) setTyped(''); }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete {tenant.name}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This permanently deletes the tenant and all associated data. This cannot be undone.
+            Type <strong>{tenant.slug}</strong> to confirm.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input
+          value={typed}
+          onChange={(e) => setTyped(e.target.value)}
+          placeholder={tenant.slug}
+          autoComplete="off"
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <Button
+            variant="destructive"
+            disabled={!canDelete || isDeleting}
+            onClick={onConfirm}
+          >
+            {isDeleting ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Deleting…</> : 'Delete permanently'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function TenantCard({
+  tenant: initialTenant,
   initialFlags,
   onDelete,
   isDeleting,
@@ -32,9 +98,14 @@ function TenantCard({
   onDelete: (id: string) => void;
   isDeleting: boolean;
 }) {
+  const [tenant, setTenant] = useState(initialTenant);
   const [flags, setFlags] = useState(initialFlags);
   const [expanded, setExpanded] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const [isStatusPending, startStatusTransition] = useTransition();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const { label: statusLabel, variant: statusVariant } = STATUS_BADGE[tenant.status];
 
   function handleFlagChange(key: (typeof KNOWN_FLAGS)[number], enabled: boolean) {
     setFlags((prev) => ({ ...prev, [key]: enabled }));
@@ -43,78 +114,149 @@ function TenantCard({
     });
   }
 
+  function handleStatusChange(action: 'suspend' | 'reactivate' | 'archive') {
+    startStatusTransition(async () => {
+      const fn = action === 'suspend' ? suspendTenant : action === 'reactivate' ? reactivateTenant : archiveTenant;
+      const result = await fn(tenant.id);
+      if (result.success) {
+        const next: TenantStatus = action === 'suspend' ? 'suspended' : action === 'reactivate' ? 'active' : 'archived';
+        setTenant((t) => ({ ...t, status: next }));
+      }
+    });
+  }
+
   return (
-    <Card>
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-xl">{tenant.name}</CardTitle>
-          <Button
-            variant="ghost"
-            size="icon"
-            disabled={isDeleting}
-            onClick={() => onDelete(tenant.id)}
-            className="text-muted-foreground hover:text-foreground hover:bg-muted/50"
-          >
-            {isDeleting ? (
-              <Loader2 className="h-5 w-5 animate-spin" />
-            ) : (
-              <Trash2 className="h-5 w-5" />
-            )}
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground">{tenant.slug}</p>
-        <p className="text-sm text-muted-foreground">Language: {tenant.language}</p>
-        <p className="text-sm text-muted-foreground mt-1">
-          Created: {new Date(tenant.created_at).toLocaleDateString()}
-        </p>
-        <div className="mt-3">
-          <a
-            href={`${protocol}://${tenant.slug}.${rootDomain}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary hover:underline text-sm"
-          >
-            Visit tenant →
-          </a>
-        </div>
+    <>
+      <Card className={tenant.status === 'archived' ? 'opacity-60' : undefined}>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <CardTitle className="text-xl truncate">{tenant.name}</CardTitle>
+              <Badge variant={statusVariant}>{statusLabel}</Badge>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              disabled={isDeleting || isStatusPending}
+              onClick={() => setDeleteOpen(true)}
+              aria-label={`Delete ${tenant.name}`}
+              className="text-muted-foreground hover:text-foreground hover:bg-muted/50 shrink-0"
+            >
+              {isDeleting ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <Trash2 className="h-5 w-5" />
+              )}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{tenant.slug}</p>
+          <p className="text-sm text-muted-foreground">Language: {tenant.language}</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Created: {new Date(tenant.created_at).toLocaleDateString()}
+          </p>
+          <div className="mt-3">
+            <a
+              href={`${protocol}://${tenant.slug}.${rootDomain}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline text-sm"
+            >
+              Visit tenant →
+            </a>
+          </div>
 
-        {/* Feature flags */}
-        <div className="mt-4 border-t pt-3">
-          <button
-            type="button"
-            className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground"
-            onClick={() => setExpanded((v) => !v)}
-          >
-            Feature Flags
-            {expanded ? (
-              <ChevronUp className="w-4 h-4" />
-            ) : (
-              <ChevronDown className="w-4 h-4" />
-            )}
-          </button>
-
-          {expanded && (
-            <div className="mt-3 space-y-2">
-              {KNOWN_FLAGS.map((key) => (
-                <div key={key} className="flex items-center justify-between">
-                  <Label htmlFor={`flag-${tenant.id}-${key}`} className="text-sm">
-                    {FLAG_LABELS[key]}
-                  </Label>
-                  <Switch
-                    id={`flag-${tenant.id}-${key}`}
-                    checked={flags[key]}
-                    disabled={isPending}
-                    onCheckedChange={(checked) => handleFlagChange(key, checked)}
-                  />
-                </div>
-              ))}
+          {/* Lifecycle actions */}
+          {tenant.status !== 'archived' && (
+            <div className="mt-3 flex gap-2">
+              {tenant.status === 'active' && (
+                <>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={isStatusPending}
+                    onClick={() => handleStatusChange('suspend')}
+                  >
+                    <PauseCircle className="h-4 w-4 mr-1" /> Suspend
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={isStatusPending}
+                    onClick={() => handleStatusChange('archive')}
+                  >
+                    <Archive className="h-4 w-4 mr-1" /> Archive
+                  </Button>
+                </>
+              )}
+              {tenant.status === 'suspended' && (
+                <>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={isStatusPending}
+                    onClick={() => handleStatusChange('reactivate')}
+                  >
+                    <PlayCircle className="h-4 w-4 mr-1" /> Reactivate
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={isStatusPending}
+                    onClick={() => handleStatusChange('archive')}
+                  >
+                    <Archive className="h-4 w-4 mr-1" /> Archive
+                  </Button>
+                </>
+              )}
             </div>
           )}
-        </div>
-      </CardContent>
-    </Card>
+
+          {/* Feature flags */}
+          <div className="mt-4 border-t pt-3">
+            <button
+              type="button"
+              className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground"
+              onClick={() => setExpanded((v) => !v)}
+            >
+              Feature Flags
+              {expanded ? (
+                <ChevronUp className="w-4 h-4" />
+              ) : (
+                <ChevronDown className="w-4 h-4" />
+              )}
+            </button>
+
+            {expanded && (
+              <div className="mt-3 space-y-2">
+                {KNOWN_FLAGS.map((key) => (
+                  <div key={key} className="flex items-center justify-between">
+                    <Label htmlFor={`flag-${tenant.id}-${key}`} className="text-sm">
+                      {FLAG_LABELS[key]}
+                    </Label>
+                    <Switch
+                      id={`flag-${tenant.id}-${key}`}
+                      checked={flags[key]}
+                      disabled={isPending}
+                      onCheckedChange={(checked) => handleFlagChange(key, checked)}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <DeleteConfirmDialog
+        tenant={tenant}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onConfirm={() => { setDeleteOpen(false); onDelete(tenant.id); }}
+        isDeleting={isDeleting}
+      />
+    </>
   );
 }
 

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -16,7 +16,7 @@ export default async function AdminPage() {
   const serviceClient = createSupabaseServiceClient();
   const { data: tenants } = await serviceClient
     .from('tenants')
-    .select('id, name, slug, language, created_at')
+    .select('id, name, slug, language, created_at, status')
     .order('created_at', { ascending: false });
 
   const tenantList = tenants ?? [];

--- a/middleware.ts
+++ b/middleware.ts
@@ -86,6 +86,37 @@ export async function middleware(request: NextRequest) {
   const tenant = JSON.parse(cached) as TenantRedisData;
 
   // -------------------------------------------------------------------------
+  // 3b. Suspended / archived tenants — show a branded gate page.
+  // -------------------------------------------------------------------------
+  if (tenant.status === 'suspended' || tenant.status === 'archived') {
+    const isSuspended = tenant.status === 'suspended';
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${tenant.name} · Courseday</title>
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #f9fafb; color: #111; display: flex; align-items: center; justify-content: center; min-height: 100vh; }
+    .card { background: white; border: 1px solid #e5e7eb; border-radius: 12px; padding: 2.5rem 3rem; max-width: 420px; width: 90%; text-align: center; }
+    h1 { font-size: 1.5rem; font-weight: 700; margin: 0 0 0.5rem; }
+    p { color: #6b7280; margin: 0; line-height: 1.6; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>${tenant.name}</h1>
+    <p>${isSuspended ? 'This venue has been temporarily suspended.' : 'This venue is no longer active.'}</p>
+  </div>
+</body>
+</html>`;
+    return new NextResponse(html, {
+      status: 403,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  // -------------------------------------------------------------------------
   // 4. Auth guard for tenant routes.
   //    Public paths (no login required): /auth/*
   // -------------------------------------------------------------------------

--- a/supabase/migrations/00025_tenant_status.sql
+++ b/supabase/migrations/00025_tenant_status.sql
@@ -1,0 +1,8 @@
+-- Add status column to tenants for lifecycle management
+-- Possible values: 'active' (default), 'suspended', 'archived'
+
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'active'
+    CONSTRAINT tenants_status_check CHECK (status IN ('active', 'suspended', 'archived'));
+
+CREATE INDEX IF NOT EXISTS tenants_status_idx ON tenants (status);


### PR DESCRIPTION
## Summary
- **Migration** `00025_tenant_status.sql`: adds `status text NOT NULL DEFAULT 'active' CHECK (status IN ('active','suspended','archived'))` to `tenants`
- **`TenantRedisData`**: gains `status` field; all Supabase selects and Redis writes updated
- **New server actions**: `suspendTenant`, `reactivateTenant`, `archiveTenant` (update DB + refresh Redis atomically)
- **Middleware**: after tenant resolution, `suspended`/`archived` tenants receive a branded HTML gate page (403) — no app rendered
- **Admin dashboard**: status badge on each tenant card; Suspend / Reactivate / Archive buttons (contextual per status); typed delete confirmation requires user to type the tenant slug before delete is enabled

## Test plan
- [ ] Run migration locally (`supabase db push`)
- [ ] Suspend a tenant → visiting subdomain shows branded suspended page
- [ ] Reactivate → subdomain accessible again
- [ ] Archive → shows "no longer active" gate page
- [ ] Delete confirmation dialog requires typing slug; wrong input keeps button disabled
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)