### PR TITLE
Hide logout button on mobile for viewer/staff role

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -148,7 +148,11 @@ export default async function TenantLayout({ children }: { children: React.React
                       </span>
                     )}
                     <NotificationBell initialCount={unreadCount} />
-                    {user && <UserMenu user={user} signOutLabel={t('signOut')} />}
+                    {user && (
+                      <span className={editor ? undefined : 'hidden sm:inline-flex'}>
+                        <UserMenu user={user} signOutLabel={t('signOut')} />
+                      </span>
+                    )}
                   </div>
                 </header>
                 <main id="main-content" className="flex-1 pb-16 sm:pb-0">


### PR DESCRIPTION
## Summary

- Logout button in top navbar now hidden on mobile (`< sm`) for viewer/staff users
- Editors keep it visible at all breakpoints (they have fewer nav items)
- Accidental taps on small screens eliminated for staff

## Test plan

- [ ] Open day view as viewer on mobile — logout button absent from top nav
- [ ] Open day view as editor on mobile — logout button still visible
- [ ] On desktop (≥ sm) as viewer — logout button visible as before

https://claude.ai/code/session_01NQDTP9gANCbgpuhxFYhagG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQDTP9gANCbgpuhxFYhagG)_