### PR TITLE
Whitelabelling: strip Courseday from tenant HTML page titles and PWA manifest

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -49,19 +49,19 @@ export async function generateMetadata(): Promise<Metadata> {
   try {
     const tenant = await getTenantFromHeaders()
     const data = await getTenantRow(tenant.id)
-    const name = data?.name as string | undefined
+    const name = (data?.name ?? tenant.slug) as string
     const palette = getTenantPalette(
       (data?.theme_palette as string | null) ?? null,
       (data?.accent_color as string | null) ?? null
     )
     return {
-      title: name ? `${name} · Courseday` : 'Courseday',
+      title: name,
       manifest: '/pwa/manifest',
       themeColor: palette.legacyAccentHex,
       appleWebApp: {
         capable: true,
         statusBarStyle: 'default',
-        title: name ?? 'Courseday',
+        title: name,
       },
       icons: {
         apple: '/pwa/icon',
@@ -69,12 +69,10 @@ export async function generateMetadata(): Promise<Metadata> {
     }
   } catch {
     return {
-      title: 'Courseday',
       manifest: '/pwa/manifest',
       appleWebApp: {
         capable: true,
         statusBarStyle: 'default',
-        title: 'Courseday',
       },
       icons: {
         apple: '/pwa/icon',

--- a/app/[tenant]/pwa/manifest/route.ts
+++ b/app/[tenant]/pwa/manifest/route.ts
@@ -4,8 +4,8 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { getTenantPalette } from '@/lib/theme/palettes'
 
 export async function GET() {
+  const tenant = await getTenantFromHeaders()
   try {
-    const tenant = await getTenantFromHeaders()
     const supabase = await createSupabaseServerClient()
 
     const { data } = await supabase
@@ -14,14 +14,14 @@ export async function GET() {
       .eq('id', tenant.id)
       .single()
 
-    const name = (data?.name as string | null) ?? 'Courseday'
+    const name = (data?.name as string | null) ?? tenant.slug
     const palette = getTenantPalette(
       (data?.theme_palette as string | null) ?? null,
       (data?.accent_color as string | null) ?? null
     )
 
     const manifest = {
-      name: `${name} · Courseday`,
+      name,
       short_name: name,
       description: 'Daily operations and team communication for golf venues.',
       start_url: '/',
@@ -56,8 +56,8 @@ export async function GET() {
   } catch {
     return NextResponse.json(
       {
-        name: 'Courseday',
-        short_name: 'Courseday',
+        name: tenant.slug,
+        short_name: tenant.slug,
         start_url: '/',
         display: 'standalone',
         background_color: '#ffffff',


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Tenant browser tabs and PWA install names now show only the venue name (e.g. "Royal Golf Club") with no "Courseday" suffix
- Falls back to the tenant slug if no name is set
- Catch block in `layout.tsx` now omits title entirely (inherits root default) rather than leaking the brand name
- PWA manifest `route.ts` restructured so `getTenantFromHeaders()` runs before the try/catch, enabling slug fallback in error cases too

Closes #153

## Test plan

- [ ] Visit a tenant subdomain — browser tab should show only the venue name
- [ ] Install the PWA on a tenant subdomain — installed app name should be venue name only
- [ ] Verify root domain pages (`/`, `/auth/sign-in`) still show "Courseday" branding

https://claude.ai/code/session_01Hey5U2SDpTGLN4GdsiM3nY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hey5U2SDpTGLN4GdsiM3nY)_