### PR TITLE
perf: add 24h TTL to subdomain Redis cache writes

### DIFF
--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -77,7 +77,7 @@ export async function createTenant(data: {
     language: (tenant as { language?: string }).language ?? 'en',
     status: ((tenant as { status?: string }).status ?? 'active') as TenantStatus,
   }
-  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData), { ex: 86400 })
+  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData), 'EX', 86400)
 
   // Create initial membership row for the creating user with role 'editor'.
   // Must use service client — user has no membership yet so RLS would block.
@@ -133,7 +133,7 @@ export async function getTenantBySlug(slug: string): Promise<ActionResponse<Tena
     language: (tenant as { language?: string }).language ?? 'en',
     status: ((tenant as { status?: string }).status ?? 'active') as TenantStatus,
   }
-  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData), { ex: 86400 })
+  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData), 'EX', 86400)
 
   return { success: true, data: redisData }
 }
@@ -223,7 +223,7 @@ export async function updateTenant(
     language: (updated as { language?: string }).language ?? 'en',
     status: ((updated as { status?: string }).status ?? 'active') as TenantStatus,
   }
-  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData), { ex: 86400 })
+  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData), 'EX', 86400)
 
   return { success: true, data: redisData }
 }
@@ -303,7 +303,7 @@ async function setTenantStatus(id: string, status: TenantStatus): Promise<Action
     language: (updated as { language?: string }).language ?? 'en',
     status: ((updated as { status?: string }).status ?? 'active') as TenantStatus,
   }
-  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData), { ex: 86400 })
+  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData), 'EX', 86400)
 
   return { success: true, data: undefined }
 }

--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -77,7 +77,7 @@ export async function createTenant(data: {
     language: (tenant as { language?: string }).language ?? 'en',
     status: ((tenant as { status?: string }).status ?? 'active') as TenantStatus,
   }
-  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData))
+  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData), { ex: 86400 })
 
   // Create initial membership row for the creating user with role 'editor'.
   // Must use service client — user has no membership yet so RLS would block.
@@ -133,7 +133,7 @@ export async function getTenantBySlug(slug: string): Promise<ActionResponse<Tena
     language: (tenant as { language?: string }).language ?? 'en',
     status: ((tenant as { status?: string }).status ?? 'active') as TenantStatus,
   }
-  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData))
+  await redis.set(`subdomain:${tenant.slug}`, JSON.stringify(redisData), { ex: 86400 })
 
   return { success: true, data: redisData }
 }
@@ -223,7 +223,7 @@ export async function updateTenant(
     language: (updated as { language?: string }).language ?? 'en',
     status: ((updated as { status?: string }).status ?? 'active') as TenantStatus,
   }
-  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData))
+  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData), { ex: 86400 })
 
   return { success: true, data: redisData }
 }
@@ -303,7 +303,7 @@ async function setTenantStatus(id: string, status: TenantStatus): Promise<Action
     language: (updated as { language?: string }).language ?? 'en',
     status: ((updated as { status?: string }).status ?? 'active') as TenantStatus,
   }
-  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData))
+  await redis.set(`subdomain:${updated.slug}`, JSON.stringify(redisData), { ex: 86400 })
 
   return { success: true, data: undefined }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -123,7 +123,7 @@ export async function middleware(request: NextRequest) {
         'active') as TenantRedisData['status'],
     }
     try {
-      await redis.set(cacheKey, JSON.stringify(tenant), { ex: 86400 })
+      await redis.set(cacheKey, JSON.stringify(tenant), 'EX', 86400)
     } catch (err) {
       // Cache write failure is non-fatal — DB lookup succeeded, request continues.
       console.error('[middleware] redis cache write failed', { subdomain, err })

--- a/middleware.ts
+++ b/middleware.ts
@@ -123,7 +123,7 @@ export async function middleware(request: NextRequest) {
         'active') as TenantRedisData['status'],
     }
     try {
-      await redis.set(cacheKey, JSON.stringify(tenant))
+      await redis.set(cacheKey, JSON.stringify(tenant), { ex: 86400 })
     } catch (err) {
       // Cache write failure is non-fatal — DB lookup succeeded, request continues.
       console.error('[middleware] redis cache write failed', { subdomain, err })


### PR DESCRIPTION
## Summary

- All 5 `redis.set` calls for `subdomain:{slug}` keys now pass `{ ex: 86400 }` (24h TTL)
- Covers: middleware cache-miss backfill, `createTenant`, `getTenantBySlug` backfill, `updateTenant`, `setTenantStatus`
- Safety net alongside explicit invalidation — stale data can't persist indefinitely if invalidation ever misses

## Test plan

- [ ] Create tenant → Redis key expires after 24h (verify with `redis-cli TTL subdomain:{slug}`)
- [ ] Update tenant → existing key refreshed with new 24h TTL
- [ ] Middleware cache-miss path → backfilled key has TTL
- [ ] Normal tenant routing unaffected

Closes #138

https://claude.ai/code/session_016n5sWNKT27kZm4LrSgb2ud

---
_Generated by [Claude Code](https://claude.ai/code/session_016n5sWNKT27kZm4LrSgb2ud)_