### PR TITLE
fix: update role check constraints from viewer to staff

### DIFF
--- a/supabase/migrations/00040_fix_membership_role_constraint.sql
+++ b/supabase/migrations/00040_fix_membership_role_constraint.sql
@@ -1,0 +1,26 @@
+-- =============================================================================
+-- Migration 00040: Fix role check constraints after 00039 failed to apply
+-- =============================================================================
+-- Migration 00039 (merge_staff_into_memberships) was never pushed to production.
+-- Production still has CHECK (role IN ('editor', 'viewer')) on both tables and
+-- one existing 'viewer' membership row. This migration brings production in line
+-- with the intended state: role is 'editor' | 'staff'.
+-- =============================================================================
+
+BEGIN;
+
+-- 1. memberships: drop old constraint first, rename rows, add new constraint.
+ALTER TABLE memberships DROP CONSTRAINT IF EXISTS memberships_role_check;
+UPDATE memberships SET role = 'staff' WHERE role = 'viewer';
+ALTER TABLE memberships
+  ADD CONSTRAINT memberships_role_check CHECK (role IN ('editor', 'staff'));
+ALTER TABLE memberships ALTER COLUMN role SET DEFAULT 'staff';
+
+-- 2. pending_invitations: same pattern.
+ALTER TABLE pending_invitations DROP CONSTRAINT IF EXISTS pending_invitations_role_check;
+UPDATE pending_invitations SET role = 'staff' WHERE role = 'viewer';
+ALTER TABLE pending_invitations
+  ADD CONSTRAINT pending_invitations_role_check CHECK (role IN ('editor', 'staff'));
+ALTER TABLE pending_invitations ALTER COLUMN role SET DEFAULT 'staff';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Migration 00039 (`merge_staff_into_memberships`) was never applied to production, leaving `memberships` and `pending_invitations` with `CHECK (role IN ('editor', 'viewer'))`
- The invite action sends `role='staff'` (post-rename), which violated the old constraint — causing the error while the invite email still went out
- Migration 00040 drops the old constraints, renames any remaining `viewer` rows to `staff`, and adds the correct `('editor', 'staff')` constraints on both tables; also updates the column defaults
- Already applied directly to production via Supabase MCP

## Test plan

- [ ] Invite a new member (new email) — membership created, invite email sent, no error
- [ ] Invite an existing user — membership created directly, no error
- [ ] Confirm existing members with `viewer` role now show as `staff`
- [ ] Role change (editor ↔ staff) works in settings

https://claude.ai/code/session_01HvggSRQmGuoFRBsf52buSN

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvggSRQmGuoFRBsf52buSN)_