### PR TITLE
feat: iCal feed of own shifts via signed token URL (#162)

### DIFF
--- a/app/[tenant]/my-schedule/page.tsx
+++ b/app/[tenant]/my-schedule/page.tsx
@@ -6,11 +6,19 @@ import { getTenantFromHeaders } from '@/lib/tenant'
 import { getFeatureFlags } from '@/app/actions/feature-flags'
 import { getMyShifts } from '@/app/actions/shifts'
 import { MyScheduleList } from '@/components/my-schedule-list'
+import { IcalFeedSection } from '@/components/ical-feed-section'
 import { getTenantToday } from '@/lib/day-utils'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { getUser } from '@/app/actions/auth'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+
+function buildFeedUrl(slug: string, token: string): string {
+  const domain = process.env.NEXT_PUBLIC_ROOT_DOMAIN ?? 'localhost:3000'
+  const protocol = domain.startsWith('localhost') ? 'http' : 'https'
+  return `${protocol}://${domain}/api/calendar/${token}/shifts.ics`
+}
 
 export default async function MySchedulePage() {
   const tenant = await getTenantFromHeaders()
@@ -18,18 +26,25 @@ export default async function MySchedulePage() {
   const flags = await getFeatureFlags(tenant.id)
   if (!flags.staff_schedule) notFound()
 
-  await requireTenantMember()
+  const { user } = await requireTenantMember()
 
   const supabase = await createSupabaseServerClient()
-  const { data: tenantRow } = await supabase
-    .from('tenants')
-    .select('timezone')
-    .eq('id', tenant.id)
-    .single()
+  const [tenantResult, membershipResult] = await Promise.all([
+    supabase.from('tenants').select('timezone').eq('id', tenant.id).single(),
+    supabase
+      .from('memberships')
+      .select('ical_token')
+      .eq('user_id', user.id)
+      .eq('tenant_id', tenant.id)
+      .maybeSingle(),
+  ])
 
-  const today = getTenantToday(tenantRow?.timezone ?? 'UTC')
+  const today = getTenantToday(tenantResult.data?.timezone ?? 'UTC')
   const from = today
   const to = format(addDays(new Date(today + 'T12:00:00'), 28), 'yyyy-MM-dd')
+
+  const existingToken = membershipResult.data?.ical_token ?? null
+  const initialUrl = existingToken ? buildFeedUrl(tenant.slug, existingToken) : null
 
   const [t, shifts] = await Promise.all([
     getTranslations('Tenant.staff.mySchedule'),
@@ -40,6 +55,7 @@ export default async function MySchedulePage() {
     <div className="mx-auto max-w-2xl px-4 py-6">
       <h1 className="mb-6 text-xl font-bold">{t('title')}</h1>
       <MyScheduleList initialShifts={shifts} today={today} />
+      <IcalFeedSection initialUrl={initialUrl} />
     </div>
   )
 }

--- a/app/actions/ical.ts
+++ b/app/actions/ical.ts
@@ -1,0 +1,77 @@
+'use server'
+
+import { createSupabaseServerClient, createSupabaseServiceClient } from '@/lib/supabase-server'
+import { getTenantFromHeaders } from '@/lib/tenant'
+import { getUser } from '@/app/actions/auth'
+import type { ActionResponse } from '@/types/actions'
+
+function buildFeedUrl(slug: string, token: string): string {
+  const domain = process.env.NEXT_PUBLIC_ROOT_DOMAIN ?? 'localhost:3000'
+  const protocol = domain.startsWith('localhost') ? 'http' : 'https'
+  return `${protocol}://${domain}/api/calendar/${token}/shifts.ics`
+}
+
+export async function getOrCreateIcalToken(): Promise<
+  ActionResponse<{ url: string; token: string }>
+> {
+  const user = await getUser()
+  if (!user) return { success: false, error: 'Not authenticated.' }
+
+  const tenant = await getTenantFromHeaders()
+  const supabase = await createSupabaseServerClient()
+
+  const { data: membership, error } = await supabase
+    .from('memberships')
+    .select('id, ical_token')
+    .eq('user_id', user.id)
+    .eq('tenant_id', tenant.id)
+    .maybeSingle()
+
+  if (error) return { success: false, error: error.message }
+  if (!membership) return { success: false, error: 'Not a member of this tenant.' }
+
+  if (membership.ical_token) {
+    return {
+      success: true,
+      data: { token: membership.ical_token, url: buildFeedUrl(tenant.slug, membership.ical_token) },
+    }
+  }
+
+  const token = crypto.randomUUID()
+  const { error: updateError } = await supabase
+    .from('memberships')
+    .update({ ical_token: token, ical_token_created_at: new Date().toISOString() })
+    .eq('id', membership.id)
+
+  if (updateError) return { success: false, error: updateError.message }
+
+  return { success: true, data: { token, url: buildFeedUrl(tenant.slug, token) } }
+}
+
+export async function rotateIcalToken(): Promise<ActionResponse<{ url: string; token: string }>> {
+  const user = await getUser()
+  if (!user) return { success: false, error: 'Not authenticated.' }
+
+  const tenant = await getTenantFromHeaders()
+  const supabase = await createSupabaseServerClient()
+
+  const { data: membership, error } = await supabase
+    .from('memberships')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('tenant_id', tenant.id)
+    .maybeSingle()
+
+  if (error) return { success: false, error: error.message }
+  if (!membership) return { success: false, error: 'Not a member of this tenant.' }
+
+  const token = crypto.randomUUID()
+  const { error: updateError } = await supabase
+    .from('memberships')
+    .update({ ical_token: token, ical_token_created_at: new Date().toISOString() })
+    .eq('id', membership.id)
+
+  if (updateError) return { success: false, error: updateError.message }
+
+  return { success: true, data: { token, url: buildFeedUrl(tenant.slug, token) } }
+}

--- a/app/api/calendar/[token]/shifts.ics/route.ts
+++ b/app/api/calendar/[token]/shifts.ics/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { buildIcal } from '@/lib/ical'
+import type { IcalShift } from '@/lib/ical'
+import { addDays, format } from 'date-fns'
+
+export const runtime = 'nodejs'
+
+export async function GET(_request: Request, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params
+  const serviceClient = createSupabaseServiceClient()
+
+  // Look up membership by token
+  const { data: membership, error } = await serviceClient
+    .from('memberships')
+    .select('id, user_id, tenant_id')
+    .eq('ical_token', token)
+    .maybeSingle()
+
+  if (error || !membership) {
+    return new NextResponse('Not Found', { status: 404 })
+  }
+
+  // Check staff_schedule feature flag for this tenant
+  const { data: flagRow } = await serviceClient
+    .from('feature_flags')
+    .select('enabled')
+    .eq('tenant_id', membership.tenant_id)
+    .eq('flag_key', 'staff_schedule')
+    .maybeSingle()
+
+  // Missing row = enabled by default
+  const flagEnabled = flagRow ? flagRow.enabled : true
+  if (!flagEnabled) {
+    return new NextResponse('Not Found', { status: 404 })
+  }
+
+  // Fetch shifts for next 90 days
+  const today = format(new Date(), 'yyyy-MM-dd')
+  const until = format(addDays(new Date(), 90), 'yyyy-MM-dd')
+
+  const { data: days } = await serviceClient
+    .from('day')
+    .select('id, date_iso')
+    .eq('tenant_id', membership.tenant_id)
+    .gte('date_iso', today)
+    .lte('date_iso', until)
+
+  const dayRows = days ?? []
+  const shifts: IcalShift[] = []
+
+  if (dayRows.length > 0) {
+    const dayMap = new Map<string, string>(dayRows.map((d) => [d.id, d.date_iso as string]))
+    const dayIds = dayRows.map((d) => d.id)
+
+    const { data: shiftRows } = await serviceClient
+      .from('shift')
+      .select('id, day_id, start_time, end_time, role, notes')
+      .eq('tenant_id', membership.tenant_id)
+      .eq('user_id', membership.user_id)
+      .in('day_id', dayIds)
+      .order('start_time', { nullsFirst: true })
+
+    for (const s of shiftRows ?? []) {
+      shifts.push({
+        id: s.id,
+        date_iso: dayMap.get(s.day_id) ?? '',
+        start_time: s.start_time ?? null,
+        end_time: s.end_time ?? null,
+        role_label: (s.role as string | null) ?? null,
+        notes: (s.notes as string | null) ?? null,
+      })
+    }
+  }
+
+  const ical = buildIcal(shifts, '-//Courseday//Shift Feed//EN')
+
+  return new NextResponse(ical, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/calendar; charset=utf-8',
+      'Cache-Control': 'private, max-age=300',
+    },
+  })
+}

--- a/components/ical-feed-section.tsx
+++ b/components/ical-feed-section.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { getOrCreateIcalToken, rotateIcalToken } from '@/app/actions/ical'
+import { toast } from 'sonner'
+
+interface Props {
+  initialUrl: string | null
+}
+
+export function IcalFeedSection({ initialUrl }: Props) {
+  const t = useTranslations('Tenant.staff.icalFeed')
+  const [url, setUrl] = useState<string | null>(initialUrl)
+  const [copied, setCopied] = useState(false)
+  const [rotateOpen, setRotateOpen] = useState(false)
+  const [isGenerating, startGenerating] = useTransition()
+  const [isRotating, startRotating] = useTransition()
+
+  function handleCopy() {
+    if (!url) return
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  function handleGenerate() {
+    startGenerating(async () => {
+      const result = await getOrCreateIcalToken()
+      if (result.success) {
+        setUrl(result.data.url)
+      } else {
+        toast.error(t('errorGenerate'))
+      }
+    })
+  }
+
+  function handleRotate() {
+    startRotating(async () => {
+      const result = await rotateIcalToken()
+      if (result.success) {
+        setUrl(result.data.url)
+        setRotateOpen(false)
+      } else {
+        toast.error(t('errorRotate'))
+      }
+    })
+  }
+
+  return (
+    <section className="mt-8 rounded-lg border p-4">
+      <h2 className="mb-1 text-base font-semibold">{t('title')}</h2>
+      <p className="text-muted-foreground mb-4 text-sm">{t('description')}</p>
+
+      {url ? (
+        <div className="space-y-3">
+          <div>
+            <label className="text-muted-foreground mb-1 block text-xs font-medium">
+              {t('urlLabel')}
+            </label>
+            <div className="flex gap-2">
+              <Input readOnly value={url} className="font-mono text-xs" />
+              <Button size="sm" variant="outline" onClick={handleCopy}>
+                {copied ? t('copied') : t('copy')}
+              </Button>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setRotateOpen(true)}
+            disabled={isRotating}
+          >
+            {isRotating ? t('rotating') : t('rotate')}
+          </Button>
+        </div>
+      ) : (
+        <Button size="sm" onClick={handleGenerate} disabled={isGenerating}>
+          {isGenerating ? t('generating') : t('generate')}
+        </Button>
+      )}
+
+      <AlertDialog open={rotateOpen} onOpenChange={setRotateOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('rotateConfirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('rotateConfirmDescription')}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRotating}>{t('rotateConfirmCancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRotate} disabled={isRotating}>
+              {isRotating ? t('rotating') : t('rotateConfirmAction')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  )
+}

--- a/lib/ical.ts
+++ b/lib/ical.ts
@@ -21,7 +21,7 @@ function foldLine(line: string): string {
     first = false
     // Back up until we're on a valid UTF-8 boundary
     let end = Math.min(offset + limit, bytes.length)
-    while (end > offset && (bytes[end] & 0xc0) === 0x80) end--
+    while (end > offset && end < bytes.length && (bytes[end]! & 0xc0) === 0x80) end--
     parts.push((parts.length > 0 ? ' ' : '') + bytes.slice(offset, end).toString('utf8') + '\r\n')
     offset = end
   }
@@ -33,10 +33,7 @@ function prop(name: string, value: string): string {
 }
 
 // Format Date to iCal DATE-TIME in UTC: 20230101T120000Z
-function toIcalDate(dateStr: string, timeStr: string, timezone: string): string {
-  // dateStr: "2024-01-15", timeStr: "09:00"
-  // We store times as plain HH:MM strings; treat as tenant-local but emit as-is
-  // For simplicity, emit as floating local time (no Z) since we don't have tz conversion here
+function toIcalDate(dateStr: string, timeStr: string): string {
   const [h, m] = timeStr.split(':')
   const d = dateStr.replace(/-/g, '')
   const hh = (h ?? '00').padStart(2, '0')
@@ -70,8 +67,8 @@ export function buildIcal(shifts: IcalShift[], prodId: string): string {
   for (const shift of shifts) {
     if (!shift.start_time || !shift.end_time) continue
 
-    const dtstart = toIcalDate(shift.date_iso, shift.start_time, 'UTC')
-    const dtend = toIcalDate(shift.date_iso, shift.end_time, 'UTC')
+    const dtstart = toIcalDate(shift.date_iso, shift.start_time)
+    const dtend = toIcalDate(shift.date_iso, shift.end_time)
     const summary = escapeIcal(shift.role_label ?? 'Shift')
     const uid = `${shift.id}@courseday`
 

--- a/lib/ical.ts
+++ b/lib/ical.ts
@@ -1,0 +1,90 @@
+// RFC 5545 minimal iCal generator — no external deps
+
+function escapeIcal(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\n/g, '\\n')
+}
+
+// Fold lines at 75 octets per RFC 5545 §3.1
+function foldLine(line: string): string {
+  const bytes = Buffer.from(line, 'utf8')
+  if (bytes.length <= 75) return line + '\r\n'
+
+  const parts: string[] = []
+  let offset = 0
+  let first = true
+  while (offset < bytes.length) {
+    const limit = first ? 75 : 74
+    first = false
+    // Back up until we're on a valid UTF-8 boundary
+    let end = Math.min(offset + limit, bytes.length)
+    while (end > offset && (bytes[end] & 0xc0) === 0x80) end--
+    parts.push((parts.length > 0 ? ' ' : '') + bytes.slice(offset, end).toString('utf8') + '\r\n')
+    offset = end
+  }
+  return parts.join('')
+}
+
+function prop(name: string, value: string): string {
+  return foldLine(`${name}:${value}`)
+}
+
+// Format Date to iCal DATE-TIME in UTC: 20230101T120000Z
+function toIcalDate(dateStr: string, timeStr: string, timezone: string): string {
+  // dateStr: "2024-01-15", timeStr: "09:00"
+  // We store times as plain HH:MM strings; treat as tenant-local but emit as-is
+  // For simplicity, emit as floating local time (no Z) since we don't have tz conversion here
+  const [h, m] = timeStr.split(':')
+  const d = dateStr.replace(/-/g, '')
+  const hh = (h ?? '00').padStart(2, '0')
+  const mm = (m ?? '00').padStart(2, '0')
+  return `${d}T${hh}${mm}00`
+}
+
+export interface IcalShift {
+  id: string
+  date_iso: string
+  start_time: string | null
+  end_time: string | null
+  role_label: string | null
+  notes: string | null
+}
+
+export function buildIcal(shifts: IcalShift[], prodId: string): string {
+  const now = new Date()
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}/, '')
+
+  const lines: string[] = [
+    'BEGIN:VCALENDAR\r\n',
+    prop('VERSION', '2.0'),
+    prop('PRODID', escapeIcal(prodId)),
+    prop('CALSCALE', 'GREGORIAN'),
+    prop('METHOD', 'PUBLISH'),
+  ]
+
+  for (const shift of shifts) {
+    if (!shift.start_time || !shift.end_time) continue
+
+    const dtstart = toIcalDate(shift.date_iso, shift.start_time, 'UTC')
+    const dtend = toIcalDate(shift.date_iso, shift.end_time, 'UTC')
+    const summary = escapeIcal(shift.role_label ?? 'Shift')
+    const uid = `${shift.id}@courseday`
+
+    lines.push('BEGIN:VEVENT\r\n')
+    lines.push(prop('UID', uid))
+    lines.push(prop('DTSTAMP', now + 'Z'))
+    lines.push(prop('DTSTART', dtstart))
+    lines.push(prop('DTEND', dtend))
+    lines.push(prop('SUMMARY', summary))
+    if (shift.notes) lines.push(prop('DESCRIPTION', escapeIcal(shift.notes)))
+    lines.push('END:VEVENT\r\n')
+  }
+
+  lines.push('END:VCALENDAR\r\n')
+  return lines.join('')
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -673,6 +673,23 @@
         "showPast": "Show past shifts",
         "hidePast": "Hide past shifts",
         "loadingPast": "Loading…"
+      },
+      "icalFeed": {
+        "title": "Calendar feed",
+        "description": "Subscribe to your shifts in Google Calendar, Apple Calendar, or any iCal client.",
+        "urlLabel": "Feed URL",
+        "copy": "Copy",
+        "copied": "Copied!",
+        "rotate": "Rotate URL",
+        "rotateConfirmTitle": "Rotate calendar URL?",
+        "rotateConfirmDescription": "This invalidates the current URL. You will need to re-subscribe in your calendar app.",
+        "rotateConfirmCancel": "Cancel",
+        "rotateConfirmAction": "Rotate",
+        "rotating": "Rotating…",
+        "generate": "Get feed URL",
+        "generating": "Generating…",
+        "errorGenerate": "Could not generate feed URL.",
+        "errorRotate": "Could not rotate feed URL."
       }
     },
     "venueType": {

--- a/supabase/migrations/00043_add_membership_ical_token.sql
+++ b/supabase/migrations/00043_add_membership_ical_token.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE memberships
+  ADD COLUMN ical_token             text,
+  ADD COLUMN ical_token_created_at  timestamptz;
+
+CREATE UNIQUE INDEX memberships_ical_token_unique
+  ON memberships (ical_token) WHERE ical_token IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **Migration 00043**: adds `ical_token` + `ical_token_created_at` to `memberships` with a partial unique index
- **`lib/ical.ts`**: RFC 5545 VCALENDAR/VEVENT builder — no external deps, line folding at 75 octets, CRLF line endings, proper iCal escaping
- **`app/actions/ical.ts`**: `getOrCreateIcalToken` + `rotateIcalToken` server actions gated to any tenant member
- **`app/api/calendar/[token]/shifts.ics/route.ts`**: public token-authed route — 90-day shift window, `staff_schedule` flag guard → 404, `Cache-Control: private, max-age=300`
- **`components/ical-feed-section.tsx`**: read-only URL input + Copy button + Rotate button with confirm dialog
- **`app/[tenant]/my-schedule/page.tsx`**: pre-loads existing token server-side, renders `IcalFeedSection` below shift list
- **`messages/en.json`**: `Tenant.staff.icalFeed.*` i18n keys

## Test plan

- [ ] Sign in as a tenant member, go to `/my-schedule` — "Calendar feed" section appears at bottom
- [ ] Click "Get feed URL" — URL appears in read-only input
- [ ] Click Copy — URL copied to clipboard
- [ ] Paste URL into browser — `.ics` file downloads with correct VCALENDAR structure and shifts for next 90 days
- [ ] Click Rotate → confirm — new URL generated, old URL returns 404
- [ ] Token URL for tenant with `staff_schedule` flag off → 404
- [ ] Invalid/unknown token → 404
- [ ] Shifts missing `start_time` or `end_time` are excluded from feed

https://claude.ai/code/session_013YVUnMeZ2VGfcriFV45H2k

---
_Generated by [Claude Code](https://claude.ai/code/session_013YVUnMeZ2VGfcriFV45H2k)_