### PR TITLE
feat: per-tenant favicon and Apple touch icon (issue #157)

### DIFF
--- a/app/[tenant]/apple-icon.tsx
+++ b/app/[tenant]/apple-icon.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from 'next/og'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { getTenantPalette } from '@/lib/theme/palettes'
+
+export const size = { width: 180, height: 180 }
+export const contentType = 'image/png'
+
+export default async function AppleIcon({ params }: { params: Promise<{ tenant: string }> }) {
+  const { tenant: slug } = await params
+
+  const supabase = createSupabaseServiceClient()
+  const { data } = await supabase
+    .from('tenants')
+    .select('name, theme_palette, accent_color, logo_url')
+    .eq('slug', slug)
+    .single()
+
+  const palette = getTenantPalette(data?.theme_palette ?? null, data?.accent_color ?? null)
+  const bg = palette.legacyAccentHex
+  const logoUrl = data?.logo_url as string | null | undefined
+
+  if (logoUrl) {
+    return new ImageResponse(
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: bg,
+        }}
+      >
+        <img src={logoUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+      </div>,
+      size
+    )
+  }
+
+  const initial = (data?.name ?? 'C')[0]!.toUpperCase()
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: bg,
+        color: '#ffffff',
+        fontWeight: 700,
+        fontSize: 90,
+        fontFamily: 'sans-serif',
+      }}
+    >
+      {initial}
+    </div>,
+    size
+  )
+}

--- a/app/[tenant]/icon.tsx
+++ b/app/[tenant]/icon.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from 'next/og'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { getTenantPalette } from '@/lib/theme/palettes'
+
+export const size = { width: 32, height: 32 }
+export const contentType = 'image/png'
+
+export default async function Icon({ params }: { params: Promise<{ tenant: string }> }) {
+  const { tenant: slug } = await params
+
+  const supabase = createSupabaseServiceClient()
+  const { data } = await supabase
+    .from('tenants')
+    .select('name, theme_palette, accent_color, logo_url')
+    .eq('slug', slug)
+    .single()
+
+  const palette = getTenantPalette(data?.theme_palette ?? null, data?.accent_color ?? null)
+  const bg = palette.legacyAccentHex
+  const logoUrl = data?.logo_url as string | null | undefined
+
+  if (logoUrl) {
+    return new ImageResponse(
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: bg,
+        }}
+      >
+        <img src={logoUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+      </div>,
+      size
+    )
+  }
+
+  const initial = (data?.name ?? 'C')[0]!.toUpperCase()
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: bg,
+        color: '#ffffff',
+        fontWeight: 700,
+        fontSize: 16,
+        fontFamily: 'sans-serif',
+      }}
+    >
+      {initial}
+    </div>,
+    size
+  )
+}

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -63,9 +63,6 @@ export async function generateMetadata(): Promise<Metadata> {
         statusBarStyle: 'default',
         title: name,
       },
-      icons: {
-        apple: '/pwa/icon',
-      },
     }
   } catch {
     return {
@@ -73,9 +70,6 @@ export async function generateMetadata(): Promise<Metadata> {
       appleWebApp: {
         capable: true,
         statusBarStyle: 'default',
-      },
-      icons: {
-        apple: '/pwa/icon',
       },
     }
   }


### PR DESCRIPTION
## Summary

- Adds `app/[tenant]/icon.tsx` (32×32 PNG) — browser tab favicon per tenant
- Adds `app/[tenant]/apple-icon.tsx` (180×180 PNG) — iOS home-screen icon per tenant
- Removes explicit `icons.apple` override in `generateMetadata` so Next.js serves the new `apple-icon` route automatically

Both files use Next.js Image Generation API (`next/og` `ImageResponse`). They resolve the tenant slug from route params, query `logo_url`, `theme_palette`, and `accent_color` via the service client, then render:
- **Logo present** → palette-colored background with the logo image contained within
- **No logo** → solid palette-colored square with the first letter of the tenant name in white bold

## Test plan

- [ ] `pnpm dev` → visit `http://demo.localhost:3000` and confirm browser tab shows tenant-derived icon
- [ ] `curl -I http://demo.localhost:3000/icon` and `.../apple-icon` both return `image/png`
- [ ] Tenant with logo: confirm logo renders; tenant without logo: confirm colored monogram renders
- [ ] CI typecheck + build passes

Closes #157

https://claude.ai/code/session_01U2JgVHrAjAoqkqZRZFxjUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2JgVHrAjAoqkqZRZFxjUT)_