### PR TITLE
T-10: Realtime updates — tenant day view (incl. PWA)

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useDayRealtime } from './useDayRealtime';
 import { useTranslations } from 'next-intl';
 import { Plus, Copy, LayoutTemplate } from 'lucide-react';
 import { DayNav } from '@/components/day-nav';
@@ -51,6 +52,9 @@ export function DayViewClient({
   const [breakfastConfigs, setBreakfastConfigs] = useState<BreakfastConfiguration[]>(
     initialBreakfastConfigs
   );
+
+  // Subscribe to realtime updates for this day — unsubscribes on navigation away.
+  useDayRealtime(dayId, setActivities, setReservations, setBreakfastConfigs);
 
   // Activity modal state
   const [activityModalOpen, setActivityModalOpen] = useState(false);

--- a/app/[tenant]/day/[date]/useDayRealtime.ts
+++ b/app/[tenant]/day/[date]/useDayRealtime.ts
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-client';
+import type {
+  ActivityWithRelations,
+  Reservation,
+  BreakfastConfiguration,
+} from '@/types/index';
+
+type SetActivities = React.Dispatch<React.SetStateAction<ActivityWithRelations[]>>;
+type SetReservations = React.Dispatch<React.SetStateAction<Reservation[]>>;
+type SetBreakfastConfigs = React.Dispatch<React.SetStateAction<BreakfastConfiguration[]>>;
+
+/**
+ * Subscribes to Postgres changes for the three day-view tables scoped to the
+ * given `dayId`. State setters are patched on each event:
+ *
+ * - INSERT: append (skip if already present, e.g. optimistic update from this session)
+ * - UPDATE: replace by id (preserves existing joined fields like poc/venue_type
+ *   that realtime rows don't carry)
+ * - DELETE: remove by id
+ *
+ * The channel is removed on component unmount or when `dayId` changes (navigation).
+ *
+ * Limitation: calendar aggregate counts are not updated in real-time.
+ * Realtime only applies to the day view.
+ */
+export function useDayRealtime(
+  dayId: string,
+  setActivities: SetActivities,
+  setReservations: SetReservations,
+  setBreakfastConfigs: SetBreakfastConfigs
+) {
+  useEffect(() => {
+    const supabase = createSupabaseBrowserClient();
+
+    const channel = supabase
+      .channel(`day-${dayId}`)
+      // Activities
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'activity',
+          filter: `day_id=eq.${dayId}`,
+        },
+        (payload) => {
+          if (payload.eventType === 'INSERT') {
+            const row = payload.new as ActivityWithRelations;
+            setActivities((prev) => {
+              if (prev.some((a) => a.id === row.id)) return prev;
+              return [...prev, row].sort((a, b) =>
+                (a.start_time ?? '').localeCompare(b.start_time ?? '')
+              );
+            });
+          } else if (payload.eventType === 'UPDATE') {
+            const row = payload.new as ActivityWithRelations;
+            // Merge to preserve joined fields (venue_type, poc, tags) that
+            // the realtime payload doesn't include.
+            setActivities((prev) =>
+              prev.map((a) => (a.id === row.id ? { ...a, ...row } : a))
+            );
+          } else if (payload.eventType === 'DELETE') {
+            const id = (payload.old as { id: string }).id;
+            setActivities((prev) => prev.filter((a) => a.id !== id));
+          }
+        }
+      )
+      // Reservations
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'reservation',
+          filter: `day_id=eq.${dayId}`,
+        },
+        (payload) => {
+          if (payload.eventType === 'INSERT') {
+            const row = payload.new as Reservation;
+            setReservations((prev) => {
+              if (prev.some((r) => r.id === row.id)) return prev;
+              return [...prev, row].sort((a, b) =>
+                (a.start_time ?? '').localeCompare(b.start_time ?? '')
+              );
+            });
+          } else if (payload.eventType === 'UPDATE') {
+            const row = payload.new as Reservation;
+            setReservations((prev) =>
+              prev.map((r) => (r.id === row.id ? row : r))
+            );
+          } else if (payload.eventType === 'DELETE') {
+            const id = (payload.old as { id: string }).id;
+            setReservations((prev) => prev.filter((r) => r.id !== id));
+          }
+        }
+      )
+      // Breakfast configurations
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'breakfast_configuration',
+          filter: `day_id=eq.${dayId}`,
+        },
+        (payload) => {
+          if (payload.eventType === 'INSERT') {
+            const row = payload.new as BreakfastConfiguration;
+            setBreakfastConfigs((prev) => {
+              if (prev.some((c) => c.id === row.id)) return prev;
+              return [...prev, row];
+            });
+          } else if (payload.eventType === 'UPDATE') {
+            const row = payload.new as BreakfastConfiguration;
+            setBreakfastConfigs((prev) =>
+              prev.map((c) => (c.id === row.id ? row : c))
+            );
+          } else if (payload.eventType === 'DELETE') {
+            const id = (payload.old as { id: string }).id;
+            setBreakfastConfigs((prev) => prev.filter((c) => c.id !== id));
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [dayId, setActivities, setReservations, setBreakfastConfigs]);
+}

