### PR TITLE
T-4: Fix Zod 4 schema resolver — swap zodResolver for standardSchemaResolver

### DIFF
--- a/components/activity-form.tsx
+++ b/components/activity-form.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { z } from 'zod';
 import { toast } from 'sonner';
 import { Check, Plus } from 'lucide-react';
@@ -134,7 +134,7 @@ export function ActivityForm({
   const modalTitle = isEditing ? t('editTitle') : t('addTitle');
 
   const { register, handleSubmit, watch, setValue, reset, formState: { errors } } = useForm<FormData>({
-    resolver: zodResolver(formSchema),
+    resolver: standardSchemaResolver(formSchema),
     defaultValues: defaultValues(editItem),
   });
 

--- a/components/activity-tag-management.tsx
+++ b/components/activity-tag-management.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { toast } from 'sonner';
 import { Pencil, Trash2, Plus } from 'lucide-react';
 import {
@@ -59,7 +59,7 @@ function ActivityTagDialog({
     reset,
     formState: { errors },
   } = useForm<ActivityTagFormData>({
-    resolver: zodResolver(activityTagSchema),
+    resolver: standardSchemaResolver(activityTagSchema),
     defaultValues: { name: '' },
   });
 

--- a/components/breakfast-form.tsx
+++ b/components/breakfast-form.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { z } from 'zod';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
@@ -78,7 +78,7 @@ export function BreakfastForm({ isOpen, onClose, dayId, editItem, onSuccess }: P
   const isEditing = !!editItem;
 
   const { register, handleSubmit, reset } = useForm<FormData>({
-    resolver: zodResolver(formSchema),
+    resolver: standardSchemaResolver(formSchema),
     defaultValues: defaultValues(editItem),
   });
 

--- a/components/feature-request-management.tsx
+++ b/components/feature-request-management.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
 import {
@@ -54,7 +54,7 @@ export function FeatureRequestManagement() {
     reset,
     formState: { errors },
   } = useForm<FeatureRequestFormData>({
-    resolver: zodResolver(featureRequestSchema),
+    resolver: standardSchemaResolver(featureRequestSchema),
     defaultValues: { title: '', description: '' },
   });
 

--- a/components/poc-management.tsx
+++ b/components/poc-management.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { toast } from 'sonner';
 import { Pencil, Trash2, Plus } from 'lucide-react';
 import { getAllPOCs, createPOC, updatePOC, deletePOC } from '@/app/actions/poc';
@@ -58,7 +58,7 @@ function PocDialog({
     reset,
     formState: { errors },
   } = useForm<PocFormData>({
-    resolver: zodResolver(pocSchema),
+    resolver: standardSchemaResolver(pocSchema),
     defaultValues: { name: '', email: '', phone: '' },
   });
 

--- a/components/reservation-form.tsx
+++ b/components/reservation-form.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { z } from 'zod';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
@@ -76,7 +76,7 @@ export function ReservationForm({ isOpen, onClose, dayId, editItem, onSuccess }:
   const isEditing = !!editItem;
 
   const { register, handleSubmit, reset } = useForm<FormData>({
-    resolver: zodResolver(formSchema),
+    resolver: standardSchemaResolver(formSchema),
     defaultValues: defaultValues(editItem),
   });
 

--- a/components/venue-type-management.tsx
+++ b/components/venue-type-management.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { toast } from 'sonner';
 import { Pencil, Trash2, Plus } from 'lucide-react';
 import { getAllVenueTypes, createVenueType, updateVenueType, deleteVenueType } from '@/app/actions/venue-type';
@@ -54,7 +54,7 @@ function VenueTypeDialog({
     reset,
     formState: { errors },
   } = useForm<VenueTypeFormData>({
-    resolver: zodResolver(venueTypeSchema),
+    resolver: standardSchemaResolver(venueTypeSchema),
     defaultValues: { name: '', code: '' },
   });
 


### PR DESCRIPTION
## Summary

`zodResolver` from `@hookform/resolvers/zod` throws `"Invalid input: not a Zod schema"` when passed a Zod 4 schema. The project uses `zod ^4.3.6`.

**Fix:** replace `zodResolver` with `standardSchemaResolver` from `@hookform/resolvers/standard-schema` — the Standard Schema bridge that Zod 4 supports natively.

Applied to all `useForm()` call sites (same root cause):
- `feature-request-management.tsx` (reported in ticket)
- `activity-form.tsx`, `breakfast-form.tsx`, `reservation-form.tsx`
- `activity-tag-management.tsx`, `poc-management.tsx`, `venue-type-management.tsx`

No package changes needed — `@hookform/resolvers ^5.2.2` already ships `standard-schema`.

## Test plan

- [ ] Open `/admin/settings/feedback` — no runtime error
- [ ] Submit a valid feature request — succeeds
- [ ] Submit with empty title — shows validation error
- [ ] Activity, reservation, and breakfast forms still validate correctly
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)