### PR TITLE
T-5: Branding — city search with OpenWeather Geocoding API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 KV_REST_API_URL=your_upstash_redis_url
 KV_REST_API_TOKEN=your_upstash_redis_token
 NEXT_PUBLIC_ROOT_DOMAIN=localhost:3000   # or your production domain
+OPENWEATHER_API_KEY=your_openweather_api_key   # used by /api/geocode for city search in branding settings
 ```
 
 ## Architecture

--- a/app/[tenant]/admin/settings/settings-form.tsx
+++ b/app/[tenant]/admin/settings/settings-form.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { CitySearch } from '@/components/city-search';
 
 interface SettingsFormProps {
   tenantId: string;
@@ -186,39 +187,20 @@ export function SettingsForm({ tenantId, initialAccentColor, initialLogoUrl, ini
             Used to show weather forecasts on the day view.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1">
-              <Label htmlFor="latitude">Latitude</Label>
-              <Input
-                id="latitude"
-                type="number"
-                step="any"
-                min={-90}
-                max={90}
-                placeholder="51.5074"
-                value={latitude}
-                onChange={(e) => setLatitude(e.target.value)}
-              />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="longitude">Longitude</Label>
-              <Input
-                id="longitude"
-                type="number"
-                step="any"
-                min={-180}
-                max={180}
-                placeholder="-0.1278"
-                value={longitude}
-                onChange={(e) => setLongitude(e.target.value)}
-              />
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Decimal degrees. Find your coordinates at{' '}
-            <span className="font-mono">maps.google.com</span> → right-click → &ldquo;What&rsquo;s here?&rdquo;
-          </p>
+        <CardContent>
+          {/* City search replaces manual lat/lon inputs */}
+          <CitySearch
+            initialLatitude={latitude ? parseFloat(latitude) : null}
+            initialLongitude={longitude ? parseFloat(longitude) : null}
+            onSelect={(lat, lon) => {
+              setLatitude(String(lat));
+              setLongitude(String(lon));
+            }}
+            onClear={() => {
+              setLatitude('');
+              setLongitude('');
+            }}
+          />
         </CardContent>
       </Card>
 

--- a/app/api/geocode/route.ts
+++ b/app/api/geocode/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Server-side proxy so OPENWEATHER_API_KEY never reaches the client bundle.
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get('q');
+  if (!q || q.trim().length < 2) {
+    return NextResponse.json([]);
+  }
+
+  const apiKey = process.env.OPENWEATHER_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Geocoding not configured.' }, { status: 503 });
+  }
+
+  const url =
+    `https://api.openweathermap.org/geo/1.0/direct` +
+    `?q=${encodeURIComponent(q.trim())}&limit=5&appid=${apiKey}`;
+
+  try {
+    const res = await fetch(url, {
+      // Cache for 60 s — same query returns the same cities
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Geocoding service error.' }, { status: 502 });
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ error: 'Failed to reach geocoding service.' }, { status: 500 });
+  }
+}

--- a/components/city-search.tsx
+++ b/components/city-search.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Search, X, MapPin } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+
+export interface GeoResult {
+  name: string;
+  lat: number;
+  lon: number;
+  country: string;
+  state?: string;
+}
+
+function formatCity(r: GeoResult) {
+  return r.state ? `${r.name}, ${r.state}, ${r.country}` : `${r.name}, ${r.country}`;
+}
+
+interface CitySearchProps {
+  initialLatitude: number | null;
+  initialLongitude: number | null;
+  onSelect: (lat: number, lon: number) => void;
+  onClear: () => void;
+}
+
+export function CitySearch({ initialLatitude, initialLongitude, onSelect, onClear }: CitySearchProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<GeoResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<GeoResult | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onMouseDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, []);
+
+  const search = useCallback(async (q: string) => {
+    if (q.trim().length < 2) {
+      setResults([]);
+      setOpen(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/geocode?q=${encodeURIComponent(q)}`);
+      if (!res.ok) throw new Error('Search failed');
+      const data: GeoResult[] | { error: string } = await res.json();
+      if ('error' in data) throw new Error(data.error);
+      setResults(data);
+      setOpen(data.length > 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'City search failed.');
+      setResults([]);
+      setOpen(false);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const val = e.target.value;
+    setQuery(val);
+    setSelected(null);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(val), 300);
+  }
+
+  function handleSelect(r: GeoResult) {
+    setSelected(r);
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+    onSelect(r.lat, r.lon);
+  }
+
+  function handleClear() {
+    setSelected(null);
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+    onClear();
+  }
+
+  const hasCoords = initialLatitude != null && initialLongitude != null;
+
+  return (
+    <div ref={containerRef} className="relative space-y-2">
+      {selected ? (
+        // Newly selected city
+        <div className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+          <div className="flex items-center gap-2">
+            <MapPin className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span>{formatCity(selected)}</span>
+          </div>
+          <button
+            type="button"
+            onClick={handleClear}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Clear location"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      ) : hasCoords && !query ? (
+        // Pre-existing coordinates (no city name stored)
+        <div className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <MapPin className="h-4 w-4 shrink-0" />
+            <span className="font-mono text-xs">
+              {initialLatitude?.toFixed(4)}, {initialLongitude?.toFixed(4)}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={handleClear}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Clear location"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      ) : (
+        // Search input
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          <Input
+            placeholder="Search for a city…"
+            value={query}
+            onChange={handleInputChange}
+            onFocus={() => results.length > 0 && setOpen(true)}
+            className="pl-9"
+            aria-label="City search"
+            aria-autocomplete="list"
+            aria-expanded={open}
+          />
+        </div>
+      )}
+
+      {loading && <p className="text-xs text-muted-foreground">Searching…</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      {!loading && !error && open && results.length === 0 && query.length >= 2 && (
+        <p className="text-xs text-muted-foreground">No cities found.</p>
+      )}
+
+      {open && results.length > 0 && (
+        <ul
+          role="listbox"
+          className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md overflow-hidden"
+        >
+          {results.map((r, i) => (
+            <li key={i} role="option" aria-selected={false}>
+              <button
+                type="button"
+                onClick={() => handleSelect(r)}
+                className="flex w-full items-center gap-2 px-3 py-2.5 text-sm text-left hover:bg-accent transition-colors"
+              >
+                <MapPin className="h-4 w-4 text-muted-foreground shrink-0" />
+                {formatCity(r)}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **`/api/geocode` route handler** — server-side proxy to OpenWeather Geocoding API (`geo/1.0/direct`). `OPENWEATHER_API_KEY` never leaves the server. Responses cached 60 s. Returns `[]` on short queries, `503` if key missing.
- **`CitySearch` component** — debounced (300ms) search input with dropdown of up to 5 city results. Selecting a city sets `latitude`/`longitude` in form state. Clear button resets. Pre-existing coordinates shown when no city has been selected yet.
- **`SettingsForm`** — manual lat/lon number inputs replaced with `CitySearch`. Internal lat/lon state unchanged; saves via existing `updateTenant` flow.
- **`CLAUDE.md`** — `OPENWEATHER_API_KEY` documented.

## Test plan

- [ ] Set `OPENWEATHER_API_KEY` in `.env.local`
- [ ] Open `/admin/settings/branding` — city search input visible
- [ ] Type "lon" → dropdown shows London, Londonderry, etc.
- [ ] Select a city → lat/lon saved; "Save changes" persists to DB
- [ ] Clear → fields reset
- [ ] Without API key → search shows error, does not crash
- [ ] API key not present in client bundle (check Network tab)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)