### PR TITLE
refactor: remove unused code field from venue_type

### DIFF
--- a/app/actions/venue-type.ts
+++ b/app/actions/venue-type.ts
@@ -8,10 +8,6 @@ import type { VenueTypeFormData } from '@/lib/venue-type-schema'
 import type { ActionResponse } from '@/types/actions'
 import type { VenueType } from '@/types/index'
 
-function normaliseEmpty(s: string | undefined | null): string | null {
-  return s && s.trim() !== '' ? s.trim() : null
-}
-
 export async function getAllVenueTypes(): Promise<ActionResponse<VenueType[]>> {
   const tenantId = await getTenantId()
   const role = await getUserRole(tenantId)
@@ -43,7 +39,6 @@ export async function createVenueType(raw: VenueTypeFormData): Promise<ActionRes
     .insert({
       tenant_id: tenantId,
       name: parsed.data.name.trim(),
-      code: normaliseEmpty(parsed.data.code),
     })
     .select()
     .single()
@@ -52,7 +47,7 @@ export async function createVenueType(raw: VenueTypeFormData): Promise<ActionRes
     const isDupe = error.code === '23505'
     return {
       success: false,
-      error: isDupe ? 'A venue type with that name or code already exists.' : error.message,
+      error: isDupe ? 'A venue type with that name already exists.' : error.message,
     }
   }
 
