### PR TITLE
fix: drop deleted_at from queries and mutations

### DIFF
--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -24,7 +24,6 @@ export async function getProgramItemsForDayWithClient(
     .select('*, point_of_contact(*), venue_type(*)')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .is('deleted_at', null)
     .order('start_time', { nullsFirst: true })
   return (data ?? []) as unknown as Activity[]
 }
@@ -44,7 +43,6 @@ export async function getReservationsForDayWithClient(
     .select('*')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .is('deleted_at', null)
     .order('start_time', { nullsFirst: true })
   return (data ?? []) as unknown as Reservation[]
 }
@@ -67,7 +65,6 @@ export async function getBreakfastConfigsForDayWithClient(
     .select('*')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .is('deleted_at', null)
     .order('start_time', { nullsFirst: true })
   return (data ?? []) as unknown as BreakfastConfiguration[]
 }
@@ -90,7 +87,6 @@ export async function getDayNotesForDayWithClient(
     .select('*')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .is('deleted_at', null)
     .order('created_at', { ascending: true })
   return (data ?? []) as unknown as DayNote[]
 }

--- a/app/[tenant]/day/[date]/useDayRealtime.ts
+++ b/app/[tenant]/day/[date]/useDayRealtime.ts
@@ -67,8 +67,7 @@ export function useDayRealtime(
         },
         (payload) => {
           if (payload.eventType === 'INSERT') {
-            const row = payload.new as ActivityWithRelations & { deleted_at?: string | null }
-            if (row.deleted_at) return
+            const row = payload.new as ActivityWithRelations
             setActivities((prev) => {
               if (prev.some((a) => a.id === row.id)) return prev
               const withoutPendingDuplicate = prev.filter((item) => {
@@ -84,11 +83,7 @@ export function useDayRealtime(
               )
             })
           } else if (payload.eventType === 'UPDATE') {
-            const row = payload.new as ActivityWithRelations & { deleted_at?: string | null }
-            if (row.deleted_at) {
-              setActivities((prev) => prev.filter((a) => a.id !== row.id))
-              return
-            }
+            const row = payload.new as ActivityWithRelations
             setActivities((prev) => prev.map((a) => (a.id === row.id ? { ...a, ...row } : a)))
           } else if (payload.eventType === 'DELETE') {
             const id = (payload.old as { id: string }).id
@@ -107,8 +102,7 @@ export function useDayRealtime(
         },
         (payload) => {
           if (payload.eventType === 'INSERT') {
-            const row = payload.new as Reservation & { deleted_at?: string | null }
-            if (row.deleted_at) return
+            const row = payload.new as Reservation
             setReservations((prev) => {
               if (prev.some((r) => r.id === row.id)) return prev
               const withoutPendingDuplicate = prev.filter((item) => {
@@ -124,11 +118,7 @@ export function useDayRealtime(
               )
             })
           } else if (payload.eventType === 'UPDATE') {
-            const row = payload.new as Reservation & { deleted_at?: string | null }
-            if (row.deleted_at) {
-              setReservations((prev) => prev.filter((r) => r.id !== row.id))
-              return
-            }
+            const row = payload.new as Reservation
             setReservations((prev) => prev.map((r) => (r.id === row.id ? row : r)))
           } else if (payload.eventType === 'DELETE') {
             const id = (payload.old as { id: string }).id
@@ -147,8 +137,7 @@ export function useDayRealtime(
         },
         (payload) => {
           if (payload.eventType === 'INSERT') {
-            const row = payload.new as BreakfastConfiguration & { deleted_at?: string | null }
-            if (row.deleted_at) return
+            const row = payload.new as BreakfastConfiguration
             setBreakfastConfigs((prev) => {
               if (prev.some((c) => c.id === row.id)) return prev
               const withoutPendingDuplicate = prev.filter((item) => {
@@ -162,11 +151,7 @@ export function useDayRealtime(
               return [...withoutPendingDuplicate, row]
             })
           } else if (payload.eventType === 'UPDATE') {
-            const row = payload.new as BreakfastConfiguration & { deleted_at?: string | null }
-            if (row.deleted_at) {
-              setBreakfastConfigs((prev) => prev.filter((c) => c.id !== row.id))
-              return
-            }
+            const row = payload.new as BreakfastConfiguration
             setBreakfastConfigs((prev) => prev.map((c) => (c.id === row.id ? row : c)))
           } else if (payload.eventType === 'DELETE') {
             const id = (payload.old as { id: string }).id
@@ -185,21 +170,14 @@ export function useDayRealtime(
         },
         (payload) => {
           if (payload.eventType === 'INSERT') {
-            const row = payload.new as DayNote & { deleted_at?: string | null }
-            if (row.deleted_at) return
+            const row = payload.new as DayNote
             setDayNotes((prev) => {
               if (prev.some((n) => n.id === row.id)) return prev
-              return [...prev, row as DayNote].sort((a, b) =>
-                a.created_at.localeCompare(b.created_at)
-              )
+              return [...prev, row].sort((a, b) => a.created_at.localeCompare(b.created_at))
             })
           } else if (payload.eventType === 'UPDATE') {
-            const row = payload.new as DayNote & { deleted_at?: string | null }
-            if (row.deleted_at) {
-              setDayNotes((prev) => prev.filter((n) => n.id !== row.id))
-              return
-            }
-            setDayNotes((prev) => prev.map((n) => (n.id === row.id ? (row as DayNote) : n)))
+            const row = payload.new as DayNote
+            setDayNotes((prev) => prev.map((n) => (n.id === row.id ? row : n)))
           } else if (payload.eventType === 'DELETE') {
             const id = (payload.old as { id: string }).id
             setDayNotes((prev) => prev.filter((n) => n.id !== id))

--- a/app/[tenant]/month-queries.ts
+++ b/app/[tenant]/month-queries.ts
@@ -12,7 +12,6 @@ export async function getProgramItemsForMonth(
     .select('*')
     .eq('tenant_id', tenantId)
     .in('day_id', dayIds)
-    .is('deleted_at', null)
   return (data ?? []) as Activity[]
 }
 
@@ -27,7 +26,6 @@ export async function getReservationsForMonth(
     .select('*')
     .eq('tenant_id', tenantId)
     .in('day_id', dayIds)
-    .is('deleted_at', null)
   return (data ?? []) as Reservation[]
 }
 
@@ -43,6 +41,5 @@ export async function getBreakfastConfigsForMonth(
     .eq('tenant_id', tenantId)
     .gte('breakfast_date', start)
     .lte('breakfast_date', end)
-    .is('deleted_at', null)
   return (data ?? []) as BreakfastConfiguration[]
 }

--- a/app/actions/activities.ts
+++ b/app/actions/activities.ts
@@ -253,7 +253,6 @@ export async function updateActivity(
     })
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
     .select()
     .single()
 
@@ -287,21 +286,14 @@ export async function deleteActivity(id: string): Promise<ActionResponse> {
 
   const { supabase } = await createTenantClient()
 
-  const now = new Date().toISOString()
   const { data: existing } = await supabase
     .from('activity')
     .select('title, day_id')
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
     .maybeSingle()
 
-  const { error } = await supabase
-    .from('activity')
-    .update({ deleted_at: now, updated_at: now })
-    .eq('id', id)
-    .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
+  const { error } = await supabase.from('activity').delete().eq('id', id).eq('tenant_id', tenantId)
 
   if (error) return { success: false, error: error.message }
 
@@ -331,14 +323,12 @@ export async function deleteActivityRecurrenceGroup(groupId: string): Promise<Ac
   const tenantId = await getTenantId()
   await requireEditor(tenantId)
 
-  const now = new Date().toISOString()
   const { supabase } = await createTenantClient()
   const { error } = await supabase
     .from('activity')
-    .update({ deleted_at: now, updated_at: now })
+    .delete()
     .eq('recurrence_group_id', groupId)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
 
   if (error) return { success: false, error: error.message }
   revalidateDay()
@@ -358,7 +348,6 @@ export async function deleteActivityFromHere(id: string, groupId: string): Promi
     .select('day_id, title')
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
     .maybeSingle()
 
   if (!curr) return { success: false, error: 'Activity not found.' }
@@ -381,7 +370,6 @@ export async function deleteActivityFromHere(id: string, groupId: string): Promi
     .select('id, day_id')
     .eq('recurrence_group_id', groupId)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
 
   if (!groupActivities?.length) return { success: true, data: undefined }
 
@@ -401,13 +389,11 @@ export async function deleteActivityFromHere(id: string, groupId: string): Promi
 
   if (toDeleteIds.length === 0) return { success: true, data: undefined }
 
-  const tombstoneAt = new Date().toISOString()
   const { error } = await supabase
     .from('activity')
-    .update({ deleted_at: tombstoneAt, updated_at: tombstoneAt })
+    .delete()
     .in('id', toDeleteIds)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
 
   if (error) return { success: false, error: error.message }
 
@@ -443,7 +429,6 @@ export async function getActivitiesForDay(
     )
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .is('deleted_at', null)
     .order('start_time', { nullsFirst: true })
 
   if (error) return { success: false, error: error.message }

--- a/app/actions/agenda.ts
+++ b/app/actions/agenda.ts
@@ -40,25 +40,14 @@ export async function getDaySummaries(
 
   // Fetch counts in parallel — only select the columns we need
   const [activitiesRes, reservationsRes, breakfastRes] = await Promise.all([
-    supabase
-      .from('activity')
-      .select('day_id')
-      .eq('tenant_id', tenantId)
-      .in('day_id', dayIds)
-      .is('deleted_at', null),
-    supabase
-      .from('reservation')
-      .select('day_id')
-      .eq('tenant_id', tenantId)
-      .in('day_id', dayIds)
-      .is('deleted_at', null),
+    supabase.from('activity').select('day_id').eq('tenant_id', tenantId).in('day_id', dayIds),
+    supabase.from('reservation').select('day_id').eq('tenant_id', tenantId).in('day_id', dayIds),
     supabase
       .from('breakfast_configuration')
       .select('breakfast_date,total_guests')
       .eq('tenant_id', tenantId)
       .gte('breakfast_date', start)
-      .lte('breakfast_date', end)
-      .is('deleted_at', null),
+      .lte('breakfast_date', end),
   ])
 
   // Build summary map

--- a/app/actions/breakfast.ts
+++ b/app/actions/breakfast.ts
@@ -111,7 +111,6 @@ export async function updateBreakfastConfiguration(
     })
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
     .select()
     .single()
 
@@ -147,21 +146,18 @@ export async function deleteBreakfastConfiguration(id: string): Promise<ActionRe
 
   const { supabase } = await createTenantClient()
 
-  const now = new Date().toISOString()
   const { data: existing } = await supabase
     .from('breakfast_configuration')
     .select('group_name, day_id')
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
     .maybeSingle()
 
   const { error } = await supabase
     .from('breakfast_configuration')
-    .update({ deleted_at: now, updated_at: now })
+    .delete()
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
 
   if (error) return { success: false, error: error.message }
 
@@ -201,7 +197,6 @@ export async function getBreakfastConfigurationsForDay(
     .select('*')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .is('deleted_at', null)
     .order('start_time', { nullsFirst: true })
 
   if (error) return { success: false, error: error.message }

--- a/app/actions/checklists.ts
+++ b/app/actions/checklists.ts
@@ -230,7 +230,6 @@ export async function attachChecklistTemplatesToActivity(
     .select('id, day_id, tenant_id')
     .eq('id', activityId)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
     .single()
 
   if (activityErr || !activityRow) {

--- a/app/actions/day-notes.ts
+++ b/app/actions/day-notes.ts
@@ -29,7 +29,6 @@ export async function getDayNotes(dayId: string): Promise<ActionResponse<DayNote
     .select('*')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .is('deleted_at', null)
     .order('created_at', { ascending: true })
 
   if (error) return { success: false, error: error.message }
@@ -82,7 +81,6 @@ export async function updateDayNote(id: string, content: string): Promise<Action
     .eq('id', id)
     .eq('tenant_id', tenantId)
     .eq('user_id', user.id)
-    .is('deleted_at', null)
     .select()
     .single()
 
@@ -94,15 +92,13 @@ export async function deleteDayNote(id: string): Promise<ActionResponse> {
   const tenantId = await getTenantId()
   const user = await requireEditor(tenantId)
 
-  const now = new Date().toISOString()
   const { supabase } = await createTenantClient()
   const { error } = await supabase
     .from('day_notes')
-    .update({ deleted_at: now, updated_at: now })
+    .delete()
     .eq('id', id)
     .eq('tenant_id', tenantId)
     .eq('user_id', user.id)
-    .is('deleted_at', null)
 
   if (error) return { success: false, error: error.message }
   return { success: true, data: undefined }

--- a/app/actions/reservations.ts
+++ b/app/actions/reservations.ts
@@ -98,7 +98,6 @@ export async function updateReservation(
     })
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
     .select()
     .single()
 
@@ -133,21 +132,18 @@ export async function deleteReservation(id: string): Promise<ActionResponse> {
 
   const { supabase } = await createTenantClient()
 
-  const now = new Date().toISOString()
   const { data: existing } = await supabase
     .from('reservation')
     .select('guest_name, day_id')
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
     .maybeSingle()
 
   const { error } = await supabase
     .from('reservation')
-    .update({ deleted_at: now, updated_at: now })
+    .delete()
     .eq('id', id)
     .eq('tenant_id', tenantId)
-    .is('deleted_at', null)
 
   if (error) return { success: false, error: error.message }
 
@@ -185,7 +181,6 @@ export async function getReservationsForDay(dayId: string): Promise<ActionRespon
     .select('*')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .is('deleted_at', null)
     .order('start_time', { nullsFirst: true })
 
   if (error) return { success: false, error: error.message }

--- a/tests/actions/program-item-actions.test.ts
+++ b/tests/actions/program-item-actions.test.ts
@@ -183,13 +183,13 @@ describe('updateActivity', () => {
 describe('deleteActivity', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('soft-deletes by id and tenant and returns success', async () => {
+  it('hard-deletes by id and tenant and returns success', async () => {
     const selectChain = makeChain({
       data: { title: 'T', day_id: 'day-1' },
       error: null,
     })
-    const updateChain = makeChain({ data: null, error: null })
-    const from = vi.fn().mockReturnValueOnce(selectChain).mockReturnValueOnce(updateChain)
+    const deleteChain = makeChain({ data: null, error: null })
+    const from = vi.fn().mockReturnValueOnce(selectChain).mockReturnValueOnce(deleteChain)
     vi.mocked(createTenantClient).mockResolvedValue({
       supabase: { from } as never,
       tenantId: 'tenant-1',
@@ -198,18 +198,16 @@ describe('deleteActivity', () => {
     const result = await deleteActivity('item-1')
     expect(result.success).toBe(true)
     expect(from).toHaveBeenCalledWith('activity')
-    expect(updateChain.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
-      expect.objectContaining({ deleted_at: expect.any(String), updated_at: expect.any(String) })
-    )
+    expect(deleteChain.delete as ReturnType<typeof vi.fn>).toHaveBeenCalled()
   })
 
-  it('returns error when Supabase update fails', async () => {
+  it('returns error when Supabase delete fails', async () => {
     const selectChain = makeChain({
       data: { title: 'T', day_id: 'day-1' },
       error: null,
     })
-    const updateChain = makeChain({ data: null, error: { message: 'update error' } })
-    const from = vi.fn().mockReturnValueOnce(selectChain).mockReturnValueOnce(updateChain)
+    const deleteChain = makeChain({ data: null, error: { message: 'delete error' } })
+    const from = vi.fn().mockReturnValueOnce(selectChain).mockReturnValueOnce(deleteChain)
     vi.mocked(createTenantClient).mockResolvedValue({
       supabase: { from } as never,
       tenantId: 'tenant-1',
@@ -217,7 +215,7 @@ describe('deleteActivity', () => {
 
     const result = await deleteActivity('item-1')
     assertFailure(result)
-    expect(result.error).toBe('update error')
+    expect(result.error).toBe('delete error')
   })
 })
 
@@ -226,7 +224,7 @@ describe('deleteActivity', () => {
 describe('deleteActivityRecurrenceGroup', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('soft-deletes all items in the recurrence group', async () => {
+  it('hard-deletes all items in the recurrence group', async () => {
     const chain = makeChain({ data: null, error: null })
     const from = vi.fn().mockReturnValue(chain)
     vi.mocked(createTenantClient).mockResolvedValue({
@@ -239,9 +237,7 @@ describe('deleteActivityRecurrenceGroup', () => {
 
     const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls
     expect(eqCalls).toContainEqual(['recurrence_group_id', 'group-abc'])
-    expect(chain.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
-      expect.objectContaining({ deleted_at: expect.any(String) })
-    )
+    expect(chain.delete as ReturnType<typeof vi.fn>).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
## Summary

Production day/agenda/calendar views were rendering empty even though the rows were in Supabase. Root cause is a schema mismatch left over from migration `00041_remove_handover.sql`:

- The migration dropped the `deleted_at` column from `activity`, `reservation`, `breakfast_configuration`, and `day_notes` (and switched their delete RLS back to hard-delete).
- The application code never caught up — every read still calls `.is('deleted_at', null)` and every soft-delete still calls `.update({ deleted_at: ... })`.
- PostgREST rejects the queries with `column "deleted_at" does not exist`, supabase-js returns `{data: null, error}`, the query code does `(data ?? [])` → empty array, the page renders nothing.
- Production postgres logs show this firing on every request:
  ```
  ERROR: column activity.deleted_at does not exist
  ERROR: column reservation.deleted_at does not exist
  ERROR: column breakfast_configuration.deleted_at does not exist
  ERROR: column day_notes.deleted_at does not exist
  ```

This is unrelated to the caching layer fixed in #130 — the data was never being read in the first place.

### Changes

- Drop `.is('deleted_at', null)` from every read path: `app/[tenant]/day/[date]/queries.ts`, `app/[tenant]/month-queries.ts`, `app/actions/agenda.ts`, and the read paths inside `activities.ts`, `reservations.ts`, `breakfast.ts`, `day-notes.ts`, `checklists.ts`.
- Switch delete actions from `update({ deleted_at })` to a real `.delete()`:
  - `deleteActivity`, `deleteActivityRecurrenceGroup`, `deleteActivityFromHere`
  - `deleteReservation`
  - `deleteBreakfastConfiguration`
  - `deleteDayNote`
  - RLS already grants editors `DELETE` per migration 41 lines 53–67.
- Drop `deleted_at` branches from `useDayRealtime.ts` payload handlers; hard delete fires the `DELETE` event the handlers already cover.
- Update `program-item-actions.test.ts` to expect `.delete()` instead of the soft-delete update payload.

### Test plan

- [ ] On 2026-05-07 / 2026-05-08, the existing rows for `pavillon` and `demo` tenants render in the day view, agenda, and calendar pips
- [ ] Creating a new activity / reservation / breakfast on one device shows up on another after a hard reload
- [ ] Editing an item updates across devices via realtime
- [ ] Deleting an item removes it from all devices via the `DELETE` realtime event
- [ ] Deleting a recurrence group / "from here" still works
- [ ] Day notes create / update / delete still work
- [ ] Postgres error logs no longer show `column "deleted_at" does not exist`

https://claude.ai/code/session_012GYz1egZsANTbUCC8vsukW

---
_Generated by [Claude Code](https://claude.ai/code/session_012GYz1egZsANTbUCC8vsukW)_