### PR TITLE
Promote AI quick-add to global navbar

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, usePathname, useRouter } from 'next/navigation'
 import { useDayRealtime } from './useDayRealtime'
 import { useTranslations } from 'next-intl'
-import { Plus, Sparkles, SlidersHorizontal } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { toast } from 'sonner'
 import { DayNav } from '@/components/day-nav'
 import { DaySummaryCard } from '@/components/day-summary-card'
@@ -19,14 +19,11 @@ import { DayNotes } from '@/components/day-notes'
 import { DayInfoBanner } from '@/components/day-info-banner'
 import { StaffScheduleSection } from '@/components/staff-schedule-section'
 import { HandoverControls } from '@/components/handover-controls'
-import { QuickAddInput } from '@/components/quick-add-input'
 import type { ActivityQuickAddSeed } from '@/components/activity-form'
 import type { ReservationQuickAdd } from '@/components/reservation-form'
 import type { BreakfastQuickAdd } from '@/components/breakfast-form'
 import { Button } from '@/components/ui/button'
-import { MenuItem } from '@/components/ui/menu-item'
 import { KbdHint } from '@/components/kbd-hint'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useFeatureFlag } from '@/lib/feature-flags-context'
 import { useActiveDay } from '@/lib/active-day-context'
 import { useDayViewHotkeys } from '@/lib/keyboard-shortcuts'
