### PR TITLE
feat: staff roster week grid at /schedule/[weekStart] (#156)

### DIFF
--- a/app/[tenant]/schedule/[weekStart]/page.tsx
+++ b/app/[tenant]/schedule/[weekStart]/page.tsx
@@ -1,0 +1,57 @@
+import { notFound, redirect } from 'next/navigation'
+import { format, addDays, parseISO, startOfISOWeek } from 'date-fns'
+import { getTenantFromHeaders } from '@/lib/tenant'
+import { requireTenantMember } from '@/lib/guards'
+import { getFeatureFlags } from '@/app/actions/feature-flags'
+import { ensureDaysRange } from '@/app/actions/days'
+import { getWeekShifts } from '@/app/actions/shifts'
+import { getTenantAssigneesList } from '@/app/[tenant]/day/[date]/queries'
+import { RosterGrid } from '@/components/roster-grid'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+const YMD_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+export default async function ScheduleWeekPage({
+  params,
+}: {
+  params: Promise<{ weekStart: string }>
+}) {
+  const { weekStart } = await params
+
+  if (!YMD_REGEX.test(weekStart)) {
+    const monday = format(startOfISOWeek(new Date()), 'yyyy-MM-dd')
+    redirect(`/schedule/${monday}`)
+  }
+
+  const [tenant, { role }] = await Promise.all([
+    getTenantFromHeaders(),
+    requireTenantMember(),
+  ] as const)
+
+  const flags = await getFeatureFlags(tenant.id)
+  if (!flags.staff_schedule) notFound()
+
+  const weekEnd = format(addDays(parseISO(weekStart), 6), 'yyyy-MM-dd')
+
+  const [daysResult, shifts, assignees] = await Promise.all([
+    ensureDaysRange(weekStart, weekEnd),
+    getWeekShifts(weekStart),
+    getTenantAssigneesList(tenant.id),
+  ])
+
+  const days = daysResult.success ? daysResult.data : []
+  const isEditor = role === 'editor'
+
+  return (
+    <RosterGrid
+      weekStart={weekStart}
+      weekEnd={weekEnd}
+      days={days}
+      shifts={shifts}
+      assignees={assignees}
+      isEditor={isEditor}
+    />
+  )
+}

--- a/app/[tenant]/schedule/page.tsx
+++ b/app/[tenant]/schedule/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation'
+import { format, startOfISOWeek } from 'date-fns'
+
+export const dynamic = 'force-dynamic'
+
+export default function SchedulePage() {
+  const monday = format(startOfISOWeek(new Date()), 'yyyy-MM-dd')
+  redirect(`/schedule/${monday}`)
+}

--- a/app/actions/shifts.ts
+++ b/app/actions/shifts.ts
@@ -1,12 +1,14 @@
 'use server'
 
-import { createTenantClient } from '@/lib/supabase-server'
+import { createTenantClient, createSupabaseServerClient } from '@/lib/supabase-server'
 import { getTenantId } from '@/lib/tenant'
 import { requireEditor } from '@/lib/membership'
 import { shiftSchema } from '@/lib/shift-schema'
 import type { ShiftFormData } from '@/lib/shift-schema'
 import type { ActionResponse } from '@/types/actions'
-import type { Shift } from '@/types/index'
+import type { Shift, ShiftWithAssignee } from '@/types/index'
+import { getTenantAssignees } from '@/app/[tenant]/day/[date]/queries'
+import { addDays, format, parseISO } from 'date-fns'
 
 function normaliseTime(s: string | undefined | null): string | null {
   const t = (s ?? '').trim()
@@ -142,4 +144,41 @@ export async function deleteShift(id: string, dayId: string): Promise<ActionResp
 
   if (error) return { success: false, error: error.message }
   return { success: true, data: undefined }
+}
+
+export async function getWeekShifts(weekStart: string): Promise<ShiftWithAssignee[]> {
+  const tenantId = await getTenantId()
+  const weekEnd = format(addDays(parseISO(weekStart), 6), 'yyyy-MM-dd')
+
+  const supabase = await createSupabaseServerClient()
+
+  const { data: days } = await supabase
+    .from('day')
+    .select('id')
+    .eq('tenant_id', tenantId)
+    .gte('date_iso', weekStart)
+    .lte('date_iso', weekEnd)
+
+  const dayIds = (days ?? []).map((d) => d.id)
+  if (dayIds.length === 0) return []
+
+  const { data } = await supabase
+    .from('shift')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .in('day_id', dayIds)
+    .order('start_time', { nullsFirst: true })
+
+  const rows = (data ?? []) as unknown as Array<Omit<ShiftWithAssignee, 'assignee'>>
+  if (rows.length === 0) return []
+
+  const assignees = await getTenantAssignees(tenantId)
+  return rows.map((s) => ({
+    ...s,
+    assignee: assignees.get(s.user_id) ?? {
+      user_id: s.user_id,
+      email: '',
+      display_name: '—',
+    },
+  }))
 }

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -27,6 +27,7 @@ export function CommandPalette() {
   const { tenantTodayYmd, activeDayYmd } = useActiveDay()
   const { isEditor } = useAuth()
   const showChecklists = useFeatureFlag('checklists')
+  const showStaffSchedule = useFeatureFlag('staff_schedule')
   const showReservations = useFeatureFlag('reservations')
   const showBreakfast = useFeatureFlag('breakfast_config')
   const { commandPaletteOpen, setCommandPaletteOpen, setQuickAddOpen } = useKeyboardShortcuts()
@@ -37,8 +38,9 @@ export function CommandPalette() {
     () =>
       getVisibleSettingsRoutes({
         checklists: showChecklists,
+        staffSchedule: showStaffSchedule,
       }),
-    [showChecklists]
+    [showChecklists, showStaffSchedule]
   )
 
   const close = useCallback(() => {

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -28,9 +28,11 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
   const settingsT = useTranslations('Tenant.settings')
   const qaT = useTranslations('Tenant.quickAdd')
   const showChecklists = useFeatureFlag('checklists')
+  const showStaffSchedule = useFeatureFlag('staff_schedule')
   const { setQuickAddOpen } = useKeyboardShortcuts()
   const settingsRoutes = getVisibleSettingsRoutes({
     checklists: showChecklists,
+    staffSchedule: showStaffSchedule,
   })
 
   const navItems = [

--- a/components/roster-grid.tsx
+++ b/components/roster-grid.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { format, addDays, parseISO, startOfISOWeek } from 'date-fns'
+import { ChevronLeft, ChevronRight, CalendarDays } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ShiftForm } from '@/components/shift-form'
+import type { Day, ShiftAssignee, ShiftWithAssignee } from '@/types/index'
+
+type Props = {
+  weekStart: string
+  weekEnd: string
+  days: Day[]
+  shifts: ShiftWithAssignee[]
+  assignees: ShiftAssignee[]
+  isEditor: boolean
+}
+
+export function RosterGrid({ weekStart, weekEnd, days, shifts, assignees, isEditor }: Props) {
+  const t = useTranslations('Tenant.staff.roster')
+  const router = useRouter()
+
+  const [localShifts, setLocalShifts] = useState<ShiftWithAssignee[]>(shifts)
+  const [formOpen, setFormOpen] = useState(false)
+  const [selectedDayId, setSelectedDayId] = useState<string | null>(null)
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null)
+  const [editShift, setEditShift] = useState<ShiftWithAssignee | null>(null)
+
+  // Build day list sorted by date_iso (should already be sorted from DB)
+  const sortedDays = [...days].sort((a, b) => a.date_iso.localeCompare(b.date_iso))
+
+  // Group shifts by user_id + day_id
+  const shiftsByUserDay = new Map<string, ShiftWithAssignee[]>()
+  for (const s of localShifts) {
+    const key = `${s.user_id}::${s.day_id}`
+    const existing = shiftsByUserDay.get(key) ?? []
+    shiftsByUserDay.set(key, [...existing, s])
+  }
+
+  function navigate(direction: 'prev' | 'next' | 'today') {
+    let target: string
+    if (direction === 'today') {
+      target = format(startOfISOWeek(new Date()), 'yyyy-MM-dd')
+    } else {
+      const delta = direction === 'prev' ? -7 : 7
+      target = format(addDays(parseISO(weekStart), delta), 'yyyy-MM-dd')
+    }
+    router.push(`/schedule/${target}`)
+  }
+
+  function openAdd(dayId: string, userId: string) {
+    setEditShift(null)
+    setSelectedDayId(dayId)
+    setSelectedUserId(userId)
+    setFormOpen(true)
+  }
+
+  function openEdit(shift: ShiftWithAssignee) {
+    setEditShift(shift)
+    setSelectedDayId(shift.day_id)
+    setSelectedUserId(null)
+    setFormOpen(true)
+  }
+
+  function handleSaved(item: ShiftWithAssignee) {
+    setLocalShifts((prev) => {
+      const idx = prev.findIndex((s) => s.id === item.id)
+      if (idx >= 0) {
+        const next = [...prev]
+        next[idx] = item
+        return next.sort((a, b) => (a.start_time ?? '').localeCompare(b.start_time ?? ''))
+      }
+      return [...prev, item].sort((a, b) => (a.start_time ?? '').localeCompare(b.start_time ?? ''))
+    })
+  }
+
+  // Week header label e.g. "May 4 – May 10, 2026"
+  const startDate = parseISO(weekStart)
+  const endDate = parseISO(weekEnd)
+  const startLabel = format(startDate, 'MMM d')
+  const endLabel = format(endDate, 'MMM d, yyyy')
+  const weekLabel = `${startLabel} – ${endLabel}`
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6">
+      {/* Header */}
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">{t('title')}</h1>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="iconSm"
+            onClick={() => navigate('prev')}
+            title={t('prevWeek')}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm font-medium tabular-nums">{weekLabel}</span>
+          <Button
+            variant="ghost"
+            size="iconSm"
+            onClick={() => navigate('next')}
+            title={t('nextWeek')}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => navigate('today')}>
+            <CalendarDays className="mr-1.5 h-3.5 w-3.5" />
+            {t('today')}
+          </Button>
+        </div>
+      </div>
+
+      {/* Grid */}
+      {assignees.length === 0 ? (
+        <p className="text-muted-foreground text-sm">{t('noStaff')}</p>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full min-w-[640px] border-collapse text-sm">
+            <thead>
+              <tr className="bg-muted/40">
+                <th className="w-40 border-b px-4 py-2 text-left font-medium">
+                  {t('staffColumn')}
+                </th>
+                {sortedDays.map((day) => {
+                  const date = parseISO(day.date_iso)
+                  return (
+                    <th
+                      key={day.id}
+                      className="border-b border-l px-2 py-2 text-center font-medium"
+                    >
+                      <div>{format(date, 'EEE')}</div>
+                      <div className="text-muted-foreground font-normal">{format(date, 'd')}</div>
+                    </th>
+                  )
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {assignees.map((assignee, rowIdx) => (
+                <tr key={assignee.user_id} className={rowIdx % 2 === 0 ? '' : 'bg-muted/20'}>
+                  <td className="border-b px-4 py-2 font-medium">
+                    <div className="truncate" title={assignee.display_name}>
+                      {assignee.display_name}
+                    </div>
+                    {assignee.email && assignee.email !== assignee.display_name && (
+                      <div className="text-muted-foreground truncate text-xs">{assignee.email}</div>
+                    )}
+                  </td>
+                  {sortedDays.map((day) => {
+                    const cellShifts = shiftsByUserDay.get(`${assignee.user_id}::${day.id}`) ?? []
+                    return (
+                      <td key={day.id} className="group border-b border-l px-1 py-1 align-top">
+                        <div className="flex min-h-[3rem] flex-col gap-1">
+                          {cellShifts.map((shift) => (
+                            // eslint-disable-next-line no-restricted-syntax
+                            <button
+                              key={shift.id}
+                              onClick={isEditor ? () => openEdit(shift) : undefined}
+                              className={`w-full rounded px-1.5 py-1 text-left text-xs ${
+                                isEditor
+                                  ? 'bg-accent/60 hover:bg-accent cursor-pointer transition-colors'
+                                  : 'bg-accent/60 cursor-default'
+                              }`}
+                            >
+                              {shift.start_time || shift.end_time ? (
+                                <span className="font-medium">
+                                  {shift.start_time?.slice(0, 5)}
+                                  {shift.end_time ? `–${shift.end_time.slice(0, 5)}` : ''}
+                                </span>
+                              ) : null}
+                              {shift.role ? (
+                                <span className="text-muted-foreground ml-1">{shift.role}</span>
+                              ) : null}
+                            </button>
+                          ))}
+                          {isEditor && cellShifts.length === 0 && (
+                            // eslint-disable-next-line no-restricted-syntax
+                            <button
+                              onClick={() => openAdd(day.id, assignee.user_id)}
+                              className="text-muted-foreground/40 hover:text-muted-foreground hover:bg-muted/40 flex h-full min-h-[3rem] w-full cursor-pointer items-center justify-center rounded transition-colors"
+                              aria-label={t('addShiftAria', {
+                                name: assignee.display_name,
+                                date: day.date_iso,
+                              })}
+                            >
+                              +
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Single ShiftForm instance shared across all cells */}
+      {isEditor && selectedDayId && (
+        <ShiftForm
+          isOpen={formOpen}
+          onClose={() => setFormOpen(false)}
+          dayId={selectedDayId}
+          assignees={assignees}
+          editItem={editShift}
+          onSuccess={handleSaved}
+          defaultUserId={selectedUserId ?? undefined}
+        />
+      )}
+    </div>
+  )
+}

--- a/components/settings-dropdown.tsx
+++ b/components/settings-dropdown.tsx
@@ -9,6 +9,7 @@ import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover
 import { useFeatureFlag } from '@/lib/feature-flags-context'
 
 export const SETTINGS_ROUTES = [
+  { href: '/schedule', labelKey: 'tabStaffRoster' },
   { href: '/admin/settings/poc', labelKey: 'tabPoc' },
   { href: '/admin/settings/venue-types', labelKey: 'tabVenueTypes' },
   { href: '/admin/settings/activity-tags', labelKey: 'tabActivityTags' },
@@ -22,8 +23,14 @@ export const SETTINGS_ROUTES = [
 type LabelKey = (typeof SETTINGS_ROUTES)[number]['labelKey']
 type SettingsRoute = (typeof SETTINGS_ROUTES)[number]
 
-export function getVisibleSettingsRoutes(visibility: { checklists: boolean }): SettingsRoute[] {
+export function getVisibleSettingsRoutes(visibility: {
+  checklists: boolean
+  staffSchedule: boolean
+}): SettingsRoute[] {
   let routes = [...SETTINGS_ROUTES]
+  if (!visibility.staffSchedule) {
+    routes = routes.filter((route) => route.href !== '/schedule')
+  }
   if (!visibility.checklists) {
     routes = routes.filter((route) => route.href !== '/admin/settings/checklists')
   }
@@ -35,8 +42,10 @@ export function SettingsDropdown() {
   const t = useTranslations('Tenant.settings')
   const navT = useTranslations('Tenant.nav')
   const showChecklists = useFeatureFlag('checklists')
+  const showStaffSchedule = useFeatureFlag('staff_schedule')
   const routes = getVisibleSettingsRoutes({
     checklists: showChecklists,
+    staffSchedule: showStaffSchedule,
   })
 
   return (

--- a/components/shift-form.tsx
+++ b/components/shift-form.tsx
@@ -40,9 +40,19 @@ type Props = {
   assignees: ShiftAssignee[]
   editItem: ShiftWithAssignee | null
   onSuccess: (item: ShiftWithAssignee) => void
+  /** Pre-select this user when opening the form for a new shift. */
+  defaultUserId?: string
 }
 
-export function ShiftForm({ isOpen, onClose, dayId, assignees, editItem, onSuccess }: Props) {
+export function ShiftForm({
+  isOpen,
+  onClose,
+  dayId,
+  assignees,
+  editItem,
+  onSuccess,
+  defaultUserId,
+}: Props) {
   const t = useTranslations('Tenant.staff.shiftForm')
   const [isPending, startTransition] = useTransition()
   const isEditing = !!editItem
@@ -59,8 +69,8 @@ export function ShiftForm({ isOpen, onClose, dayId, assignees, editItem, onSucce
   })
 
   useEffect(() => {
-    reset(defaultValues(editItem))
-  }, [editItem, isOpen, reset])
+    reset(defaultValues(editItem, defaultUserId))
+  }, [editItem, isOpen, defaultUserId, reset])
 
   function onSubmit(data: ShiftFormData) {
     startTransition(async () => {
@@ -148,10 +158,10 @@ export function ShiftForm({ isOpen, onClose, dayId, assignees, editItem, onSucce
   )
 }
 
-function defaultValues(editItem: ShiftWithAssignee | null): ShiftFormData {
+function defaultValues(editItem: ShiftWithAssignee | null, defaultUserId?: string): ShiftFormData {
   if (!editItem) {
     return {
-      user_id: '',
+      user_id: defaultUserId ?? '',
       role: '',
       start_time: '',
       end_time: '',

--- a/components/shift-form.tsx
+++ b/components/shift-form.tsx
@@ -41,7 +41,7 @@ type Props = {
   editItem: ShiftWithAssignee | null
   onSuccess: (item: ShiftWithAssignee) => void
   /** Pre-select this user when opening the form for a new shift. */
-  defaultUserId?: string
+  defaultUserId?: string | undefined
 }
 
 export function ShiftForm({

--- a/messages/en.json
+++ b/messages/en.json
@@ -502,7 +502,8 @@
       "cityUnexpectedResponse": "Unexpected response from geocoding service.",
       "clearLocationAria": "Clear location",
       "locationCoordsHint": "Clear the coordinates above to search for a city by name.",
-      "staffScheduleDisabled": "Staff scheduling is disabled for this venue by a platform admin."
+      "staffScheduleDisabled": "Staff scheduling is disabled for this venue by a platform admin.",
+      "tabStaffRoster": "Staff Roster"
     },
     "checklists": {
       "title": "Checklists",
@@ -653,6 +654,15 @@
         "delete": "Delete",
         "deleting": "Deleting…",
         "deleted": "Shift removed."
+      },
+      "roster": {
+        "title": "Staff Roster",
+        "prevWeek": "Previous week",
+        "nextWeek": "Next week",
+        "today": "Today",
+        "staffColumn": "Team member",
+        "noStaff": "No team members yet.",
+        "addShiftAria": "Add shift for {name} on {date}"
       }
     },
     "venueType": {


### PR DESCRIPTION
## Summary

- New route `app/[tenant]/schedule/page.tsx` redirects to the current ISO week Monday at `/schedule/[weekStart]`
- New route `app/[tenant]/schedule/[weekStart]/page.tsx` fetches week days (via `ensureDaysRange`), shifts, and assignees in parallel; calls `notFound()` when `staff_schedule` flag is off
- New `components/roster-grid.tsx` — client grid with rows = staff member, cols = 7 days; empty cells open `ShiftForm` pre-filled with day + staff; shift chips open edit mode; prev/today/next week navigation in header
- `app/actions/shifts.ts` — added `getWeekShifts(weekStart)` server action that queries shifts across the week's day IDs and joins assignee data
- `components/shift-form.tsx` — added optional `defaultUserId` prop so the roster grid can pre-select the staff member on new-shift creation
- `messages/en.json` — new keys under `Tenant.staff.roster.*` and `Tenant.settings.tabStaffRoster`
- `components/settings-dropdown.tsx` + `components/mobile-nav.tsx` + `components/command-palette.tsx` — roster link added, feature-flagged behind `staff_schedule`

## Test plan

- [ ] With `staff_schedule` flag **on**: visit `/schedule` → redirects to current ISO week; grid renders with staff rows and day columns
- [ ] Click an empty cell → `ShiftForm` opens with that staff member pre-selected
- [ ] Click an existing shift chip → `ShiftForm` opens in edit mode
- [ ] Prev / Next / Today buttons navigate to the correct week
- [ ] With `staff_schedule` flag **off**: `/schedule/[weekStart]` returns 404
- [ ] Staff (non-editor) role: grid renders read-only (no `+` add cells, no edit on shift chips)
- [ ] Settings gear dropdown and mobile nav settings drawer show "Staff Roster" link when flag is on

https://claude.ai/code/session_01UCdW77WsoT6AGcXs6iJSMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCdW77WsoT6AGcXs6iJSMY)_