### PR TITLE
fix(ci): supabase db push no longer accepts --project-ref

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -5,9 +5,12 @@ on:
     branches: [main]
     paths:
       - 'supabase/migrations/**'
+      - '.github/workflows/migration-check.yml'
   pull_request:
     paths:
       - 'supabase/migrations/**'
+      - '.github/workflows/migration-check.yml'
+  workflow_dispatch:
 
 jobs:
   validate:
@@ -56,8 +59,14 @@ jobs:
         with:
           version: latest
 
+      - name: Link Supabase project
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
       - name: Push migrations
-        run: supabase db push --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
## Problem

The migration deploy on the merge of #118 failed:

```
unknown flag: --project-ref
```

The Supabase CLI dropped `--project-ref` from `supabase db push`. The flag is still on `supabase link`, so the modern pattern is to link first, then push.

## Fix

```yaml
- name: Link Supabase project
  run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
- name: Push migrations
  run: supabase db push
```

`supabase db push` defaults to `--linked: true`, so no flag is needed on the push step.

## Re-trigger pending migration

The failed run did not apply `00036_remove_venue_type_code.sql`. To force a re-run on merge:

- Added `.github/workflows/migration-check.yml` to the workflow's path filter, so this PR's merge to `main` triggers the deploy job under the fixed workflow.
- 00036 is idempotent (`DROP INDEX IF EXISTS` / `DROP COLUMN IF EXISTS`), so even if it had partially run it's safe to re-apply.
- Also added `workflow_dispatch` so the deploy can be triggered manually if anything else goes sideways.

## Verification plan

- [ ] CI lint/typecheck/unit/build pass on this PR.
- [ ] After merge, the Migrations workflow runs on `main` and `Push Migrations to Production` succeeds.
- [ ] Confirm `code` column is gone from `venue_type` on the production Supabase project (`select column_name from information_schema.columns where table_name='venue_type'`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WnqjLCVSZFnv4JoKYS35by)_