### PR TITLE
fix: return 404 for unknown tenant in PWA manifest

### DIFF
--- a/app/[tenant]/pwa/manifest/route.ts
+++ b/app/[tenant]/pwa/manifest/route.ts
@@ -4,7 +4,13 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { getTenantPalette } from '@/lib/theme/palettes'
 
 export async function GET() {
-  const tenant = await getTenantFromHeaders()
+  let tenant
+  try {
+    tenant = await getTenantFromHeaders()
+  } catch {
+    return new NextResponse(null, { status: 404 })
+  }
+
   try {
     const supabase = await createSupabaseServerClient()
 
@@ -54,17 +60,6 @@ export async function GET() {
       },
     })
   } catch {
-    return NextResponse.json(
-      {
-        name: tenant.slug,
-        short_name: tenant.slug,
-        start_url: '/',
-        display: 'standalone',
-        background_color: '#ffffff',
-        theme_color: '#e5e7eb',
-        icons: [{ src: '/icon.svg', sizes: 'any', type: 'image/svg+xml' }],
-      },
-      { headers: { 'Content-Type': 'application/manifest+json' } }
-    )
+    return new NextResponse(null, { status: 404 })
   }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Strip Courseday branding from tenant PWA manifest (closes #154)
- Return `404` when tenant headers are missing (not-found / outside tenant context)
- Return `404` on Supabase lookup failure instead of generic fallback manifest

## Test plan

- [ ] `curl http://demo.localhost:3000/pwa/manifest | jq` → `name`/`short_name` = tenant name only
- [ ] `curl -i http://nonexistent.localhost:3000/pwa/manifest` → `404`
- [ ] `grep -i courseday app/\[tenant\]/pwa/manifest/route.ts` → no matches

https://claude.ai/code/session_01FDhiCCrw4ArWEZ8mYHYfky
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDhiCCrw4ArWEZ8mYHYfky)_