### PR TITLE
perf: trim selects, dedup tenant data, lazy-load form modals

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { useSearchParams, usePathname, useRouter } from 'next/navigation'
 import { useDayRealtime } from './useDayRealtime'
 import { useTranslations } from 'next-intl'
@@ -9,12 +10,19 @@ import { toast } from 'sonner'
 import { DayNav } from '@/components/day-nav'
 import { DaySummaryCard } from '@/components/day-summary-card'
 import { ViewerDayDashboard } from '@/components/viewer-day-dashboard'
-import { ActivityForm } from '@/components/activity-form'
 import { ActivityCard } from '@/components/activity-card'
-import { ReservationForm } from '@/components/reservation-form'
 import { ReservationCard } from '@/components/reservation-card'
-import { BreakfastForm } from '@/components/breakfast-form'
 import { BreakfastCard } from '@/components/breakfast-card'
+
+// Lazy-load heavy form modals — they only render when a user opens an edit/add
+// dialog, so keep them out of the initial day-view JS bundle.
+const ActivityForm = dynamic(() => import('@/components/activity-form').then((m) => m.ActivityForm))
+const ReservationForm = dynamic(() =>
+  import('@/components/reservation-form').then((m) => m.ReservationForm)
+)
+const BreakfastForm = dynamic(() =>
+  import('@/components/breakfast-form').then((m) => m.BreakfastForm)
+)
 import { DayNotes } from '@/components/day-notes'
 import { DayInfoBanner } from '@/components/day-info-banner'
 import { StaffScheduleSection } from '@/components/staff-schedule-section'

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createSupabaseServerClient, createSupabaseServiceClient } from '@/lib/supabase-server'
 import type { Database } from '@/types/supabase'
