### PR TITLE
perf: add display swap to Geist fonts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,11 +7,13 @@ import './globals.css'
 const geistSans = Geist({
   variable: '--font-geist-sans',
   subsets: ['latin'],
+  display: 'swap',
 })
 
 const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
   subsets: ['latin'],
+  display: 'swap',
 })
 
 const fraunces = Fraunces({


### PR DESCRIPTION
## Summary

- Add `display: 'swap'` to `Geist` and `Geist_Mono` font configs in `app/layout.tsx`
- Prevents FOIT (invisible text flash) on slow connections
- Matches existing `Fraunces` font config which already had `display: 'swap'`

Closes #137

https://claude.ai/code/session_01V5EaDUA8YjSYQfhKHUwcPR

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5EaDUA8YjSYQfhKHUwcPR)_