### PR TITLE
fix: ensure tenant data syncs across devices

### DIFF
--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -1,5 +1,9 @@
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
 import { getTenantFromHeaders } from '@/lib/tenant'
 import { requireTenantMember } from '@/lib/guards'
 import { getAuthState } from '@/app/actions/auth'

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -1,5 +1,9 @@
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
 import { getTenantFromHeaders } from '@/lib/tenant'
 import { requireTenantMember } from '@/lib/guards'
 import { ensureDaysRange } from '@/app/actions/days'

--- a/app/actions/activities.ts
+++ b/app/actions/activities.ts
@@ -10,6 +10,7 @@ import { ensureDayExists } from '@/app/actions/days'
 import { notifyTenantMembers, getDayDate, awaitNotifications } from '@/lib/notifications'
 import { mutationRateLimit } from '@/lib/rate-limit'
 import { snapshotMatchingTemplatesForActivity } from '@/lib/checklist-snapshot'
+import { revalidateDay } from '@/lib/revalidate'
 import type { ActionResponse } from '@/types/actions'
 import type { Activity, ActivityWithRelations } from '@/types/index'
 import type { ActivityFormData } from '@/lib/program-item-schema'
@@ -123,6 +124,7 @@ export async function createActivity(raw: ActivityFormData): Promise<ActionRespo
       'createActivity'
     )
 
+    revalidateDay()
     return { success: true, data: activity }
   }
 
@@ -216,6 +218,7 @@ export async function createActivity(raw: ActivityFormData): Promise<ActionRespo
     'createActivity (recurring)'
   )
 
+  revalidateDay()
   return { success: true, data: primary }
 }
 
@@ -274,6 +277,7 @@ export async function updateActivity(
     'updateActivity'
   )
 
+  revalidateDay()
   return { success: true, data: row as Activity }
 }
 
@@ -319,6 +323,7 @@ export async function deleteActivity(id: string): Promise<ActionResponse> {
     )
   }
 
+  revalidateDay()
   return { success: true, data: undefined }
 }
 
@@ -336,6 +341,7 @@ export async function deleteActivityRecurrenceGroup(groupId: string): Promise<Ac
     .is('deleted_at', null)
 
   if (error) return { success: false, error: error.message }
+  revalidateDay()
   return { success: true, data: undefined }
 }
 
@@ -418,6 +424,7 @@ export async function deleteActivityFromHere(id: string, groupId: string): Promi
     'deleteActivityFromHere'
   )
 
+  revalidateDay()
   return { success: true, data: undefined }
 }
 

--- a/app/actions/breakfast.ts
+++ b/app/actions/breakfast.ts
@@ -6,6 +6,7 @@ import { requireEditor, getUserRole } from '@/lib/membership'
 import { isFeatureEnabled } from '@/app/actions/feature-flags'
 import { createBreakfastSchema, updateBreakfastSchema } from '@/lib/breakfast-schema'
 import { notifyTenantMembers, getDayDate, awaitNotifications } from '@/lib/notifications'
+import { revalidateDay } from '@/lib/revalidate'
 import type { CreateBreakfastFormData, UpdateBreakfastFormData } from '@/lib/breakfast-schema'
 import type { ActionResponse } from '@/types/actions'
 import type { BreakfastConfiguration } from '@/types/index'
@@ -75,6 +76,7 @@ export async function createBreakfastConfiguration(
     'createBreakfastConfiguration'
   )
 
+  revalidateDay()
   return { success: true, data: data as BreakfastConfiguration }
 }
 
@@ -132,6 +134,7 @@ export async function updateBreakfastConfiguration(
     'updateBreakfastConfiguration'
   )
 
+  revalidateDay()
   return { success: true, data: row }
 }
 
@@ -181,6 +184,7 @@ export async function deleteBreakfastConfiguration(id: string): Promise<ActionRe
     )
   }
 
+  revalidateDay()
   return { success: true, data: undefined }
 }
 