@@ -76,7 +71,6 @@ export async function updateVenueType(
     .from('venue_type')
     .update({
       name: parsed.data.name.trim(),
-      code: normaliseEmpty(parsed.data.code),
       updated_at: new Date().toISOString(),
     })
     .eq('id', id)
@@ -88,7 +82,7 @@ export async function updateVenueType(
     const isDupe = error.code === '23505'
     return {
       success: false,
-      error: isDupe ? 'A venue type with that name or code already exists.' : error.message,
+      error: isDupe ? 'A venue type with that name already exists.' : error.message,
     }
   }
 

--- a/components/activity-form.tsx
+++ b/components/activity-form.tsx
@@ -136,7 +136,6 @@ export function ActivityForm({
   const [venueTypes, setVenueTypes] = useState(initialVenueTypes)
   const [showNewVt, setShowNewVt] = useState(false)
   const [newVtName, setNewVtName] = useState('')
-  const [newVtCode, setNewVtCode] = useState('')
   const [isSavingVt, startVtTransition] = useTransition()
 
   // Tag multi-select
@@ -192,7 +191,6 @@ export function ActivityForm({
       setNewPocEmail('')
       setNewPocPhone('')
       setNewVtName('')
-      setNewVtCode('')
       getAllActivityTags().then((r) => {
         if (r.success) setAllTags(r.data)
       })
@@ -237,7 +235,6 @@ export function ActivityForm({
     setNewPocEmail('')
     setNewPocPhone('')
     setNewVtName('')
-    setNewVtCode('')
     getAllActivityTags().then((r) => {
       if (r.success) setAllTags(r.data)
     })
@@ -275,7 +272,7 @@ export function ActivityForm({
   function handleSaveVenueType() {
     if (!newVtName.trim()) return
     startVtTransition(async () => {
-      const result = await createVenueType({ name: newVtName, code: newVtCode })
+      const result = await createVenueType({ name: newVtName })
       if (!result.success) {
         toast.error(result.error)
         return
@@ -284,7 +281,6 @@ export function ActivityForm({
       setValue('venueTypeId', result.data.id)
       setShowNewVt(false)
       setNewVtName('')
-      setNewVtCode('')
       toast.success(t('venueTypeAdded'))
     })
   }
@@ -448,11 +444,6 @@ export function ActivityForm({
               placeholder={t('namePlaceholder')}
               value={newVtName}
               onChange={(e) => setNewVtName(e.target.value)}
-            />
-            <Input
-              placeholder={t('codePlaceholder')}
-              value={newVtCode}
-              onChange={(e) => setNewVtCode(e.target.value)}
             />
             <div className="flex justify-end gap-2">
               <Button type="button" size="sm" variant="outline" onClick={() => setShowNewVt(false)}>

--- a/components/venue-type-management.tsx
+++ b/components/venue-type-management.tsx
@@ -55,11 +55,11 @@ function VenueTypeDialog({
     formState: { errors },
   } = useForm<VenueTypeFormData>({
     resolver: standardSchemaResolver(venueTypeSchema),
-    defaultValues: { name: '', code: '' },
+    defaultValues: { name: '' },
   })
 
   useEffect(() => {
-    reset(initial ? { name: initial.name, code: initial.code ?? '' } : { name: '', code: '' })
+    reset(initial ? { name: initial.name } : { name: '' })
   }, [initial, open, reset])
 
   function onSubmit(data: VenueTypeFormData) {
@@ -89,11 +89,6 @@ function VenueTypeDialog({
             <Label htmlFor="vt-name">Name *</Label>
             <Input id="vt-name" {...register('name')} />
             {errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="vt-code">Code</Label>
-            <Input id="vt-code" {...register('code')} placeholder="e.g. REST" />
           </div>
 
           <div className="flex justify-end gap-2 pt-2">
@@ -180,7 +175,6 @@ export function VenueTypeManagement() {
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
-              <TableHead>Code</TableHead>
               <TableHead className="w-24" />
             </TableRow>
           </TableHeader>
@@ -188,7 +182,6 @@ export function VenueTypeManagement() {
             {venueTypes.map((vt) => (
               <TableRow key={vt.id}>
                 <TableCell className="font-medium">{vt.name}</TableCell>
-                <TableCell>{vt.code ?? '—'}</TableCell>
                 <TableCell>
                   <div className="flex justify-end gap-1">
                     <Button

--- a/lib/venue-type-schema.ts
+++ b/lib/venue-type-schema.ts
@@ -2,7 +2,6 @@ import { z } from 'zod'
 
 export const venueTypeSchema = z.object({
   name: z.string().min(1, 'Name is required').max(200),
-  code: z.string().max(50).optional().or(z.literal('')),
 })
 
 export type VenueTypeFormData = z.infer<typeof venueTypeSchema>

--- a/messages/de.json
+++ b/messages/de.json
@@ -322,8 +322,7 @@
       "venueTypeAdded": "Raumart hinzugefügt.",
       "namePlaceholder": "Name *",
       "emailPlaceholder": "E-Mail (optional)",
-      "phonePlaceholder": "Telefon (optional)",
-      "codePlaceholder": "Code (optional)"
+      "phonePlaceholder": "Telefon (optional)"
     },
     "reservationForm": {
       "addTitle": "Reservierung hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -427,8 +427,7 @@
       "venueTypeAdded": "Venue type added.",
       "namePlaceholder": "Name *",
       "emailPlaceholder": "Email (optional)",
-      "phonePlaceholder": "Phone (optional)",
-      "codePlaceholder": "Code (optional)"
+      "phonePlaceholder": "Phone (optional)"
     },
     "reservationForm": {
       "addTitle": "Add reservation",

--- a/messages/es.json
+++ b/messages/es.json
@@ -322,8 +322,7 @@
       "venueTypeAdded": "Tipo de espacio añadido.",
       "namePlaceholder": "Nombre *",
       "emailPlaceholder": "Correo (opcional)",
-      "phonePlaceholder": "Teléfono (opcional)",
-      "codePlaceholder": "Código (opcional)"
+      "phonePlaceholder": "Teléfono (opcional)"
     },
     "reservationForm": {
       "addTitle": "Añadir reserva",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -427,8 +427,7 @@
       "venueTypeAdded": "Type de lieu ajouté.",
       "namePlaceholder": "Nom *",
       "emailPlaceholder": "E-mail (optionnel)",
-      "phonePlaceholder": "Téléphone (optionnel)",
-      "codePlaceholder": "Code (optionnel)"
+      "phonePlaceholder": "Téléphone (optionnel)"
     },
     "reservationForm": {
       "addTitle": "Ajouter une réservation",

--- a/supabase/migrations/00036_remove_venue_type_code.sql
+++ b/supabase/migrations/00036_remove_venue_type_code.sql
@@ -1,0 +1,7 @@
+-- Remove unused `code` column from venue_type.
+-- The column is not referenced in business logic; `name` already provides
+-- per-tenant uniqueness via venue_type_tenant_name_unique.
+
+DROP INDEX IF EXISTS venue_type_tenant_code_unique;
+
+ALTER TABLE venue_type DROP COLUMN IF EXISTS code;

--- a/tests/actions/venue-type.test.ts
+++ b/tests/actions/venue-type.test.ts
@@ -2,18 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { venueTypeSchema } from '@/lib/venue-type-schema'
 
 describe('venueTypeSchema', () => {
-  it('accepts a valid name and code', () => {
-    const result = venueTypeSchema.safeParse({ name: 'Main Restaurant', code: 'REST' })
+  it('accepts a valid name', () => {
+    const result = venueTypeSchema.safeParse({ name: 'Main Restaurant' })
     expect(result.success).toBe(true)
   })
 
-  it('accepts name only (code optional)', () => {
+  it('accepts name only', () => {
     const result = venueTypeSchema.safeParse({ name: 'Terrace' })
-    expect(result.success).toBe(true)
-  })
-
-  it('accepts empty string for code (treated as absent)', () => {
-    const result = venueTypeSchema.safeParse({ name: 'Clubhouse', code: '' })
     expect(result.success).toBe(true)
   })
 
@@ -30,11 +25,6 @@ describe('venueTypeSchema', () => {
 
   it('accepts name with special characters', () => {
     const result = venueTypeSchema.safeParse({ name: '19th Hole Bar & Grill' })
-    expect(result.success).toBe(true)
-  })
-
-  it('accepts a code with spaces', () => {
-    const result = venueTypeSchema.safeParse({ name: 'Pro Shop', code: 'PRO SHOP' })
     expect(result.success).toBe(true)
   })
 })

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1117,7 +1117,6 @@ export type Database = {
       }
       venue_type: {
         Row: {
-          code: string | null
           created_at: string
           id: string
           name: string
@@ -1125,7 +1124,6 @@ export type Database = {
           updated_at: string
         }
         Insert: {
-          code?: string | null
           created_at?: string
           id?: string
           name: string
@@ -1133,7 +1131,6 @@ export type Database = {
           updated_at?: string
         }
         Update: {
-          code?: string | null
           created_at?: string
           id?: string
           name?: string


### PR DESCRIPTION
Closes #108

## Summary

The `code` column on `venue_type` was unused operationally and added friction during onboarding. `name` already provides per-tenant uniqueness via `venue_type_tenant_name_unique`, and no business logic, joins, exports, or integrations referenced `code`.

## Changes

**Database**
- New migration `00036_remove_venue_type_code.sql` drops `venue_type_tenant_code_unique` index and the `code` column.

**Types**
- `types/supabase.ts` — manually updated to drop `code` from `venue_type` Row/Insert/Update (no Supabase CLI in this env; rerun `pnpm db:types` post-merge to confirm).

**Schema / actions**
- `lib/venue-type-schema.ts` — drops `code` from Zod schema.
- `app/actions/venue-type.ts` — removes `normaliseEmpty` helper, drops `code` from insert/update, simplifies dupe error message.

**UI**
- `components/venue-type-management.tsx` — removes Code label/input, Code column, and `vt.code` cell.
- `components/activity-form.tsx` — removes inline `newVtCode` state + Input on the new-venue-type quick-create panel.

**i18n**
- Drops `Tenant.activityForm.codePlaceholder` from `en/fr/de/es.json`.

**Tests**
- `tests/actions/venue-type.test.ts` — drops the four code-specific cases; keeps name-only assertions.

## Verification

- `pnpm exec tsc --noEmit` → clean
- `pnpm test:run` → 22 files / 187 tests passed
- `pnpm lint` → 0 errors (43 pre-existing warnings, none in touched files)
- `pnpm build` → success

## Notes

- `program_item.venue_type_id` and `checklist_template.venue_type_id` reference `venue_type.id` (not `code`); no FK changes.
- Redis tenant cache does not contain venue type codes.
- After merge, run `pnpm db:types` once the migration is applied to regenerate `types/supabase.ts` (the manual diff here matches the expected output).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WnqjLCVSZFnv4JoKYS35by)_