### PR TITLE
feat(new-tenant): add spam folder hint on confirmation screen

### DIFF
--- a/app/(platform)/new/new-tenant-form.tsx
+++ b/app/(platform)/new/new-tenant-form.tsx
@@ -73,6 +73,9 @@ export function NewTenantForm() {
                 {t('checkEmailBodyPrefix')} <strong>{email}</strong>. {t('checkEmailBodySuffix')}
               </p>
               <p className="text-sm text-muted-foreground">
+                {t('checkEmailSpamHint')}
+              </p>
+              <p className="text-sm text-muted-foreground">
                 {t('checkEmailDomainPrefix')}{' '}
                 <strong>{createdSlug}.{rootDomain}</strong>
               </p>

--- a/messages/de.json
+++ b/messages/de.json
@@ -69,6 +69,7 @@
       "checkEmailDomain": "Dann melden Sie sich an bei {domain}",
       "checkEmailBodyPrefix": "Wir haben einen Bestätigungslink gesendet an",
       "checkEmailBodySuffix": "Klicken Sie darauf, um Ihr Konto zu aktivieren.",
+      "checkEmailSpamHint": "Falls Sie sie nicht finden, prüfen Sie bitte Ihren Spam- oder Junk-Ordner.",
       "checkEmailDomainPrefix": "Dann melden Sie sich an bei"
     }
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -168,6 +168,7 @@
       "checkEmailDomain": "Then sign in at {domain}",
       "checkEmailBodyPrefix": "We sent a confirmation link to",
       "checkEmailBodySuffix": "Click it to activate your account.",
+      "checkEmailSpamHint": "If you don't see it, check your spam or junk folder.",
       "checkEmailDomainPrefix": "Then sign in at"
     }
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -69,6 +69,7 @@
       "checkEmailDomain": "Luego inicia sesión en {domain}",
       "checkEmailBodyPrefix": "Hemos enviado un enlace de confirmación a",
       "checkEmailBodySuffix": "Haz clic en él para activar tu cuenta.",
+      "checkEmailSpamHint": "Si no lo ves, revisa tu carpeta de spam o correo no deseado.",
       "checkEmailDomainPrefix": "Luego inicia sesión en"
     }
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -168,6 +168,7 @@
       "checkEmailDomain": "Connectez-vous ensuite sur {domain}",
       "checkEmailBodyPrefix": "Nous avons envoyé un lien de confirmation à",
       "checkEmailBodySuffix": "Cliquez dessus pour activer votre compte.",
+      "checkEmailSpamHint": "Si vous ne le voyez pas, vérifiez votre dossier spam ou courrier indésirable.",
       "checkEmailDomainPrefix": "Connectez-vous ensuite sur"
     }
   },


### PR DESCRIPTION
## Summary
- After creating a new venue, the confirmation screen now also tells the user the email might land in their spam/junk folder.
- New `checkEmailSpamHint` translation key added in `en`, `fr`, `de`, `es`.

## Test plan
- [ ] Visit `/new`, submit the form, confirm the new spam-folder hint appears between the "we sent a link" sentence and the "sign in at …" line.
- [ ] Switch tenant language to fr/de/es and re-check the hint renders the localized copy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AaLJZYdgaMpgL9BsgjUvSQ)_