--- a/supabase/migrations/00026_realtime.sql
+++ b/supabase/migrations/00026_realtime.sql
@@ -1,0 +1,17 @@
+-- =============================================================================
+-- Migration 00026: Enable Supabase Realtime for day-view tables
+-- =============================================================================
+--
+-- REPLICA IDENTITY FULL ensures that UPDATE and DELETE events include the
+-- complete old row in the realtime payload, not just the primary key.
+--
+-- Limitation: realtime subscriptions are scoped to the day view only.
+-- Calendar aggregate counts are NOT updated in real-time.
+
+ALTER TABLE activity REPLICA IDENTITY FULL;
+ALTER TABLE reservation REPLICA IDENTITY FULL;
+ALTER TABLE breakfast_configuration REPLICA IDENTITY FULL;
+
+ALTER PUBLICATION supabase_realtime ADD TABLE activity;
+ALTER PUBLICATION supabase_realtime ADD TABLE reservation;
+ALTER PUBLICATION supabase_realtime ADD TABLE breakfast_configuration;


### PR DESCRIPTION
## Summary

Two changes: a DB migration to enable realtime on the day-view tables, and a hook that wires live updates into the existing React state.

### Migration `00026_realtime.sql`

- `REPLICA IDENTITY FULL` on `activity`, `reservation`, `breakfast_configuration` — required for `UPDATE`/`DELETE` events to carry the full row
- Adds all three tables to `supabase_realtime` publication

### `useDayRealtime` hook

- Subscribes to a single Supabase channel `day-{dayId}` with three `postgres_changes` listeners, each filtered by `day_id=eq.{dayId}`
- State patch strategy:
  - **INSERT** — append, skip if already present (prevents duplicate when the local user's optimistic update already added it)
  - **UPDATE** — merge `{ ...existing, ...row }` to preserve joined fields (`venue_type`, `point_of_contact`, `tags`) that the realtime payload doesn't include
  - **DELETE** — filter by `id`
- `useEffect` cleanup calls `supabase.removeChannel()` on unmount or `dayId` change — no channel leaks on navigation

### `DayViewClient`

Single `useDayRealtime(dayId, setActivities, setReservations, setBreakfastConfigs)` call wires the hook. Both editor and viewer benefit (viewer receives state via props passed to `ViewerDayDashboard`).

### PWA

Service workers pass through WebSocket connections transparently — no additional configuration needed.

### Limitations (documented in hook comment)

- Calendar aggregate counts (`golfCount`, `reservationCount`, `breakfastCount` on home page) are **not** updated in real-time

## Test plan

- [ ] Run `supabase db push` or apply migration `00026_realtime.sql`
- [ ] Open the same day in two browser tabs — changes in one appear in the other without reload
- [ ] Editor adds activity → appears in viewer tab
- [ ] Editor deletes reservation → disappears in viewer tab
- [ ] Navigate away from day → confirm channel removed (no WS connection in DevTools)
- [ ] Install as PWA, repeat the two-session smoke test
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)