### PR TITLE
T-7: Fix invite and member list — surface errors, robust email fetch

### DIFF
--- a/app/actions/memberships.ts
+++ b/app/actions/memberships.ts
@@ -39,19 +39,27 @@ export async function getMembers(): Promise<ActionResponse<Member[]>> {
   if (!memberships?.length) return { success: true, data: [] };
 
   const serviceClient = createSupabaseServiceClient();
-  const emailResults = await Promise.all(
+  // Use allSettled so one failed lookup doesn't crash the whole list.
+  const emailResults = await Promise.allSettled(
     memberships.map((m) => serviceClient.auth.admin.getUserById(m.user_id))
   );
 
   return {
     success: true,
-    data: memberships.map((m, i) => ({
-      id: m.id,
-      user_id: m.user_id,
-      email: emailResults[i].data.user?.email ?? '',
-      role: m.role as MemberRole,
-      created_at: m.created_at,
-    })),
+    data: memberships.map((m, i) => {
+      const settled = emailResults[i];
+      const email =
+        settled.status === 'fulfilled'
+          ? (settled.value.data.user?.email ?? '')
+          : '';
+      return {
+        id: m.id,
+        user_id: m.user_id,
+        email,
+        role: m.role as MemberRole,
+        created_at: m.created_at,
+      };
+    }),
   };
 }
 
@@ -90,11 +98,17 @@ export async function inviteMember(
   const serviceClient = createSupabaseServiceClient();
 
   // Look up whether the email belongs to an existing auth user.
-  const { data: existingUserId } = await serviceClient.rpc('get_user_id_by_email', {
-    p_email: trimmedEmail,
-  });
+  const { data: existingUserId, error: rpcError } = await serviceClient.rpc(
+    'get_user_id_by_email',
+    { p_email: trimmedEmail }
+  );
 
-  if (existingUserId) {
+  if (rpcError) {
+    // RPC unavailable or failed — log server-side, fall through to pending invitation.
+    console.error('[inviteMember] get_user_id_by_email RPC error:', rpcError.message);
+  }
+
+  if (!rpcError && existingUserId) {
     // User already exists — check if already a member of this tenant.
     const { data: existingMembership } = await serviceClient
       .from('memberships')

--- a/components/member-management.tsx
+++ b/components/member-management.tsx
@@ -112,6 +112,7 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
   const [members, setMembers] = useState<Member[]>([]);
   const [pending, setPending] = useState<PendingInvitation[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [removeTarget, setRemoveTarget] = useState<Member | null>(null);
   const [isRemoving, startRemoveTransition] = useTransition();
   const [isCancelling, startCancelTransition] = useTransition();
@@ -121,8 +122,17 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
       getMembers(),
       getPendingInvitations(),
     ]);
-    if (membersResult.success) setMembers(membersResult.data);
-    if (pendingResult.success) setPending(pendingResult.data);
+    if (membersResult.success) {
+      setMembers(membersResult.data);
+    } else {
+      toast.error(membersResult.error);
+      setLoadError(membersResult.error);
+    }
+    if (pendingResult.success) {
+      setPending(pendingResult.data);
+    } else {
+      toast.error(pendingResult.error);
+    }
   }
 
   useEffect(() => {
@@ -172,6 +182,10 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
 
   if (loading) {
     return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+
+  if (loadError) {
+    return <p className="text-sm text-destructive">{loadError}</p>;
   }
 
   return (


### PR DESCRIPTION
## Summary

### Root causes found

| Location | Bug |
|----------|-----|
| `getMembers` | `Promise.all` on `getUserById` — one failed lookup crashed emails for the whole list, shown as silent empty strings |
| `inviteMember` | RPC error from `get_user_id_by_email` was ignored; existing users would silently receive a pending invite instead of direct membership |
| `MemberManagement` | No toast or error state when `getMembers` / `getPendingInvitations` returned `success: false` |

### Fixes

- **`getMembers`**: `Promise.all` → `Promise.allSettled` — failed individual email lookups are isolated; member still appears in the list with an empty email rather than breaking the whole response
- **`inviteMember`**: Capture `rpcError`; log server-side; only treat RPC result as authoritative if the call succeeded; otherwise fall through to pending invitation (safe degraded behaviour)
- **`MemberManagement`**: Added `loadError` state; `refresh()` now calls `toast.error` and sets `loadError` on failure; renders an error message instead of empty list

### Required env vars

- `SUPABASE_SERVICE_ROLE_KEY` — needed for `auth.admin.getUserById` email lookups and the `get_user_id_by_email` RPC (service_role only). Without it, member emails will be empty.
- `get_user_id_by_email` RPC must be deployed (migration `00017_pending_invitations.sql`).

## Test plan

- [ ] Members page loads and shows email addresses
- [ ] Invite existing user → direct membership created
- [ ] Invite new email → pending invitation created
- [ ] Duplicate invite → "already a member" / "invitation exists" error shown
- [ ] With `SUPABASE_SERVICE_ROLE_KEY` missing → error toast shown, not silent empty list
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)