### PR TITLE
perf: remove unnecessary 'use client' from 4 components

### DIFF
--- a/components/kbd-hint.tsx
+++ b/components/kbd-hint.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { cn } from '@/lib/utils'
 
 type Props = {

--- a/components/tenant-keyboard-shell.tsx
+++ b/components/tenant-keyboard-shell.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import type { ReactNode } from 'react'
 import { ActiveDayProvider } from '@/lib/active-day-context'
 import { KeyboardShortcutsProvider } from '@/lib/keyboard-shortcuts'

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import * as React from 'react'
 
 import { cn } from '@/lib/utils'

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import type { User } from '@supabase/supabase-js'
 import { LogOut } from 'lucide-react'
 import { signOut } from '@/app/actions/auth'


### PR DESCRIPTION
## Summary

- `components/kbd-hint.tsx` — pure display wrapper (`<kbd>` + `cn`), zero hooks
- `components/ui/table.tsx` — pure HTML table wrappers with `cn`, zero hooks or Radix
- `components/tenant-keyboard-shell.tsx` — only renders already-`'use client'` context providers; no hooks of its own
- `components/user-menu.tsx` — server-action form (`action={signOut}`) with no hooks; safe as a server component

Each removal was verified by confirming no `useState`, `useEffect`, `useRef`, `useContext`, `useCallback`, `useMemo`, `useReducer`, `useRouter`, `usePathname`, custom hooks, or event handler props exist in the file.

## Test plan

- [ ] CI typecheck + lint pass
- [ ] Build passes (Vercel preview)
- [ ] Tenant layout renders correctly (TenantKeyboardShell wraps providers)
- [ ] User menu sign-out works
- [ ] KbdHint renders in keyboard shortcuts sheet
- [ ] Table component renders in any data table views

Closes #136

https://claude.ai/code/session_01StWnCwXSyPCvZfxC2Koftz

---
_Generated by [Claude Code](https://claude.ai/code/session_01StWnCwXSyPCvZfxC2Koftz)_