### PR TITLE
feat: per-tenant Open Graph / Twitter preview images

### DIFF
--- a/app/[tenant]/opengraph-image.tsx
+++ b/app/[tenant]/opengraph-image.tsx
@@ -1,0 +1,93 @@
+import { ImageResponse } from 'next/og'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { getTenantPalette } from '@/lib/theme/palettes'
+
+export const alt = 'Tenant preview'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function Image({ params }: { params: Promise<{ tenant: string }> }) {
+  const { tenant: slug } = await params
+
+  const supabase = createSupabaseServiceClient()
+  const { data } = await supabase
+    .from('tenants')
+    .select('name, theme_palette, accent_color, logo_url')
+    .eq('slug', slug)
+    .single()
+
+  const palette = getTenantPalette(data?.theme_palette ?? null, data?.accent_color ?? null)
+  const bg = palette.legacyAccentHex
+  const name = (data?.name ?? slug) as string
+  const logoUrl = data?.logo_url as string | null | undefined
+
+  if (logoUrl) {
+    return new ImageResponse(
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          background: bg,
+          padding: '80px',
+          gap: '64px',
+        }}
+      >
+        <img
+          src={logoUrl}
+          alt=""
+          style={{
+            width: '180px',
+            height: '180px',
+            objectFit: 'contain',
+            flexShrink: 0,
+          }}
+        />
+        <span
+          style={{
+            color: '#ffffff',
+            fontWeight: 700,
+            fontSize: '80px',
+            fontFamily: 'sans-serif',
+            lineHeight: 1.1,
+            letterSpacing: '-2px',
+          }}
+        >
+          {name}
+        </span>
+      </div>,
+      size
+    )
+  }
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: bg,
+      }}
+    >
+      <span
+        style={{
+          color: '#ffffff',
+          fontWeight: 700,
+          fontSize: '96px',
+          fontFamily: 'sans-serif',
+          lineHeight: 1.1,
+          letterSpacing: '-3px',
+          textAlign: 'center',
+          padding: '0 80px',
+        }}
+      >
+        {name}
+      </span>
+    </div>,
+    size
+  )
+}

--- a/app/[tenant]/twitter-image.tsx
+++ b/app/[tenant]/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from './opengraph-image'


### PR DESCRIPTION
## Summary

- Adds `app/[tenant]/opengraph-image.tsx` — 1200×630 `ImageResponse` with tenant palette primary color as background; logo + name when `logo_url` is set, centered name otherwise
- Adds `app/[tenant]/twitter-image.tsx` — re-exports from the OG image (same dimensions accepted by Twitter)
- Follows the identical pattern already used by `app/[tenant]/icon.tsx` (service client query, `getTenantPalette`)

## Test plan

- [ ] `curl -I http://<slug>.localhost:3000/opengraph-image` returns 200 `image/png` 1200×630
- [ ] `curl -I http://<slug>.localhost:3000/twitter-image` returns the same
- [ ] Tenant with a logo: logo appears left, name right on palette background
- [ ] Tenant without a logo: name centered on palette background
- [ ] Two tenants with different palettes produce visibly different previews
- [ ] CI passes (typecheck, lint, unit-tests, build)

Closes #160

https://claude.ai/code/session_0152xFxNNAWSydVVcjo2rTQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_0152xFxNNAWSydVVcjo2rTQ5)_