@@ -238,6 +235,7 @@ function DayViewEditor({
   const showBreakfast = useFeatureFlag('breakfast_config')
   const showWeatherReporting = useFeatureFlag('weather_reporting')
   const showDailyBrief = useFeatureFlag('daily_brief')
+  const { pendingQuickAddResult, setPendingQuickAddResult } = useActiveDay()
 
   const {
     activities,
@@ -260,7 +258,6 @@ function DayViewEditor({
 
   const [breakfastModalOpen, setBreakfastModalOpen] = useState(false)
   const [editBreakfast, setEditBreakfast] = useState<BreakfastConfiguration | null>(null)
-  const [quickAddOpen, setQuickAddOpen] = useState(false)
   const [activityQuickAdd, setActivityQuickAdd] = useState<ActivityQuickAddSeed | null>(null)
   const [reservationQuickAdd, setReservationQuickAdd] = useState<ReservationQuickAdd | null>(null)
   const [breakfastQuickAdd, setBreakfastQuickAdd] = useState<BreakfastQuickAdd | null>(null)
@@ -473,14 +470,19 @@ function DayViewEditor({
   })
 
   useEffect(() => {
-    if (searchParams.get('openQuickAdd') === '1') {
-      setQuickAddOpen(true)
-      const params = new URLSearchParams(searchParams.toString())
-      params.delete('openQuickAdd')
-      const q = params.toString()
-      router.replace(q ? `${pathname}?${q}` : pathname, { scroll: false })
+    if (!pendingQuickAddResult) return
+    setPendingQuickAddResult(null)
+    if (pendingQuickAddResult.type === 'success') {
+      handleQuickAddSuccess(pendingQuickAddResult.data, pendingQuickAddResult.raw)
+    } else {
+      handleQuickAddParseFailed(pendingQuickAddResult.raw, pendingQuickAddResult.error)
     }
-  }, [searchParams, router, pathname])
+  }, [
+    pendingQuickAddResult,
+    setPendingQuickAddResult,
+    handleQuickAddSuccess,
+    handleQuickAddParseFailed,
+  ])
 
   useEffect(() => {
     const create = searchParams.get('create')
@@ -508,36 +510,7 @@ function DayViewEditor({
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 px-3 py-4 sm:px-6 sm:py-8">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <DayNav date={date} today={today} />
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant="outline" size="sm" className="shrink-0">
-              <SlidersHorizontal className="h-4 w-4" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="end" className="w-44 p-1">
-            <MenuItem
-              type="button"
-              onClick={() => {
-                returnFocusRef.current = null
-                setQuickAddOpen(true)
-              }}
-            >
-              <Sparkles className="h-4 w-4 shrink-0" />
-              {tQa('openButton')}
-            </MenuItem>
-          </PopoverContent>
-        </Popover>
-      </div>
-
-      <QuickAddInput
-        open={quickAddOpen}
-        onOpenChange={setQuickAddOpen}
-        contextDate={date}
-        onSuccess={handleQuickAddSuccess}
-        onParseFailed={handleQuickAddParseFailed}
-      />
+      <DayNav date={date} today={today} />
 
       {showHandover && (
         <HandoverControls

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -26,6 +26,7 @@ import { getTenantToday } from '@/lib/day-utils'
 import { getSuperadminImpersonationRole } from '@/lib/superadmin'
 import { getTenantPalette, getTenantThemeCssVariables } from '@/lib/theme/palettes'
 import { TenantKeyboardShell } from '@/components/tenant-keyboard-shell'
+import { GlobalQuickAdd } from '@/components/global-quick-add'
 
 export async function generateMetadata(): Promise<Metadata> {
   try {
@@ -138,6 +139,8 @@ export default async function TenantLayout({ children }: { children: React.React
                     <OfflineStatusPill />
                     {/* Theme toggle — visible to all signed-in users */}
                     {user && <ThemeToggle />}
+                    {/* AI quick-add — editors only */}
+                    {editor && <GlobalQuickAdd />}
                     {/* Settings dropdown — editors only, desktop */}
                     {editor && (
                       <span className="hidden sm:inline-flex">

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -29,7 +29,7 @@ export function CommandPalette() {
   const showChecklists = useFeatureFlag('checklists')
   const showReservations = useFeatureFlag('reservations')
   const showBreakfast = useFeatureFlag('breakfast_config')
-  const { commandPaletteOpen, setCommandPaletteOpen } = useKeyboardShortcuts()
+  const { commandPaletteOpen, setCommandPaletteOpen, setQuickAddOpen } = useKeyboardShortcuts()
 
   const [datePickOpen, setDatePickOpen] = useState(false)
 
@@ -58,11 +58,9 @@ export function CommandPalette() {
     close()
   }
 
-  function openQuickAddOnDay() {
-    const q = new URLSearchParams()
-    q.set('openQuickAdd', '1')
-    router.push(`/day/${activeDayYmd}?${q.toString()}`)
+  function openQuickAdd() {
     close()
+    setQuickAddOpen(true)
   }
 
   function handleSignOut() {
@@ -166,7 +164,7 @@ export function CommandPalette() {
 
               {isEditor && (
                 <Command.Group heading={t('groupCreate')}>
-                  <Command.Item value="quick-add" onSelect={openQuickAddOnDay}>
+                  <Command.Item value="quick-add" onSelect={openQuickAdd}>
                     {t('cmdQuickAdd')}
                   </Command.Item>
                   <Command.Item value="new-activity" onSelect={() => openNewOnDay('activity')}>

--- a/components/global-quick-add.tsx
+++ b/components/global-quick-add.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
+import { Sparkles } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { QuickAddInput } from '@/components/quick-add-input'
+import { Button } from '@/components/ui/button'
+import { useActiveDay } from '@/lib/active-day-context'
+import { useKeyboardShortcuts } from '@/lib/keyboard-shortcuts'
+import type { QuickAddParseData } from '@/lib/quick-add-types'
+
+/**
+ * Navbar trigger button + QuickAddInput dialog, mounted once in the tenant layout.
+ * Open state lives in KeyboardShortcutsContext so the command palette can trigger it too.
+ * Parse results are ferried to DayViewClient via ActiveDayContext.pendingQuickAddResult.
+ */
+export function GlobalQuickAdd() {
+  const t = useTranslations('Tenant.quickAdd')
+  const router = useRouter()
+  const pathname = usePathname()
+  const { activeDayYmd } = useActiveDay()
+  const { setPendingQuickAddResult } = useActiveDay()
+  const { quickAddOpen, setQuickAddOpen } = useKeyboardShortcuts()
+
+  const handleSuccess = useCallback(
+    (data: QuickAddParseData, raw: string) => {
+      setPendingQuickAddResult({ type: 'success', data, raw })
+      const targetPath = `/day/${data.contextDate}`
+      if (!pathname.startsWith(targetPath)) {
+        router.push(targetPath)
+      }
+    },
+    [pathname, router, setPendingQuickAddResult]
+  )
+
+  const handleParseFailed = useCallback(
+    (raw: string, error: string) => {
+      setPendingQuickAddResult({ type: 'failed', raw, error })
+      const targetPath = `/day/${activeDayYmd}`
+      if (!pathname.startsWith(targetPath)) {
+        router.push(targetPath)
+      }
+    },
+    [activeDayYmd, pathname, router, setPendingQuickAddResult]
+  )
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="iconSm"
+        aria-label={t('openButton')}
+        onClick={() => setQuickAddOpen(true)}
+      >
+        <Sparkles className="h-4 w-4" />
+      </Button>
+      <QuickAddInput
+        open={quickAddOpen}
+        onOpenChange={setQuickAddOpen}
+        contextDate={activeDayYmd}
+        onSuccess={handleSuccess}
+        onParseFailed={handleParseFailed}
+      />
+    </>
+  )
+}

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Home, CalendarDays, Settings } from 'lucide-react'
+import { Home, CalendarDays, Settings, Sparkles } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import {
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/drawer'
 import { getVisibleSettingsRoutes } from '@/components/settings-dropdown'
 import { useFeatureFlag } from '@/lib/feature-flags-context'
+import { useKeyboardShortcuts } from '@/lib/keyboard-shortcuts'
 
 interface MobileNavProps {
   today: string
@@ -25,7 +26,9 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
   const pathname = usePathname()
   const navT = useTranslations('Tenant.nav')
   const settingsT = useTranslations('Tenant.settings')
+  const qaT = useTranslations('Tenant.quickAdd')
   const showChecklists = useFeatureFlag('checklists')
+  const { setQuickAddOpen } = useKeyboardShortcuts()
   const settingsRoutes = getVisibleSettingsRoutes({
     checklists: showChecklists,
   })
@@ -62,6 +65,19 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
             {label}
           </Link>
         ))}
+
+        {isEditor && (
+          /* Quick-add center slot — tab nav trigger, bespoke surface. */
+          /* eslint-disable-next-line no-restricted-syntax */
+          <button
+            aria-label={qaT('openButton')}
+            onClick={() => setQuickAddOpen(true)}
+            className="text-muted-foreground flex flex-1 flex-col items-center justify-center gap-1 text-xs font-medium transition-colors"
+          >
+            <Sparkles className="h-5 w-5" aria-hidden="true" />
+            {qaT('openButton')}
+          </button>
+        )}
 
         {isEditor && (
           <Drawer direction="bottom">

--- a/lib/active-day-context.tsx
+++ b/lib/active-day-context.tsx
@@ -1,12 +1,19 @@
 'use client'
 
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import type { QuickAddParseData } from '@/lib/quick-add-types'
+
+export type PendingQuickAddResult =
+  | { type: 'success'; data: QuickAddParseData; raw: string }
+  | { type: 'failed'; raw: string; error: string }
 
 type ActiveDayContextValue = {
   /** Tenant calendar "today" from server (navigation lower bound). */
   tenantTodayYmd: string
   activeDayYmd: string
   setActiveDayYmd: (ymd: string) => void
+  pendingQuickAddResult: PendingQuickAddResult | null
+  setPendingQuickAddResult: (r: PendingQuickAddResult | null) => void
 }
 
 const ActiveDayContext = createContext<ActiveDayContextValue | null>(null)
@@ -19,14 +26,23 @@ export function ActiveDayProvider({
   children: ReactNode
 }) {
   const [activeDayYmd, setState] = useState(tenantTodayYmd)
+  const [pendingQuickAddResult, setPendingQuickAddResult] = useState<PendingQuickAddResult | null>(
+    null
+  )
 
   const setActiveDayYmd = useCallback((ymd: string) => {
     setState(ymd)
   }, [])
 
   const value = useMemo(
-    () => ({ tenantTodayYmd, activeDayYmd, setActiveDayYmd }),
-    [tenantTodayYmd, activeDayYmd, setActiveDayYmd]
+    () => ({
+      tenantTodayYmd,
+      activeDayYmd,
+      setActiveDayYmd,
+      pendingQuickAddResult,
+      setPendingQuickAddResult,
+    }),
+    [tenantTodayYmd, activeDayYmd, setActiveDayYmd, pendingQuickAddResult]
   )
 
   return <ActiveDayContext.Provider value={value}>{children}</ActiveDayContext.Provider>

--- a/lib/keyboard-shortcuts.tsx
+++ b/lib/keyboard-shortcuts.tsx
@@ -30,6 +30,8 @@ type KeyboardShortcutsContextValue = {
   setCommandPaletteOpen: (open: boolean) => void
   shortcutsSheetOpen: boolean
   setShortcutsSheetOpen: (open: boolean) => void
+  quickAddOpen: boolean
+  setQuickAddOpen: (open: boolean) => void
   /** When true, day-level single-letter shortcuts should not run. */
   dayHotkeysSuspended: boolean
 }
@@ -47,8 +49,9 @@ export function useKeyboardShortcuts(): KeyboardShortcutsContextValue {
 export function KeyboardShortcutsProvider({ children }: { children: ReactNode }) {
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
   const [shortcutsSheetOpen, setShortcutsSheetOpen] = useState(false)
+  const [quickAddOpen, setQuickAddOpen] = useState(false)
 
-  const dayHotkeysSuspended = commandPaletteOpen || shortcutsSheetOpen
+  const dayHotkeysSuspended = commandPaletteOpen || shortcutsSheetOpen || quickAddOpen
 
   const value = useMemo(
     () => ({
@@ -56,9 +59,11 @@ export function KeyboardShortcutsProvider({ children }: { children: ReactNode })
       setCommandPaletteOpen,
       shortcutsSheetOpen,
       setShortcutsSheetOpen,
+      quickAddOpen,
+      setQuickAddOpen,
       dayHotkeysSuspended,
     }),
-    [commandPaletteOpen, shortcutsSheetOpen, dayHotkeysSuspended]
+    [commandPaletteOpen, shortcutsSheetOpen, quickAddOpen, dayHotkeysSuspended]
   )
 
   useEffect(() => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #115. Moves the AI quick-add entry point from the day-view Popover into the global tenant navbar so editors can trigger it from any route.

- **`components/global-quick-add.tsx`** (new): self-contained trigger button + `QuickAddInput` dialog, editor-only. Open state lives in `KeyboardShortcutsContext` so command palette and mobile nav share it.
- **`lib/keyboard-shortcuts.tsx`**: add `quickAddOpen`/`setQuickAddOpen`; also counts toward `dayHotkeysSuspended`.
- **`lib/active-day-context.tsx`**: add `pendingQuickAddResult` slot — ferries parsed payloads from the global component to `DayViewEditor` after navigation or on the same page.
- **`app/[tenant]/layout.tsx`**: render `<GlobalQuickAdd />` in the header action group (editors only).
- **`components/mobile-nav.tsx`**: centre Sparkles button calls `setQuickAddOpen(true)` for editor sessions.
- **`components/command-palette.tsx`**: replaces `openQuickAddOnDay` (navigate + `?openQuickAdd=1`) with direct `setQuickAddOpen(true)`.
- **`app/[tenant]/day/[date]/DayViewClient.tsx`**: removes local `quickAddOpen` state, day-scoped Popover trigger, `<QuickAddInput>` mount, and `?openQuickAdd=1` effect; subscribes to `pendingQuickAddResult` to keep existing success/failure handlers wired for both same-page and post-navigation cases.

## Test plan

- [ ] Quick-add button visible in navbar on home, agenda, settings, and day routes (editor only)
- [ ] Mobile nav shows Sparkles centre slot for editors
- [ ] Dialog opens with `contextDate = activeDayYmd` (today on non-day routes, the day's date on day routes)
- [ ] Parse success on non-day route → navigates to `/day/{contextDate}` with correct prefilled form open
- [ ] Parse success on day route → prefilled form opens with no extra navigation
- [ ] Parse failure → reservation form opens with raw text in notes
- [ ] `reservations`/`breakfast_config` feature flags still fall back correctly
- [ ] Command palette quick-add shortcut opens dialog (no navigation)
- [ ] Viewers do not see the button
- [ ] All 187 unit tests pass

https://claude.ai/code/session_015HEyx9bQzAKm12ceUjDdDQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015HEyx9bQzAKm12ceUjDdDQ)_