--- a/app/actions/reservations.ts
+++ b/app/actions/reservations.ts
@@ -6,6 +6,7 @@ import { getUserRole, requireEditor } from '@/lib/membership'
 import { isFeatureEnabled } from '@/app/actions/feature-flags'
 import { reservationSchema } from '@/lib/reservation-schema'
 import { notifyTenantMembers, getDayDate, awaitNotifications } from '@/lib/notifications'
+import { revalidateDay } from '@/lib/revalidate'
 import type { ReservationFormData } from '@/lib/reservation-schema'
 import type { ActionResponse } from '@/types/actions'
 import type { Reservation } from '@/types/index'
@@ -61,6 +62,7 @@ export async function createReservation(
     'createReservation'
   )
 
+  revalidateDay()
   return { success: true, data: data as Reservation }
 }
 
@@ -118,6 +120,7 @@ export async function updateReservation(
     'updateReservation'
   )
 
+  revalidateDay()
   return { success: true, data: data as Reservation }
 }
 
@@ -167,6 +170,7 @@ export async function deleteReservation(id: string): Promise<ActionResponse> {
     )
   }
 
+  revalidateDay()
   return { success: true, data: undefined }
 }
 

--- a/lib/revalidate.ts
+++ b/lib/revalidate.ts
@@ -1,0 +1,9 @@
+import { revalidatePath } from 'next/cache'
+
+export function revalidateDay(date?: string | null) {
+  revalidatePath('/[tenant]/day/[date]', 'page')
+  revalidatePath('/[tenant]', 'page')
+  if (date) {
+    revalidatePath(`/[tenant]/day/${date}`, 'page')
+  }
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'courseday-v2';
+const CACHE_NAME = 'courseday-v3';
 
 // Never cache these paths
 const SKIP_PREFIXES = ['/auth/', '/api/'];
@@ -57,7 +57,22 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Network-first for pages — fall back to cache when offline
+  // HTML page navigations: always go to network, never cache.
+  // Caching SSR pages causes stale data across devices because revalidation
+  // can't reach a service-worker cache.
+  const isPageNavigation =
+    event.request.mode === 'navigate' ||
+    (event.request.destination === 'document') ||
+    (event.request.headers.get('accept') || '').includes('text/html');
+
+  if (isPageNavigation) {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
+  // Network-first for everything else (e.g. images, fonts) — fall back to cache offline
   event.respondWith(
     fetch(event.request)
       .then((response) => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,3 +10,9 @@ vi.mock('@/lib/redis', () => ({
     expire: vi.fn(),
   })),
 }))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  unstable_cache: <T>(fn: T) => fn,
+}))


### PR DESCRIPTION
## Summary

Activities, reservations, and breakfast configs were saving to Supabase but never appearing on other devices. Three caching layers conspired:

- **Server actions never invalidated the route cache.** `app/actions/activities.ts`, `reservations.ts`, and `breakfast.ts` mutated the DB but skipped `revalidatePath`, so the Next.js full-route cache kept serving the old SSR.
- **Day + tenant home pages had no dynamic directive.** Added `dynamic = 'force-dynamic'` and `revalidate = 0` so each request re-queries Supabase.
- **The service worker cached HTML page navigations.** `public/sw.js` was network-first for pages, which sounds safe but writes every successful HTML response into the cache and shadows revalidation. Page navigations now bypass the SW cache entirely; static assets keep their cache-first behavior. Bumped `CACHE_NAME` to `v3` so existing clients drop the stale cache on activate.

Added `lib/revalidate.ts` exposing a single `revalidateDay()` helper used by all mutation actions.

## Test plan

- [ ] On Device A, create an activity → hard reload on Device B → activity is visible
- [ ] Same flow for a reservation
- [ ] Same flow for a breakfast configuration
- [ ] Edits and deletes propagate to other devices on reload
- [ ] Existing clients pick up the new service worker (CACHE_NAME bump) and stop serving stale HTML
- [ ] Realtime updates still work for already-open tabs (no regression)

https://claude.ai/code/session_012GYz1egZsANTbUCC8vsukW

---
_Generated by [Claude Code](https://claude.ai/code/session_012GYz1egZsANTbUCC8vsukW)_