### PR TITLE
lint: add jsx-a11y + react-hooks/exhaustive-deps enforcement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+## Linting & Code Quality
+
+Run `pnpm lint` before opening a PR. The pre-commit hook (husky + lint-staged) runs Prettier and ESLint automatically on staged files.
+
+### Accessibility (jsx-a11y)
+
+All JSX is linted with `eslint-plugin-jsx-a11y` (full recommended ruleset). New components must pass a11y rules without suppression unless there is a deliberate pattern.
+
+**Common rules to watch:**
+
+| Rule                                              | What it catches                                     | When to suppress                                                                                                                  |
+| ------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `jsx-a11y/no-autofocus`                           | `autoFocus` prop                                    | Dialogs and inline-edit forms — moving focus on open is correct a11y. Suppress with an inline `eslint-disable-next-line` comment. |
+| `jsx-a11y/no-noninteractive-element-interactions` | Click/keyboard handlers on non-interactive elements | Composite keyboard-navigable widgets. Use `eslint-disable-next-line` with a one-line explanation.                                 |
+| `jsx-a11y/no-noninteractive-tabindex`             | `tabIndex ≥ 0` on non-interactive ARIA roles        | Same as above — composite widget pattern.                                                                                         |
+| `jsx-a11y/click-events-have-key-events`           | `onClick` without a keyboard handler                | Almost never suppress — fix by using a native button/link or adding `onKeyDown` + appropriate `role`.                             |
+| `jsx-a11y/no-static-element-interactions`         | Event handlers on elements with no ARIA role        | Almost never suppress — use a native interactive element.                                                                         |
+
+**Suppression template:**
+
+```tsx
+// Reason: <one-line explanation of the deliberate pattern>
+// eslint-disable-next-line jsx-a11y/<rule-name>
+<div role="group" tabIndex={0} onKeyDown={handler}>
+```
+
+### React Hooks (exhaustive-deps)
+
+`react-hooks/exhaustive-deps` runs at `warn` level. Each warning should be inspected:
+
+- Missing dep that causes stale closure → add it to the array.
+- Missing dep that would cause an infinite loop → restructure with `useRef` or `useCallback`.
+- Intentional omission (e.g., stable server action reference) → add `// eslint-disable-next-line` with a comment.

