### PR TITLE
feat(#163): tenant-customizable email from-name and reply-to

### DIFF
--- a/app/[tenant]/admin/settings/branding/page.tsx
+++ b/app/[tenant]/admin/settings/branding/page.tsx
@@ -12,7 +12,9 @@ export default async function BrandingSettingsPage() {
   const supabase = await createSupabaseServerClient()
   const { data } = await supabase
     .from('tenants')
-    .select('theme_palette, accent_color, logo_url, latitude, longitude')
+    .select(
+      'theme_palette, accent_color, logo_url, latitude, longitude, email_from_name, email_reply_to'
+    )
     .eq('id', tenant.id)
     .single()
 
@@ -22,6 +24,8 @@ export default async function BrandingSettingsPage() {
     logo_url?: string | null
     latitude?: number | null
     longitude?: number | null
+    email_from_name?: string | null
+    email_reply_to?: string | null
   } | null
 
   return (
@@ -29,11 +33,14 @@ export default async function BrandingSettingsPage() {
       <h1 className="mb-6 text-2xl font-semibold">{t('tabBranding')}</h1>
       <SettingsForm
         tenantId={tenant.id}
+        tenantName={tenant.name}
         initialPaletteId={row?.theme_palette ?? null}
         initialAccentColor={row?.accent_color ?? null}
         initialLogoUrl={row?.logo_url ?? null}
         initialLatitude={row?.latitude ?? null}
         initialLongitude={row?.longitude ?? null}
+        initialEmailFromName={row?.email_from_name ?? null}
+        initialEmailReplyTo={row?.email_reply_to ?? null}
       />
     </div>
   )

--- a/app/[tenant]/admin/settings/branding/page.tsx
+++ b/app/[tenant]/admin/settings/branding/page.tsx
@@ -13,12 +13,13 @@ export default async function BrandingSettingsPage() {
   const { data } = await supabase
     .from('tenants')
     .select(
-      'theme_palette, accent_color, logo_url, latitude, longitude, email_from_name, email_reply_to'
+      'name, theme_palette, accent_color, logo_url, latitude, longitude, email_from_name, email_reply_to'
     )
     .eq('id', tenant.id)
     .single()
 
   const row = data as {
+    name?: string | null
     theme_palette?: string | null
     accent_color?: string | null
     logo_url?: string | null
@@ -33,7 +34,7 @@ export default async function BrandingSettingsPage() {
       <h1 className="mb-6 text-2xl font-semibold">{t('tabBranding')}</h1>
       <SettingsForm
         tenantId={tenant.id}
-        tenantName={tenant.name}
+        tenantName={row?.name ?? ''}
         initialPaletteId={row?.theme_palette ?? null}
         initialAccentColor={row?.accent_color ?? null}
         initialLogoUrl={row?.logo_url ?? null}

--- a/app/[tenant]/admin/settings/settings-form.tsx
+++ b/app/[tenant]/admin/settings/settings-form.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner'
 import { updateTenant } from '@/app/actions/tenants'
 import { createSupabaseBrowserClient } from '@/lib/supabase-client'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { CitySearch } from '@/components/city-search'
@@ -19,20 +20,26 @@ import {
 
 interface SettingsFormProps {
   tenantId: string
+  tenantName: string
   initialPaletteId: string | null
   initialAccentColor: string | null
   initialLogoUrl: string | null
   initialLatitude: number | null
   initialLongitude: number | null
+  initialEmailFromName: string | null
+  initialEmailReplyTo: string | null
 }
 
 export function SettingsForm({
   tenantId,
+  tenantName,
   initialPaletteId,
   initialAccentColor,
   initialLogoUrl,
   initialLatitude,
   initialLongitude,
+  initialEmailFromName,
+  initialEmailReplyTo,
 }: SettingsFormProps) {
   const [paletteId, setPaletteId] = useState<TenantPaletteId>(
     resolveTenantPaletteId(initialPaletteId, initialAccentColor)
@@ -42,6 +49,8 @@ export function SettingsForm({
   const [longitude, setLongitude] = useState(
     initialLongitude != null ? String(initialLongitude) : ''
   )
+  const [emailFromName, setEmailFromName] = useState(initialEmailFromName ?? '')
+  const [emailReplyTo, setEmailReplyTo] = useState(initialEmailReplyTo ?? '')
   const [uploading, setUploading] = useState(false)
   const [saving, setSaving] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -97,6 +106,12 @@ export function SettingsForm({
   }
 
   async function handleSave() {
+    const replyTo = emailReplyTo.trim()
+    if (replyTo && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(replyTo)) {
+      toast.error('Reply-to email is not valid')
+      return
+    }
+
     setSaving(true)
     try {
       const lat = latitude.trim() ? parseFloat(latitude) : null
@@ -109,6 +124,8 @@ export function SettingsForm({
         logo_url: logoUrl || null,
         latitude: lat != null && !isNaN(lat) ? lat : null,
         longitude: lon != null && !isNaN(lon) ? lon : null,
+        email_from_name: emailFromName.trim() || null,
+        email_reply_to: replyTo || null,
       })
 
       if (!result.success) {
@@ -200,6 +217,38 @@ export function SettingsForm({
               setLongitude('')
             }}
           />
+        </CardContent>
+      </Card>
+
+      {/* Email branding */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Email sender</CardTitle>
+          <CardDescription>
+            Customise how morning brief emails appear in recipients&apos; inboxes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email-from-name">Sender name</Label>
+            <Input
+              id="email-from-name"
+              type="text"
+              value={emailFromName}
+              onChange={(e) => setEmailFromName(e.target.value)}
+              placeholder={tenantName}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email-reply-to">Reply-to email</Label>
+            <Input
+              id="email-reply-to"
+              type="email"
+              value={emailReplyTo}
+              onChange={(e) => setEmailReplyTo(e.target.value)}
+              placeholder="ops@yourvenue.com"
+            />
+          </div>
         </CardContent>
       </Card>
 

--- a/app/[tenant]/admin/settings/settings-form.tsx
+++ b/app/[tenant]/admin/settings/settings-form.tsx
@@ -20,26 +20,26 @@ import {
 
 interface SettingsFormProps {
   tenantId: string
-  tenantName: string
+  tenantName?: string
   initialPaletteId: string | null
   initialAccentColor: string | null
   initialLogoUrl: string | null
   initialLatitude: number | null
   initialLongitude: number | null
-  initialEmailFromName: string | null
-  initialEmailReplyTo: string | null
+  initialEmailFromName?: string | null
+  initialEmailReplyTo?: string | null
 }
 
 export function SettingsForm({
   tenantId,
-  tenantName,
+  tenantName = '',
   initialPaletteId,
   initialAccentColor,
   initialLogoUrl,
   initialLatitude,
   initialLongitude,
-  initialEmailFromName,
-  initialEmailReplyTo,
+  initialEmailFromName = null,
+  initialEmailReplyTo = null,
 }: SettingsFormProps) {
   const [paletteId, setPaletteId] = useState<TenantPaletteId>(
     resolveTenantPaletteId(initialPaletteId, initialAccentColor)

--- a/app/actions/tenants.ts
+++ b/app/actions/tenants.ts
@@ -154,6 +154,8 @@ export async function updateTenant(
     latitude?: number | null
     longitude?: number | null
     onboarding_completed?: boolean
+    email_from_name?: string | null
+    email_reply_to?: string | null
   }
 ): Promise<ActionResponse<TenantRedisData>> {
   const user = await getUser()

--- a/lib/morning-brief-cron.ts
+++ b/lib/morning-brief-cron.ts
@@ -77,15 +77,21 @@ export type MorningBriefCronResult = {
  * `getTenantToday` and compare `now` to 7:00 that local calendar day, so
  * short-interval crons (Pro) are not required.
  */
+function extractEmailAddress(from: string): string {
+  const match = from.match(/<([^>]+)>/)
+  return match ? match[1] : from
+}
+
 export async function runMorningBriefEmailCron(): Promise<MorningBriefCronResult> {
   const supabase = createSupabaseServiceClient()
   const resendKey = process.env.RESEND_API_KEY
-  const from = process.env.RESEND_FROM_EMAIL ?? 'Courseday <onboarding@resend.dev>'
+  const fromEnv = process.env.RESEND_FROM_EMAIL ?? 'Courseday <onboarding@resend.dev>'
+  const fromAddress = extractEmailAddress(fromEnv)
   const resend = resendKey ? new Resend(resendKey) : null
 
   const { data: tenants, error: tenantsError } = await supabase
     .from('tenants')
-    .select('id, name, slug, timezone')
+    .select('id, name, slug, timezone, email_from_name, email_reply_to')
 
   if (tenantsError || !tenants) {
     return {
@@ -218,13 +224,18 @@ export async function runMorningBriefEmailCron(): Promise<MorningBriefCronResult
         const subject = `Daily brief — ${tenant.name} — ${dateLabel}`
         const text = formatDailyBriefMarkdown(brief.content) + `\n\n${dayUrl}\n`
         const html = briefToHtml(brief, tenant.name, dayUrl, dateLabel)
+        const tenantFromName =
+          (tenant as { email_from_name?: string | null }).email_from_name ?? tenant.name
+        const tenantReplyTo =
+          (tenant as { email_reply_to?: string | null }).email_reply_to ?? undefined
 
         const { error: sendErr } = await resend.emails.send({
-          from,
+          from: `${tenantFromName} <${fromAddress}>`,
           to,
           subject,
           text,
           html,
+          ...(tenantReplyTo ? { replyTo: tenantReplyTo } : {}),
         })
         if (sendErr) {
           errors.push(`${to}: ${sendErr.message}`)

--- a/lib/morning-brief-cron.ts
+++ b/lib/morning-brief-cron.ts
@@ -79,7 +79,7 @@ export type MorningBriefCronResult = {
  */
 function extractEmailAddress(from: string): string {
   const match = from.match(/<([^>]+)>/)
-  return match ? match[1] : from
+  return match ? (match[1] ?? from) : from
 }
 
 export async function runMorningBriefEmailCron(): Promise<MorningBriefCronResult> {

--- a/supabase/migrations/00042_tenant_email_branding.sql
+++ b/supabase/migrations/00042_tenant_email_branding.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tenants
+  ADD COLUMN email_from_name TEXT,
+  ADD COLUMN email_reply_to TEXT;


### PR DESCRIPTION
## Summary

- Adds `email_from_name` and `email_reply_to` columns to the `tenants` table (migration `00042_tenant_email_branding.sql`)
- Extends `updateTenant` action to accept both fields
- Branding settings page fetches and surfaces both fields as inputs ("Sender name" / "Reply-to email") with email validation on the reply-to field
- Morning brief cron constructs `from` as `"${email_from_name ?? tenant.name} <address>"` and passes `replyTo` when set; falls back gracefully when null

## Test plan

- [ ] `supabase db reset` — migration applies cleanly
- [ ] `pnpm db:types` — types regenerate without churn
- [ ] Sign in as editor → `/admin/settings/branding` → set both fields → save → inspect DB row to confirm persistence
- [ ] Trigger morning brief cron → confirm `from` and `replyTo` fields in Resend send call match tenant config

Closes #163

https://claude.ai/code/session_01KStihnca5FBayjCy55ZTHP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KStihnca5FBayjCy55ZTHP)_