### PR TITLE
perf: parallelize independent awaits in day page

### DIFF
--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -91,15 +91,18 @@ const YMD_REGEX = /^\d{4}-\d{2}-\d{2}$/
 export default async function DayPage({ params }: { params: Promise<{ date: string }> }) {
   const { date } = await params
 
-  // Get tenant from headers first (fast — headers only), then run auth check
-  // and tenant DB query in parallel since they are independent.
-  const tenant = await getTenantFromHeaders()
-  const supabase = await createSupabaseServerClient()
-
-  const [, tenantData] = await Promise.all([
+  // All three are independent — run in parallel to shorten critical-path latency.
+  const [tenant, supabase] = await Promise.all([
+    getTenantFromHeaders(),
+    createSupabaseServerClient(),
     requireTenantMember(),
-    supabase.from('tenants').select('timezone, latitude, longitude').eq('id', tenant.id).single(),
-  ])
+  ] as const)
+
+  const tenantData = await supabase
+    .from('tenants')
+    .select('timezone, latitude, longitude')
+    .eq('id', tenant.id)
+    .single()
 
   const tenantRow = tenantData.data as {
     timezone?: string | null
@@ -131,10 +134,9 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
         }
       : undefined
 
-  const flags = await getFeatureFlags(tenant.id)
+  const [flags, authState] = await Promise.all([getFeatureFlags(tenant.id), getAuthState()])
   const staffScheduleOn = flags.staff_schedule
   const dailyBriefOn = flags.daily_brief
-  const authState = await getAuthState()
 
   // Load all day data in parallel — skip disabled features.
   // Daily brief is now a fast read-only fetch (no LLM call on the critical path);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Run `getTenantFromHeaders`, `createSupabaseServerClient`, and `requireTenantMember` in a single `Promise.all` — they are fully independent, so no reason to sequence them
- Parallelize `getFeatureFlags` and `getAuthState` for the same reason
- Cuts two sequential async round-trips from the day page critical path

## Test plan

- [ ] Load a tenant day page and verify it renders correctly
- [ ] Verify auth guard still redirects unauthenticated users
- [ ] CI typecheck + unit tests pass

Closes #134

https://claude.ai/code/session_014QCcVW8zVjUmVdyh2ktRb1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QCcVW8zVjUmVdyh2ktRb1)_