### PR TITLE
T-6: Apply tenant accent color across tenant UI

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -108,7 +108,7 @@ export default async function TenantLayout({
           >
             {t('skipToContent')}
           </a>
-          <div className="min-h-screen flex flex-col" dir={dir} style={accentStyle}>
+          <div className="tenant-themed min-h-screen flex flex-col" dir={dir} style={accentStyle}>
             <header className="border-b px-6 h-14 flex items-center justify-between">
               <Logo logoUrl={row?.logo_url} tenantName={row?.name} />
               <div className="flex items-center gap-1">

--- a/app/globals.css
+++ b/app/globals.css
@@ -123,6 +123,32 @@
   }
 }
 
+/*
+ * Tenant accent color theming.
+ * The tenant layout sets --tenant-accent as an inline style on .tenant-themed
+ * when accent_color is non-null. Fallback values in :root / .dark match the
+ * current primary defaults, so unbranded tenants are visually unchanged.
+ *
+ * Light mode: accent is typically a medium-dark brand color → white foreground.
+ * Dark mode: accent default is a light value → dark foreground.
+ * For custom dark accents in dark mode, consider a future v2 with color-contrast().
+ */
+.tenant-themed {
+  --primary: var(--tenant-accent);
+  --primary-foreground: oklch(1 0 0);
+  --ring: var(--tenant-accent);
+  --sidebar-primary: var(--tenant-accent);
+  --sidebar-primary-foreground: oklch(1 0 0);
+}
+
+.dark .tenant-themed {
+  --primary: var(--tenant-accent);
+  --primary-foreground: oklch(0.141 0.005 285.823);
+  --ring: var(--tenant-accent);
+  --sidebar-primary: var(--tenant-accent);
+  --sidebar-primary-foreground: oklch(0.141 0.005 285.823);
+}
+
 .emoji-picker-container .epr-body::-webkit-scrollbar {
   width: 8px;
 }


### PR DESCRIPTION
## Summary

- Added `.tenant-themed` CSS scope in `globals.css` that maps `--primary`, `--primary-foreground`, `--ring`, `--sidebar-primary`, and `--sidebar-primary-foreground` to `var(--tenant-accent)`
- Added `tenant-themed` class to the tenant layout wrapper `<div>` (which already receives `--tenant-accent` as an inline style from `accent_color`)
- **Light mode**: white foreground on accent — works for medium-to-dark brand colors
- **Dark mode**: dark foreground on accent — works because the default dark accent is a light value
- **Fallback**: when `accent_color` is null, `--tenant-accent` falls back to the `:root`/`.dark` defaults which match the current primary exactly — no visual change for unbranded tenants

## Test plan

- [ ] Set an accent color in branding settings (e.g. `#0066cc`)
- [ ] Reload — buttons, focus rings, and sidebar primary use the accent color
- [ ] Toggle dark/light mode — both modes remain readable
- [ ] Tenant with no accent set — visually identical to before
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)