--- a/components/notification-bell.tsx
+++ b/components/notification-bell.tsx
@@ -86,47 +86,58 @@ export function NotificationBell({ initialCount }: { initialCount: number }) {
             <p className="text-muted-foreground py-8 text-center text-sm">No notifications yet.</p>
           ) : (
             notifications.map((n) => {
-              const content = (
-                <div
-                  className={cn(
-                    'border-b px-4 py-3 transition-colors last:border-0',
-                    n.read ? 'bg-background' : 'bg-primary/5',
-                    n.link && 'hover:bg-accent cursor-pointer'
-                  )}
-                  onClick={() => handleClickNotification(n)}
-                >
-                  <div className="flex items-start gap-2">
-                    {!n.read && (
-                      <span className="bg-primary mt-1.5 h-2 w-2 shrink-0 rounded-full" />
+              const rowClass = cn(
+                'border-b px-4 py-3 transition-colors last:border-0',
+                n.read ? 'bg-background' : 'bg-primary/5'
+              )
+              const rowContent = (
+                <div className="flex items-start gap-2">
+                  {!n.read && <span className="bg-primary mt-1.5 h-2 w-2 shrink-0 rounded-full" />}
+                  <div className={cn('flex-1', n.read && 'pl-4')}>
+                    <p className="text-sm leading-snug font-medium">{n.title}</p>
+                    {n.body && (
+                      <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">{n.body}</p>
                     )}
-                    <div className={cn('flex-1', n.read && 'pl-4')}>
-                      <p className="text-sm leading-snug font-medium">{n.title}</p>
-                      {n.body && (
-                        <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">
-                          {n.body}
-                        </p>
-                      )}
-                      <p className="text-muted-foreground mt-1 text-[10px]">
-                        {new Date(n.created_at).toLocaleString()}
-                      </p>
-                    </div>
+                    <p className="text-muted-foreground mt-1 text-[10px]">
+                      {new Date(n.created_at).toLocaleString()}
+                    </p>
                   </div>
                 </div>
               )
 
-              return n.link ? (
-                <Link
-                  key={n.id}
-                  href={n.link}
-                  onClick={() => {
-                    handleClickNotification(n)
-                    setOpen(false)
-                  }}
-                >
-                  {content}
-                </Link>
-              ) : (
-                <div key={n.id}>{content}</div>
+              if (n.link) {
+                return (
+                  <Link
+                    key={n.id}
+                    href={n.link}
+                    className={cn(rowClass, 'hover:bg-accent block cursor-pointer')}
+                    onClick={() => {
+                      handleClickNotification(n)
+                      setOpen(false)
+                    }}
+                  >
+                    {rowContent}
+                  </Link>
+                )
+              }
+              if (!n.read) {
+                return (
+                  // Bespoke notification row — full-bleed block layout doesn't fit Button primitive.
+                  // eslint-disable-next-line no-restricted-syntax
+                  <button
+                    key={n.id}
+                    type="button"
+                    className={cn(rowClass, 'hover:bg-accent w-full cursor-pointer text-left')}
+                    onClick={() => handleClickNotification(n)}
+                  >
+                    {rowContent}
+                  </button>
+                )
+              }
+              return (
+                <div key={n.id} className={rowClass}>
+                  {rowContent}
+                </div>
               )
             })
           )}

--- a/components/table-breakdown-builder.tsx
+++ b/components/table-breakdown-builder.tsx
@@ -144,9 +144,12 @@ function TableBlock({
   const tableNumber = index + 1
 
   return (
+    // Keyboard-navigable table-block widget: role="group" wraps inner controls and accepts arrow-key reorder events.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <div
       role="group"
       aria-label={`Table ${tableNumber}, ${seats} seats`}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
       onKeyDown={onKeyDown}
       className="bg-card focus-visible:ring-ring relative flex min-w-[64px] flex-col items-center gap-1 rounded-md border px-3 pt-5 pb-2 focus:outline-none focus-visible:ring-2"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,13 @@
 import nextConfig from 'eslint-config-next'
 import tseslint from 'typescript-eslint'
+import a11y from 'eslint-plugin-jsx-a11y'
+
+// eslint-config-next already registers the jsx-a11y plugin, so spread rules only to avoid re-registration error.
+const a11yRules = { rules: a11y.flatConfigs.recommended.rules }
 
 export default [
   ...nextConfig,
+  a11yRules,
   {
     plugins: { '@typescript-eslint': tseslint.plugin },
     rules: {
@@ -15,6 +20,10 @@ export default [
       // Pre-existing pattern throughout the codebase: syncing props to state in effects.
       // Downgraded from error to warn — address incrementally.
       'react-hooks/set-state-in-effect': 'warn',
+      // Stale-closure bugs land silently; keep this visible at warn level.
+      'react-hooks/exhaustive-deps': 'warn',
+      // autoFocus in dialogs and inline-edit forms is deliberate focus management for keyboard users.
+      'jsx-a11y/no-autofocus': 'warn',
       // Button design-system guardrails. See components/ui/button.tsx for the canonical API.
       'no-restricted-syntax': [
         'error',

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "dotenv": "^17.4.1",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.5",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "husky": "^9.1.7",
     "jsdom": "^29.0.1",
     "lint-staged": "^17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       eslint-config-next:
         specifier: ^16.2.5
         version: 16.2.5(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.39.4(jiti@2.4.2))
       husky:
         specifier: ^9.1.7
         version: 9.1.7


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Install `eslint-plugin-jsx-a11y` as direct dev dep; spread `flatConfigs.recommended` (28 rules vs. the 6 Next.js already enables)
- Explicitly surface `react-hooks/exhaustive-deps` at `warn` level so stale-closure bugs are visible in CI output
- Triage all new violations — fix real bugs, suppress deliberate patterns with comments

## What changed

**`eslint.config.mjs`**
- Import `eslint-plugin-jsx-a11y`, spread its full recommended rules (plugin already registered by Next config, so rules-only spread to avoid re-registration error)
- Add `react-hooks/exhaustive-deps: warn` (already enabled via Next preset, now explicit)
- Downgrade `jsx-a11y/no-autofocus` to `warn` — `autoFocus` in dialogs and inline-edit forms is correct keyboard focus management

**`components/notification-bell.tsx`** — real bug fixed
- Click-only `<div>` for unread notifications was inaccessible to keyboard users
- Split into `<Link>` (navigable), `<button>` (mark-read action), or `<div>` (read, no action) based on `n.link` / `n.read`

**`components/table-breakdown-builder.tsx`** — suppressed with comment
- `role="group" tabIndex={0} onKeyDown` is a deliberate composite keyboard-navigable widget pattern for table-block reordering
- Added `eslint-disable-next-line` with explanation

**`CONTRIBUTING.md`** — new file
- A11y rule guidance for reviewers: which rules to watch, when suppression is acceptable, exhaustive-deps triage guidance

## Result

```
Before: 34 warnings, 0 errors
After:  37 warnings, 0 errors (+3 no-autofocus warns on deliberate dialog autoFocus)
```

Closes #103

https://claude.ai/code/session_0176XAWVSVgSMZPzYUDFjLqo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0176XAWVSVgSMZPzYUDFjLqo)_