### PR TITLE
T-11: PWA tenant name, theme color, and icon consistency

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -27,13 +27,15 @@ export async function generateMetadata(): Promise<Metadata> {
     const supabase = await createSupabaseServerClient();
     const { data } = await supabase
       .from('tenants')
-      .select('name')
+      .select('name, accent_color')
       .eq('id', tenant.id)
       .single();
     const name = data?.name as string | undefined;
+    const accentColor = (data?.accent_color as string | null) ?? '#e5e7eb';
     return {
       title: name ? `${name} · Courseday` : 'Courseday',
       manifest: '/pwa/manifest',
+      themeColor: accentColor,
       appleWebApp: {
         capable: true,
         statusBarStyle: 'default',

--- a/app/[tenant]/pwa/icon/route.ts
+++ b/app/[tenant]/pwa/icon/route.ts
@@ -54,7 +54,7 @@ export async function GET() {
     return new NextResponse(buildSvg(initials, bg, fg), {
       headers: {
         'Content-Type': 'image/svg+xml',
-        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
       },
     });
   } catch {

--- a/app/[tenant]/pwa/manifest/route.ts
+++ b/app/[tenant]/pwa/manifest/route.ts
@@ -44,7 +44,9 @@ export async function GET() {
     return NextResponse.json(manifest, {
       headers: {
         'Content-Type': 'application/manifest+json',
-        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        // no-cache: always revalidate — manifest is tiny and must reflect
+        // branding changes (name, theme_color) without delay.
+        'Cache-Control': 'no-cache',
       },
     });
   } catch {


### PR DESCRIPTION
## Summary
- `generateMetadata` in tenant layout now fetches `accent_color` alongside `name` and emits a `themeColor` meta tag — Android Chrome and iOS status bar pick up the tenant accent
- Manifest `Cache-Control` changed from 1-hour TTL to `no-cache` so branding changes (name, theme_color) are reflected immediately
- Icon `Cache-Control` reduced from 1 hour to `max-age=300, stale-while-revalidate=3600` (5 min fresh, revalidate in background) — short enough to pick up logo/accent changes without hammering the DB

## Test plan
- [ ] Install PWA for a tenant, change accent color in settings, reload — status bar color updates on next visit
- [ ] Verify manifest response has `Cache-Control: no-cache`
- [ ] Verify icon response has `Cache-Control: public, max-age=300, stale-while-revalidate=3600`
- [ ] `<meta name="theme-color">` in page `<head>` matches tenant accent

🤖 Generated with [Claude Code](https://claude.com/claude-code)