@@ -21,7 +22,7 @@ export async function getProgramItemsForDayWithClient(
 ): Promise<Activity[]> {
   const { data } = await supabase
     .from('activity')
-    .select('*, point_of_contact(*), venue_type(*)')
+    .select('*, point_of_contact(id, name), venue_type(id, name)')
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
     .order('start_time', { nullsFirst: true })
@@ -154,34 +155,40 @@ export async function getDailyBriefForDay(
  * Returns all tenant members (assignees) keyed by user_id, with email and a
  * display name derived from the email local-part. Service-role lookup is
  * required because auth.users is not in the public schema.
+ *
+ * Request-scoped via React cache() so the N auth.admin.getUserById lookups
+ * only run once per tenant per request, even when called from multiple
+ * sub-trees (shifts list, assignee dropdowns, etc.).
  */
-export async function getTenantAssignees(tenantId: string): Promise<Map<string, ShiftAssignee>> {
-  const supabase = await createSupabaseServerClient()
-  const { data: memberships } = await supabase
-    .from('memberships')
-    .select('user_id')
-    .eq('tenant_id', tenantId)
+export const getTenantAssignees = cache(
+  async (tenantId: string): Promise<Map<string, ShiftAssignee>> => {
+    const supabase = await createSupabaseServerClient()
+    const { data: memberships } = await supabase
+      .from('memberships')
+      .select('user_id')
+      .eq('tenant_id', tenantId)
 
-  const userIds = (memberships ?? []).map((m) => m.user_id)
-  if (userIds.length === 0) return new Map()
+    const userIds = (memberships ?? []).map((m) => m.user_id)
+    if (userIds.length === 0) return new Map()
 
-  const serviceClient = createSupabaseServiceClient()
-  const lookups = await Promise.allSettled(
-    userIds.map((uid) => serviceClient.auth.admin.getUserById(uid))
-  )
+    const serviceClient = createSupabaseServiceClient()
+    const lookups = await Promise.allSettled(
+      userIds.map((uid) => serviceClient.auth.admin.getUserById(uid))
+    )
 
-  const map = new Map<string, ShiftAssignee>()
-  userIds.forEach((uid, i) => {
-    const settled = lookups[i]
-    const email = settled.status === 'fulfilled' ? (settled.value.data.user?.email ?? '') : ''
-    map.set(uid, {
-      user_id: uid,
-      email,
-      display_name: email ? email.split('@')[0] : uid.slice(0, 8),
+    const map = new Map<string, ShiftAssignee>()
+    userIds.forEach((uid, i) => {
+      const settled = lookups[i]
+      const email = settled.status === 'fulfilled' ? (settled.value.data.user?.email ?? '') : ''
+      map.set(uid, {
+        user_id: uid,
+        email,
+        display_name: email ? email.split('@')[0] : uid.slice(0, 8),
+      })
     })
-  })
-  return map
-}
+    return map
+  }
+)
 
 export async function getShiftsForDay(
   tenantId: string,

--- a/app/[tenant]/month-queries.ts
+++ b/app/[tenant]/month-queries.ts
@@ -1,45 +1,48 @@
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
+
+export type MonthActivitySummary = { day_id: string }
+export type MonthReservationSummary = { day_id: string }
+export type MonthBreakfastSummary = { breakfast_date: string; total_guests: number }
 
 export async function getProgramItemsForMonth(
   tenantId: string,
   dayIds: string[]
-): Promise<Activity[]> {
+): Promise<MonthActivitySummary[]> {
   if (dayIds.length === 0) return []
   const supabase = await createSupabaseServerClient()
   const { data } = await supabase
     .from('activity')
-    .select('*')
+    .select('day_id')
     .eq('tenant_id', tenantId)
     .in('day_id', dayIds)
-  return (data ?? []) as Activity[]
+  return (data ?? []) as MonthActivitySummary[]
 }
 
 export async function getReservationsForMonth(
   tenantId: string,
   dayIds: string[]
-): Promise<Reservation[]> {
+): Promise<MonthReservationSummary[]> {
   if (dayIds.length === 0) return []
   const supabase = await createSupabaseServerClient()
   const { data } = await supabase
     .from('reservation')
-    .select('*')
+    .select('day_id')
     .eq('tenant_id', tenantId)
     .in('day_id', dayIds)
-  return (data ?? []) as Reservation[]
+  return (data ?? []) as MonthReservationSummary[]
 }
 
 export async function getBreakfastConfigsForMonth(
   tenantId: string,
   start: string,
   end: string
-): Promise<BreakfastConfiguration[]> {
+): Promise<MonthBreakfastSummary[]> {
   const supabase = await createSupabaseServerClient()
   const { data } = await supabase
     .from('breakfast_configuration')
-    .select('*')
+    .select('breakfast_date, total_guests')
     .eq('tenant_id', tenantId)
     .gte('breakfast_date', start)
     .lte('breakfast_date', end)
-  return (data ?? []) as BreakfastConfiguration[]
+  return (data ?? []) as MonthBreakfastSummary[]
 }

--- a/app/actions/activity-tags.ts
+++ b/app/actions/activity-tags.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { cache } from 'react'
 import { createTenantClient } from '@/lib/supabase-server'
 import { getTenantId } from '@/lib/tenant'
 import { getUserRole, requireEditor } from '@/lib/membership'
@@ -7,7 +8,7 @@ import { activityTagSchema } from '@/lib/activity-tag-schema'
 import type { ActionResponse } from '@/types/actions'
 import type { ActivityTag } from '@/types/index'
 
-export async function getAllActivityTags(): Promise<ActionResponse<ActivityTag[]>> {
+const fetchAllActivityTags = cache(async (): Promise<ActionResponse<ActivityTag[]>> => {
   const tenantId = await getTenantId()
   const role = await getUserRole(tenantId)
   if (!role) return { success: false, error: 'Not authorized.' }
@@ -21,6 +22,10 @@ export async function getAllActivityTags(): Promise<ActionResponse<ActivityTag[]
 
   if (error) return { success: false, error: error.message }
   return { success: true, data: data as ActivityTag[] }
+})
+
+export async function getAllActivityTags(): Promise<ActionResponse<ActivityTag[]>> {
+  return fetchAllActivityTags()
 }
 
 export async function createActivityTag(name: string): Promise<ActionResponse<ActivityTag>> {

--- a/app/actions/feature-flags.ts
+++ b/app/actions/feature-flags.ts
@@ -1,17 +1,13 @@
 'use server'
 
+import { cache } from 'react'
 import { createSupabaseServiceClient } from '@/lib/supabase-server'
 import { getSuperadminStatus } from '@/lib/superadmin'
 import { KNOWN_FLAGS } from '@/lib/feature-flags'
 import type { FlagKey, FlagMap } from '@/lib/feature-flags'
 import type { ActionResponse } from '@/types/actions'
 
-/**
- * Returns the feature flag map for a tenant.
- * Rows missing from the DB are defaulted to enabled=true.
- * Safe to call from server components — uses the service client.
- */
-export async function getFeatureFlags(tenantId: string): Promise<FlagMap> {
+const fetchFeatureFlags = cache(async (tenantId: string): Promise<FlagMap> => {
   const serviceClient = createSupabaseServiceClient()
   const { data } = await serviceClient
     .from('feature_flags')
@@ -24,6 +20,16 @@ export async function getFeatureFlags(tenantId: string): Promise<FlagMap> {
     map[key] = row ? row.enabled : true
   }
   return map
+})
+
+/**
+ * Returns the feature flag map for a tenant.
+ * Rows missing from the DB are defaulted to enabled=true.
+ * Safe to call from server components — uses the service client.
+ * Request-scoped via React cache() so multiple call sites dedup.
+ */
+export async function getFeatureFlags(tenantId: string): Promise<FlagMap> {
+  return fetchFeatureFlags(tenantId)
 }
 
 /**

--- a/app/actions/poc.ts
+++ b/app/actions/poc.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { cache } from 'react'
 import { createTenantClient } from '@/lib/supabase-server'
 import { getTenantId } from '@/lib/tenant'
 import { getUserRole, requireEditor } from '@/lib/membership'
@@ -12,7 +13,7 @@ function normaliseEmpty(s: string | undefined | null): string | null {
   return s && s.trim() !== '' ? s.trim() : null
 }
 
-export async function getAllPOCs(): Promise<ActionResponse<PointOfContact[]>> {
+const fetchAllPOCs = cache(async (): Promise<ActionResponse<PointOfContact[]>> => {
   const tenantId = await getTenantId()
   const role = await getUserRole(tenantId)
   if (!role) return { success: false, error: 'Not authorized.' }
@@ -26,6 +27,10 @@ export async function getAllPOCs(): Promise<ActionResponse<PointOfContact[]>> {
 
   if (error) return { success: false, error: error.message }
   return { success: true, data: data as PointOfContact[] }
+})
+
+export async function getAllPOCs(): Promise<ActionResponse<PointOfContact[]>> {
+  return fetchAllPOCs()
 }
 
 export async function createPOC(raw: PocFormData): Promise<ActionResponse<PointOfContact>> {

--- a/app/actions/venue-type.ts
+++ b/app/actions/venue-type.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { cache } from 'react'
 import { createTenantClient } from '@/lib/supabase-server'
 import { getTenantId } from '@/lib/tenant'
 import { getUserRole, requireEditor } from '@/lib/membership'
@@ -8,7 +9,7 @@ import type { VenueTypeFormData } from '@/lib/venue-type-schema'
 import type { ActionResponse } from '@/types/actions'
 import type { VenueType } from '@/types/index'
 
-export async function getAllVenueTypes(): Promise<ActionResponse<VenueType[]>> {
+const fetchAllVenueTypes = cache(async (): Promise<ActionResponse<VenueType[]>> => {
   const tenantId = await getTenantId()
   const role = await getUserRole(tenantId)
   if (!role) return { success: false, error: 'Not authorized.' }
@@ -22,6 +23,10 @@ export async function getAllVenueTypes(): Promise<ActionResponse<VenueType[]>> {
 
   if (error) return { success: false, error: error.message }
   return { success: true, data: data as VenueType[] }
+})
+
+export async function getAllVenueTypes(): Promise<ActionResponse<VenueType[]>> {
+  return fetchAllVenueTypes()
 }
 
 export async function createVenueType(raw: VenueTypeFormData): Promise<ActionResponse<VenueType>> {

--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,7 @@ const nextConfig: NextConfig = {
     // Node.js APIs. The type definition lags the runtime — suppress the error.
     // @ts-expect-error nodeMiddleware is not yet in ExperimentalConfig types
     nodeMiddleware: true,
+    optimizePackageImports: ['date-fns', 'lucide-react'],
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary

Implements the five high-priority wins from the performance audit on `claude/audit-performance-WSD3B`. Medium / low findings tracked separately as #132–#138.

### Changes

1. **Slim month-view queries** (`app/[tenant]/month-queries.ts`) — calendar only needs `day_id` (or `breakfast_date` + `total_guests`) per row; was selecting `*`. New lean return types (`MonthActivitySummary`, etc.).
2. **Slim activity day-view join** (`app/[tenant]/day/[date]/queries.ts`) — replaced `point_of_contact(*), venue_type(*)` with `point_of_contact(id, name), venue_type(id, name)`; `ActivityCard` and `ViewerDayDashboard` only render `.name`.
3. **Request-scoped dedup with React `cache()`** —
   - `getFeatureFlags` (called from `[tenant]/page.tsx` and `day/[date]/page.tsx`)
   - `getAllPOCs`, `getAllVenueTypes`, `getAllActivityTags`
   - `getTenantAssignees` — biggest win: collapses N `auth.admin.getUserById` lookups per duplicate call site to one batch.
4. **Bundle: `optimizePackageImports`** for `date-fns` and `lucide-react` in `next.config.ts` — affects ~50 lucide call sites and 5+ date-fns importers.
5. **Lazy-load form modals** (`app/[tenant]/day/[date]/DayViewClient.tsx`) — `ActivityForm` (826L), `ReservationForm` (335L), `BreakfastForm` now use `next/dynamic`, splitting them out of the day-view bundle.

### Out of scope (filed as issues)

- #132 Dedup tenant metadata in `[tenant]/layout.tsx`
- #133 Fetch feature flags once in tenant layout
- #134 Parallelize sequential awaits in day page
- #135 Split + memoize `HomeClient` / `DayViewClient`
- #136 Audit 79 `'use client'` files
- #137 `display: 'swap'` on Geist fonts
- #138 TTL on subdomain redis cache writes

## Test plan

- [ ] CI: typecheck, lint, unit tests, build
- [ ] Local: `pnpm dev`, navigate calendar / month switching — counts still correct
- [ ] Local: open day view — activities, reservations, breakfast cards still render with POC / venue name
- [ ] Local: click "Add activity / reservation / breakfast" — dynamic chunks load and modal opens
- [ ] Local: settings dropdowns (POCs, venue types, tags) still populate
- [ ] Local: shift assignees still display correct names

https://claude.ai/code/session_01QGZeUyJ1eM4z2wLYh63TMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGZeUyJ1eM4z2wLYh63TMJ)_