### PR TITLE
T-8: Fix template settings + surface silent ActionResponse failures

### DIFF
--- a/components/activity-tag-management.tsx
+++ b/components/activity-tag-management.tsx
@@ -125,7 +125,11 @@ export function ActivityTagManagement() {
 
   useEffect(() => {
     getAllActivityTags().then((result) => {
-      if (result.success) setTags(result.data);
+      if (result.success) {
+        setTags(result.data);
+      } else {
+        toast.error(result.error);
+      }
       setLoading(false);
     });
   }, []);

--- a/components/feature-request-management.tsx
+++ b/components/feature-request-management.tsx
@@ -60,7 +60,11 @@ export function FeatureRequestManagement() {
 
   useEffect(() => {
     getTenantFeatureRequests().then((result) => {
-      if (result.success) setRequests(result.data);
+      if (result.success) {
+        setRequests(result.data);
+      } else {
+        toast.error(result.error);
+      }
       setLoading(false);
     });
   }, []);

--- a/components/poc-management.tsx
+++ b/components/poc-management.tsx
@@ -149,7 +149,11 @@ export function PocManagement() {
 
   useEffect(() => {
     getAllPOCs().then((result) => {
-      if (result.success) setPocs(result.data);
+      if (result.success) {
+        setPocs(result.data);
+      } else {
+        toast.error(result.error);
+      }
       setLoading(false);
     });
   }, []);

--- a/components/schedule-template-management.tsx
+++ b/components/schedule-template-management.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { getTemplates, deleteTemplate } from '@/app/actions/schedule-templates';
@@ -27,7 +28,11 @@ export function ScheduleTemplateManagement() {
   const load = useCallback(async () => {
     setLoading(true);
     const result = await getTemplates();
-    if (result.success) setTemplates(result.data);
+    if (result.success) {
+      setTemplates(result.data);
+    } else {
+      toast.error(result.error);
+    }
     setLoading(false);
   }, []);
 
@@ -48,7 +53,16 @@ export function ScheduleTemplateManagement() {
   if (loading) return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
 
   if (templates.length === 0) {
-    return <p className="text-sm text-muted-foreground">{t('settingsEmpty')}</p>;
+    // Templates are created from the day view — link there so users know where to go.
+    const today = new Date().toISOString().split('T')[0];
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">{t('settingsEmpty')}</p>
+        <Button asChild variant="outline" size="sm">
+          <Link href={`/day/${today}`}>{t('goToDayView')}</Link>
+        </Button>
+      </div>
+    );
   }
 
   return (

--- a/components/venue-type-management.tsx
+++ b/components/venue-type-management.tsx
@@ -129,7 +129,11 @@ export function VenueTypeManagement() {
 
   useEffect(() => {
     getAllVenueTypes().then((result) => {
-      if (result.success) setVenueTypes(result.data);
+      if (result.success) {
+        setVenueTypes(result.data);
+      } else {
+        toast.error(result.error);
+      }
       setLoading(false);
     });
   }, []);

--- a/messages/en.json
+++ b/messages/en.json
@@ -380,7 +380,8 @@
       "deleteDescription": "“{name}” will be permanently deleted.",
       "delete": "Delete",
       "deleting": "Deleting…",
-      "deleted": "Template deleted."
+      "deleted": "Template deleted.",
+      "goToDayView": "Open today's day view"
     },
     "venueType": {
       "title": "Venue Types",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -380,7 +380,8 @@
       "deleteDescription": "« {name} » sera définitivement supprimé.",
       "delete": "Supprimer",
       "deleting": "Suppression…",
-      "deleted": "Modèle supprimé."
+      "deleted": "Modèle supprimé.",
+      "goToDayView": "Ouvrir la vue du jour"
     },
     "venueType": {
       "title": "Types de lieu",


### PR DESCRIPTION
## Summary

### Templates settings

- `ScheduleTemplateManagement` now shows a `toast.error` when `getTemplates()` fails (previously showed an empty list indistinguishable from "no templates")
- When the list is genuinely empty, added a **CTA button** linking to today's day view — templates are saved from there, so this gives users a path to create their first one

### Audit — silent `ActionResponse` failures across all settings components

Same `if (result.success) setState(...)` pattern (no `else`) found and fixed in:

| Component | Action |
|-----------|--------|
| `poc-management` | `getAllPOCs()` |
| `venue-type-management` | `getAllVenueTypes()` |
| `activity-tag-management` | `getAllActivityTags()` |
| `feature-request-management` | `getTenantFeatureRequests()` |

All now call `toast.error(result.error)` in the `else` branch.

`MemberManagement` was already fixed in T-7.

## Test plan

- [ ] Templates page: with templates → list renders; delete works
- [ ] Templates page: no templates → empty message + "Open today's day view" link
- [ ] Templates page: DB error → toast shown, not silent empty list
- [ ] POC / venue type / activity tag / feedback pages: server errors surface as toasts
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)