### PR TITLE
perf(day): remove blocking LLM call, pin Vercel to eu-west-1

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -132,6 +132,7 @@ function DayViewEditor({
   dailyBrief,
   briefStale,
   briefIsEmpty,
+  dayHasContent,
   pocs,
   venueTypes,
   authState,
@@ -436,6 +437,7 @@ function DayViewEditor({
           showBrief={showDailyBrief}
           briefStale={showDailyBrief ? briefStale : false}
           briefIsEmpty={showDailyBrief ? briefIsEmpty : false}
+          dayHasContent={showDailyBrief ? dayHasContent : false}
           dateIso={date}
           dayId={dayId}
           isEditor

--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -16,6 +16,7 @@ import {
   getReservationsForDay,
   getBreakfastConfigsForDay,
   getDayNotesForDay,
+  getDailyBriefForDay,
   getShiftsForDay,
   getTenantAssigneesList,
 } from './queries'
@@ -32,10 +33,32 @@ import type {
 } from '@/types/index'
 import type { AuthState } from '@/types/actions'
 import type { DayNote } from '@/app/actions/day-notes'
+import type { DailyBriefRecord } from '@/types/daily-brief'
 import { getWeatherForDay } from '@/app/actions/weather'
 import type { WeatherData } from '@/app/actions/weather'
 import { getFeatureFlags } from '@/app/actions/feature-flags'
-import { ensureDailyBrief } from '@/app/actions/daily-brief'
+import { dayHasPlannedContent } from '@/lib/daily-brief-generate'
+
+// Inline stale check to avoid pulling the LLM-generation server action onto
+// the request critical path. Mirrors the helper in app/actions/daily-brief.ts.
+function isBriefStale(
+  brief: DailyBriefRecord,
+  activities: Activity[],
+  reservations: Reservation[],
+  breakfasts: BreakfastConfiguration[],
+  dayNotes: DayNote[]
+): boolean {
+  const briefTime = new Date(brief.generated_at).getTime()
+  const timestamps: string[] = [
+    ...activities.map((a) => a.updated_at),
+    ...reservations.map((r) => r.updated_at),
+    ...breakfasts.map((b) => b.updated_at),
+    ...dayNotes.map((n) => n.updated_at),
+  ]
+  if (timestamps.length === 0) return false
+  const maxUpdated = Math.max(...timestamps.map((t) => new Date(t).getTime()))
+  return maxUpdated > briefTime
+}
 
 export type DayViewProps = {
   date: string
@@ -46,9 +69,16 @@ export type DayViewProps = {
   breakfastConfigs: BreakfastConfiguration[]
   dayNotes: DayNote[]
   weather: WeatherData | null
-  dailyBrief: import('@/types/daily-brief').DailyBriefRecord | null
+  dailyBrief: DailyBriefRecord | null
   briefStale: boolean
   briefIsEmpty: boolean
+  /**
+   * True when the day has at least one activity / reservation / breakfast.
+   * Lets the daily-brief banner trigger client-side generation when no brief
+   * exists yet, replacing the previous synchronous server-side `ensureDailyBrief`
+   * call that was blocking page render on the LLM round-trip.
+   */
+  dayHasContent: boolean
   pocs: PointOfContact[]
   venueTypes: VenueType[]
   authState: AuthState
@@ -106,7 +136,9 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
   const dailyBriefOn = flags.daily_brief
   const authState = await getAuthState()
 
-  // Load all day data in parallel — skip disabled features
+  // Load all day data in parallel — skip disabled features.
+  // Daily brief is now a fast read-only fetch (no LLM call on the critical path);
+  // generation is triggered client-side from the banner when missing.
   const [
     activities,
     reservations,
@@ -117,6 +149,7 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
     venueTypesResult,
     shifts,
     shiftAssignees,
+    existingBrief,
   ] = await Promise.all([
     getProgramItemsForDay(tenant.id, day.id),
     flags.reservations ? getReservationsForDay(tenant.id, day.id) : Promise.resolve([]),
@@ -127,24 +160,26 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
     getAllVenueTypes(),
     staffScheduleOn ? getShiftsForDay(tenant.id, day.id) : Promise.resolve([]),
     staffScheduleOn ? getTenantAssigneesList(tenant.id) : Promise.resolve([]),
+    dailyBriefOn ? getDailyBriefForDay(tenant.id, day.id) : Promise.resolve(null),
   ])
 
-  // Auto-generate brief after data is loaded so we can pass it without duplicate fetches
-  const briefResult = dailyBriefOn
-    ? await ensureDailyBrief({
-        tenantId: tenant.id,
-        dayId: day.id,
-        dateIso: date,
-        activities,
-        reservations: flags.reservations ? reservations : [],
-        breakfasts: flags.breakfast_config ? breakfastConfigs : [],
-        dayNotes,
-        weather,
-      })
-    : null
-  const dailyBrief = briefResult?.status === 'ok' ? briefResult.brief : null
-  const briefStale = briefResult?.status === 'ok' ? briefResult.stale : false
-  const briefIsEmpty = briefResult?.status === 'empty'
+  const dayHasContent = dayHasPlannedContent(
+    activities,
+    flags.reservations ? reservations : [],
+    flags.breakfast_config ? breakfastConfigs : []
+  )
+  const dailyBrief = dailyBriefOn ? existingBrief : null
+  const briefStale =
+    dailyBriefOn && dailyBrief
+      ? isBriefStale(
+          dailyBrief,
+          activities,
+          flags.reservations ? reservations : [],
+          flags.breakfast_config ? breakfastConfigs : [],
+          dayNotes
+        )
+      : false
+  const briefIsEmpty = dailyBriefOn ? !dayHasContent : false
 
   return (
     <Suspense
@@ -162,6 +197,7 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
         dailyBrief={dailyBrief}
         briefStale={briefStale}
         briefIsEmpty={briefIsEmpty}
+        dayHasContent={dayHasContent}
         pocs={pocsResult.success ? pocsResult.data : []}
         venueTypes={venueTypesResult.success ? venueTypesResult.data : []}
         authState={authState}

--- a/components/day-info-banner.tsx
+++ b/components/day-info-banner.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
@@ -21,6 +21,13 @@ type Props = {
   showBrief: boolean
   briefStale: boolean
   briefIsEmpty: boolean
+  /**
+   * True when the day has at least one activity / reservation / breakfast.
+   * Combined with `isEditor`, this triggers a one-shot client-side brief
+   * generation when no brief exists yet — replaces the previous blocking
+   * `ensureDailyBrief` call on the server render path.
+   */
+  dayHasContent: boolean
   dateIso: string
   dayId: string
   isEditor: boolean
@@ -72,7 +79,9 @@ export function DayInfoBanner({
   showBrief,
   briefStale,
   briefIsEmpty,
+  dayHasContent,
   dateIso,
+  dayId,
   isEditor,
 }: Props) {
   const t = useTranslations('Tenant.dailyBrief')
@@ -82,6 +91,9 @@ export function DayInfoBanner({
   const [loading, setLoading] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
   const lastGenerateAt = useRef(0)
+  // One-shot guard so we never auto-fire generation more than once per
+  // (dayId, mount) pair.
+  const autoFiredFor = useRef<string | null>(null)
 
   const hasWeather = showWeather && weather !== null
   const hasBrief = brief !== null
@@ -117,6 +129,19 @@ export function DayInfoBanner({
       () => toast.error(t('copyFailed'))
     )
   }, [brief, t])
+
+  // Auto-generate a brief when the page loads with no brief yet for an editor.
+  // The previous server-side ensureDailyBrief call blocked rendering on the
+  // LLM round-trip; now the page renders fast and the brief streams in.
+  useEffect(() => {
+    if (!showBrief || !isEditor) return
+    if (brief) return
+    if (!dayHasContent) return
+    if (loading) return
+    if (autoFiredFor.current === dayId) return
+    autoFiredFor.current = dayId
+    void runRegenerate()
+  }, [showBrief, isEditor, brief, dayHasContent, loading, dayId, runRegenerate])
 
   if (!hasWeather && !showBrief) return null
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "regions": ["dub1"],
   "crons": [
     {
       "path": "/api/cron/morning-brief",


### PR DESCRIPTION
## Summary

Two changes that should actually move day-view server response time, after the previous perf PR (#139) only trimmed bundle/payload without touching latency.

### 1. Pin Vercel functions to `dub1` (eu-west-1)

`vercel.json` adds `"regions": ["dub1"]`. The Supabase project (`psuvzdpunhqhikldyavj`) is in `eu-west-1`; Vercel functions were running in `iad1` by default. That meant every Supabase round-trip paid **~80–100 ms** of pure transatlantic latency. With ~10 queries on the day page, that's **~1 s** of latency just from the region mismatch — even with all queries parallelised, connection setup and auth checks compound.

### 2. Drop the synchronous `ensureDailyBrief` LLM call from the day-page render

`app/[tenant]/day/[date]/page.tsx` previously did:

```ts
const briefResult = await ensureDailyBrief({ ... }) // blocks render on the LLM
```

Replaced with a fast read-only fetch in the same `Promise.all` as the rest of the day data:

```ts
dailyBriefOn ? getDailyBriefForDay(tenant.id, day.id) : Promise.resolve(null)
```

`briefStale` and `briefIsEmpty` are now computed inline from data already loaded (no extra queries). When no brief exists yet, `DayInfoBanner` fires `generateDailyBrief` once on mount via a guarded `useEffect`, so the brief streams in client-side instead of blocking the page.

### Behaviour change

Viewers (non-editors) no longer auto-generate briefs on first visit — the existing morning-brief cron and the next editor visit cover this. The `ensureDailyBrief` action itself is unchanged; tests still pass against it.

### Out of scope (also confirmed)

- Hot-path indexes are fine: `(tenant_id, day_id)` is covered for `activity`, `reservation`, `breakfast_configuration`, `shift`, `daily_brief`, `day_notes`. No index gap on the day route.
- Supabase advisor flagged a number of unindexed FKs and `auth.uid()` RLS init-plan issues — relevant for write paths and large-membership tenants but not on the read path of a single day.

## Test plan

- [ ] CI: typecheck, lint, unit tests, build
- [ ] After deploy: confirm Vercel function region in deployment metadata is `dub1`
- [ ] Open a day with no existing brief as an editor — page should render fast and brief should appear ~3–8 s later
- [ ] Open a day with existing brief — banner shows immediately, no double-generation
- [ ] Open a day with no content — banner shows "empty", no LLM call
- [ ] Open a day as a non-editor — page renders fast, no client auto-trigger
- [ ] Morning-brief cron continues to work (uses `generateAndPersistDailyBrief` directly)

https://claude.ai/code/session_01QGZeUyJ1eM4z2wLYh63TMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGZeUyJ1eM4z2wLYh63TMJ)_