### PR TITLE
fix: translations, member profiles & shift display names

### DIFF
--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -163,12 +163,19 @@ export async function getDailyBriefForDay(
 export const getTenantAssignees = cache(
   async (tenantId: string): Promise<Map<string, ShiftAssignee>> => {
     const supabase = await createSupabaseServerClient()
-    const { data: memberships } = await supabase
-      .from('memberships')
-      .select('user_id')
-      .eq('tenant_id', tenantId)
 
-    const userIds = (memberships ?? []).map((m) => m.user_id)
+    const { data: memberships } = await (supabase
+      .from('memberships')
+      .select('user_id, first_name, last_name, job_title')
+      .eq('tenant_id', tenantId) as any)
+
+    const rows = (memberships ?? []) as Array<{
+      user_id: string
+      first_name: string | null
+      last_name: string | null
+      job_title: string | null
+    }>
+    const userIds = rows.map((m) => m.user_id)
     if (userIds.length === 0) return new Map()
 
     const serviceClient = createSupabaseServiceClient()
@@ -177,14 +184,16 @@ export const getTenantAssignees = cache(
     )
 
     const map = new Map<string, ShiftAssignee>()
-    userIds.forEach((uid, i) => {
+    rows.forEach((m, i) => {
       const settled = lookups[i]
       const email =
         settled && settled.status === 'fulfilled' ? (settled.value.data.user?.email ?? '') : ''
-      map.set(uid, {
-        user_id: uid,
+      const fullName = [m.first_name, m.last_name].filter(Boolean).join(' ')
+      map.set(m.user_id, {
+        user_id: m.user_id,
         email,
-        display_name: email ? email.split('@')[0] : uid.slice(0, 8),
+        display_name: fullName || (email ? email.split('@')[0] : m.user_id.slice(0, 8)),
+        job_title: m.job_title ?? null,
       })
     })
     return map

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -192,7 +192,7 @@ export const getTenantAssignees = cache(
       map.set(m.user_id, {
         user_id: m.user_id,
         email,
-        display_name: fullName || (email ? email.split('@')[0] : m.user_id.slice(0, 8)),
+        display_name: fullName || (email ? (email.split('@')[0] ?? email) : m.user_id.slice(0, 8)),
         job_title: m.job_title ?? null,
       })
     })

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -164,10 +164,10 @@ export const getTenantAssignees = cache(
   async (tenantId: string): Promise<Map<string, ShiftAssignee>> => {
     const supabase = await createSupabaseServerClient()
 
-    const { data: memberships } = await (supabase
-      .from('memberships')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: memberships } = await (supabase.from('memberships') as any)
       .select('user_id, first_name, last_name, job_title')
-      .eq('tenant_id', tenantId) as any)
+      .eq('tenant_id', tenantId)
 
     const rows = (memberships ?? []) as Array<{
       user_id: string

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -149,6 +149,17 @@ export default async function TenantLayout({ children }: { children: React.React
                         </Link>
                       </span>
                     )}
+                    {/* Profile link — all signed-in members, desktop */}
+                    {user && (
+                      <span className="hidden sm:inline-flex">
+                        <Link
+                          href="/profile"
+                          className="text-muted-foreground hover:text-foreground px-2 text-sm font-medium transition-colors"
+                        >
+                          {t('profile')}
+                        </Link>
+                      </span>
+                    )}
                     <NotificationBell initialCount={unreadCount} />
                     {user && (
                       <span className={editor ? undefined : 'hidden sm:inline-flex'}>

--- a/app/[tenant]/profile/page.tsx
+++ b/app/[tenant]/profile/page.tsx
@@ -1,0 +1,25 @@
+import { getTranslations } from 'next-intl/server'
+import { requireTenantMember } from '@/lib/guards'
+import { getMemberProfile } from '@/app/actions/memberships'
+import { ProfileForm } from './profile-form'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export default async function ProfilePage() {
+  await requireTenantMember()
+  const t = await getTranslations('Tenant.profile')
+  const result = await getMemberProfile()
+  const profile = result.success ? result.data : null
+
+  return (
+    <div className="mx-auto max-w-lg px-6 py-8">
+      <h1 className="mb-6 text-2xl font-semibold">{t('title')}</h1>
+      <ProfileForm
+        initialFirstName={profile?.first_name ?? ''}
+        initialLastName={profile?.last_name ?? ''}
+        initialJobTitle={profile?.job_title ?? ''}
+      />
+    </div>
+  )
+}

--- a/app/[tenant]/profile/profile-form.tsx
+++ b/app/[tenant]/profile/profile-form.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { useTranslations } from 'next-intl'
+import { updateMemberProfile } from '@/app/actions/memberships'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent } from '@/components/ui/card'
+
+interface ProfileFormProps {
+  initialFirstName: string
+  initialLastName: string
+  initialJobTitle: string
+}
+
+export function ProfileForm({
+  initialFirstName,
+  initialLastName,
+  initialJobTitle,
+}: ProfileFormProps) {
+  const t = useTranslations('Tenant.profile')
+  const [firstName, setFirstName] = useState(initialFirstName)
+  const [lastName, setLastName] = useState(initialLastName)
+  const [jobTitle, setJobTitle] = useState(initialJobTitle)
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      const result = await updateMemberProfile({
+        first_name: firstName,
+        last_name: lastName,
+        job_title: jobTitle,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(t('saved'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 pt-6">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="first-name">{t('firstNameLabel')}</Label>
+            <Input
+              id="first-name"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="last-name">{t('lastNameLabel')}</Label>
+            <Input id="last-name" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="job-title">{t('jobTitleLabel')}</Label>
+          <Input
+            id="job-title"
+            value={jobTitle}
+            onChange={(e) => setJobTitle(e.target.value)}
+            placeholder={t('jobTitlePlaceholder')}
+          />
+        </div>
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? t('saving') : t('save')}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/actions/memberships.ts
+++ b/app/actions/memberships.ts
@@ -29,44 +29,51 @@ export interface TenantMemberAssignee {
   email: string
   display_name: string
   role: MemberRole
+  job_title?: string | null
 }
 
-/**
- * Returns all tenant members (editors + staff) for use in shift assignee
- * pickers and shift card display. Available to any tenant member, not just
- * editors. Names default to the email local-part until full names are added.
- */
 export async function getTenantMemberAssignees(): Promise<ActionResponse<TenantMemberAssignee[]>> {
   const tenantId = await getTenantId()
   const role = await getUserRole(tenantId)
   if (!role) return { success: false, error: 'Not authorized.' }
 
   const { supabase } = await createTenantClient()
-  const { data: memberships, error } = await supabase
+
+  const { data: memberships, error } = await (supabase
     .from('memberships')
-    .select('user_id, role')
+    .select('user_id, role, first_name, last_name, job_title')
     .eq('tenant_id', tenantId)
-    .order('created_at')
+    .order('created_at') as any)
 
   if (error) return { success: false, error: error.message }
   if (!memberships?.length) return { success: true, data: [] }
 
+  const rows = memberships as Array<{
+    user_id: string
+    role: string
+    first_name: string | null
+    last_name: string | null
+    job_title: string | null
+  }>
+
   const serviceClient = createSupabaseServiceClient()
   const emailResults = await Promise.allSettled(
-    memberships.map((m) => serviceClient.auth.admin.getUserById(m.user_id))
+    rows.map((m) => serviceClient.auth.admin.getUserById(m.user_id))
   )
 
   return {
     success: true,
-    data: memberships.map((m, i) => {
+    data: rows.map((m, i) => {
       const settled = emailResults[i]
       const email =
         settled && settled.status === 'fulfilled' ? (settled.value.data.user?.email ?? '') : ''
+      const fullName = [m.first_name, m.last_name].filter(Boolean).join(' ')
       return {
         user_id: m.user_id,
         email,
-        display_name: email ? email.split('@')[0] : m.user_id.slice(0, 8),
+        display_name: fullName || (email ? email.split('@')[0] : m.user_id.slice(0, 8)),
         role: m.role as MemberRole,
+        job_title: m.job_title ?? null,
       }
     }),
   }
@@ -336,6 +343,68 @@ export async function removeMember(membershipId: string): Promise<ActionResponse
     .delete()
     .eq('id', membershipId)
     .eq('tenant_id', tenantId)
+
+  if (error) return { success: false, error: error.message }
+  return { success: true, data: undefined }
+}
+
+export async function getMemberProfile(): Promise<
+  ActionResponse<{ first_name: string | null; last_name: string | null; job_title: string | null }>
+> {
+  const tenantId = await getTenantId()
+  const user = await getUser()
+  if (!user) return { success: false, error: 'Not authorized.' }
+  const role = await getUserRole(tenantId)
+  if (!role) return { success: false, error: 'Not authorized.' }
+
+  const { supabase } = await createTenantClient()
+
+  const { data, error } = await (supabase
+    .from('memberships')
+    .select('first_name, last_name, job_title')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', user.id)
+    .single() as any)
+
+  if (error) return { success: false, error: error.message }
+  const row = data as {
+    first_name: string | null
+    last_name: string | null
+    job_title: string | null
+  } | null
+  return {
+    success: true,
+    data: {
+      first_name: row?.first_name ?? null,
+      last_name: row?.last_name ?? null,
+      job_title: row?.job_title ?? null,
+    },
+  }
+}
+
+export async function updateMemberProfile(data: {
+  first_name: string
+  last_name: string
+  job_title: string
+}): Promise<ActionResponse> {
+  const tenantId = await getTenantId()
+  const user = await getUser()
+  if (!user) return { success: false, error: 'Not authorized.' }
+  const role = await getUserRole(tenantId)
+  if (!role) return { success: false, error: 'Not authorized.' }
+
+  const { supabase } = await createTenantClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updatePayload: any = {
+    first_name: data.first_name.trim() || null,
+    last_name: data.last_name.trim() || null,
+    job_title: data.job_title.trim() || null,
+  }
+  const { error } = await supabase
+    .from('memberships')
+    .update(updatePayload)
+    .eq('tenant_id', tenantId)
+    .eq('user_id', user.id)
 
   if (error) return { success: false, error: error.message }
   return { success: true, data: undefined }

--- a/app/actions/memberships.ts
+++ b/app/actions/memberships.ts
@@ -39,11 +39,11 @@ export async function getTenantMemberAssignees(): Promise<ActionResponse<TenantM
 
   const { supabase } = await createTenantClient()
 
-  const { data: memberships, error } = await (supabase
-    .from('memberships')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: memberships, error } = await (supabase.from('memberships') as any)
     .select('user_id, role, first_name, last_name, job_title')
     .eq('tenant_id', tenantId)
-    .order('created_at') as any)
+    .order('created_at')
 
   if (error) return { success: false, error: error.message }
   if (!memberships?.length) return { success: true, data: [] }
@@ -359,12 +359,12 @@ export async function getMemberProfile(): Promise<
 
   const { supabase } = await createTenantClient()
 
-  const { data, error } = await (supabase
-    .from('memberships')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase.from('memberships') as any)
     .select('first_name, last_name, job_title')
     .eq('tenant_id', tenantId)
     .eq('user_id', user.id)
-    .single() as any)
+    .single()
 
   if (error) return { success: false, error: error.message }
   const row = data as {
@@ -395,14 +395,12 @@ export async function updateMemberProfile(data: {
 
   const { supabase } = await createTenantClient()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const updatePayload: any = {
-    first_name: data.first_name.trim() || null,
-    last_name: data.last_name.trim() || null,
-    job_title: data.job_title.trim() || null,
-  }
-  const { error } = await supabase
-    .from('memberships')
-    .update(updatePayload)
+  const { error } = await (supabase.from('memberships') as any)
+    .update({
+      first_name: data.first_name.trim() || null,
+      last_name: data.last_name.trim() || null,
+      job_title: data.job_title.trim() || null,
+    })
     .eq('tenant_id', tenantId)
     .eq('user_id', user.id)
 

--- a/app/actions/memberships.ts
+++ b/app/actions/memberships.ts
@@ -71,7 +71,7 @@ export async function getTenantMemberAssignees(): Promise<ActionResponse<TenantM
       return {
         user_id: m.user_id,
         email,
-        display_name: fullName || (email ? email.split('@')[0] : m.user_id.slice(0, 8)),
+        display_name: fullName || (email ? (email.split('@')[0] ?? email) : m.user_id.slice(0, 8)),
         role: m.role as MemberRole,
         job_title: m.job_title ?? null,
       }

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Home, CalendarDays, Settings, Sparkles, CalendarCheck } from 'lucide-react'
+import { Home, CalendarDays, Settings, Sparkles, CalendarCheck, UserCircle } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import {
@@ -50,6 +50,16 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
             label: navT('mySchedule'),
             icon: CalendarCheck,
             active: pathname.startsWith('/my-schedule'),
+          },
+        ]
+      : []),
+    ...(!isEditor
+      ? [
+          {
+            href: '/profile',
+            label: navT('profile'),
+            icon: UserCircle,
+            active: pathname.startsWith('/profile'),
           },
         ]
       : []),
@@ -116,6 +126,14 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
                 <DrawerTitle>{settingsT('title')}</DrawerTitle>
               </DrawerHeader>
               <div className="flex flex-col gap-1 px-4 pb-8">
+                <DrawerClose asChild>
+                  <Link
+                    href="/profile"
+                    className="hover:bg-accent flex items-center rounded-md px-3 py-3 text-sm transition-colors"
+                  >
+                    {navT('profile')}
+                  </Link>
+                </DrawerClose>
                 {settingsRoutes.map(({ href, labelKey }) => (
                   <DrawerClose key={href} asChild>
                     <Link

--- a/components/settings-dropdown.tsx
+++ b/components/settings-dropdown.tsx
@@ -63,6 +63,9 @@ export function SettingsDropdown() {
         </Button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-52 p-1">
+        <MenuItem asChild>
+          <Link href="/profile">{navT('profile')}</Link>
+        </MenuItem>
         {routes.map(({ href, labelKey }) => (
           <MenuItem key={href} asChild>
             <Link href={href}>{t(labelKey as LabelKey)}</Link>

--- a/components/shift-form.tsx
+++ b/components/shift-form.tsx
@@ -62,6 +62,8 @@ export function ShiftForm({
     handleSubmit,
     reset,
     control,
+    setValue,
+    getValues,
     formState: { errors },
   } = useForm<ShiftFormData>({
     resolver: standardSchemaResolver(shiftSchema),
@@ -103,7 +105,16 @@ export function ShiftForm({
               name="user_id"
               control={control}
               render={({ field }) => (
-                <Select value={field.value || ''} onValueChange={field.onChange}>
+                <Select
+                  value={field.value || ''}
+                  onValueChange={(uid) => {
+                    field.onChange(uid)
+                    const assignee = assignees.find((a) => a.user_id === uid)
+                    if (assignee?.job_title && !getValues('role')) {
+                      setValue('role', assignee.job_title)
+                    }
+                  }}
+                >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={t('staffPlaceholder')} />
                   </SelectTrigger>
@@ -111,7 +122,9 @@ export function ShiftForm({
                     {assignees.map((a) => (
                       <SelectItem key={a.user_id} value={a.user_id}>
                         {a.display_name}
-                        {a.email && a.email !== a.display_name ? (
+                        {a.job_title ? (
+                          <span className="text-muted-foreground ml-1 text-xs">{a.job_title}</span>
+                        ) : a.email && a.email !== a.display_name ? (
                           <span className="text-muted-foreground ml-1 text-xs">{a.email}</span>
                         ) : null}
                       </SelectItem>

--- a/messages/de.json
+++ b/messages/de.json
@@ -77,7 +77,9 @@
     "nav": {
       "signOut": "Abmelden",
       "skipToContent": "Zum Hauptinhalt springen",
-      "today": "Heute"
+      "today": "Heute",
+      "mySchedule": "Mein Dienstplan",
+      "profile": "Mein Profil"
     },
     "join": {
       "homeAria": "Startseite",
@@ -374,7 +376,9 @@
       "cityUnexpectedResponse": "Unerwartete Antwort vom Geocoding-Dienst.",
       "clearLocationAria": "Standort löschen",
       "locationCoordsHint": "Löschen Sie die Koordinaten oben, um nach einer Stadt zu suchen.",
-      "staffScheduleDisabled": "Die Personalplanung ist für diesen Betrieb von einem Plattform-Administrator deaktiviert."
+      "staffScheduleDisabled": "Die Personalplanung ist für diesen Betrieb von einem Plattform-Administrator deaktiviert.",
+      "tabStaffRoster": "Dienstplan",
+      "tabMySchedule": "Mein Dienstplan"
     },
     "checklists": {
       "title": "Checklisten",
@@ -525,6 +529,56 @@
         "delete": "Löschen",
         "deleting": "Wird gelöscht…",
         "deleted": "Schicht entfernt."
+      },
+      "actuals": {
+        "clockIn": "Einchecken",
+        "clockOut": "Auschecken",
+        "clockedIn": "Eingecheckt.",
+        "clockedOut": "Ausgecheckt.",
+        "scheduled": "Geplant",
+        "actual": "Tatsächlich",
+        "editActualsAria": "Ist-Zeiten bearbeiten",
+        "title": "Ist-Zeiten bearbeiten",
+        "actualStart": "Ist-Beginn",
+        "actualEnd": "Ist-Ende",
+        "cancel": "Abbrechen",
+        "save": "Speichern",
+        "saving": "Speichern…",
+        "saved": "Zeiten aktualisiert."
+      },
+      "roster": {
+        "title": "Dienstplan",
+        "prevWeek": "Vorherige Woche",
+        "nextWeek": "Nächste Woche",
+        "today": "Heute",
+        "staffColumn": "Teammitglied",
+        "noStaff": "Noch keine Teammitglieder.",
+        "addShiftAria": "Schicht für {name} am {date} hinzufügen"
+      },
+      "mySchedule": {
+        "title": "Mein Dienstplan",
+        "empty": "Keine bevorstehenden Schichten.",
+        "emptyPast": "Keine vergangenen Schichten.",
+        "showPast": "Vergangene Schichten anzeigen",
+        "hidePast": "Vergangene Schichten ausblenden",
+        "loadingPast": "Laden…"
+      },
+      "icalFeed": {
+        "title": "Kalender-Feed",
+        "description": "Abonnieren Sie Ihre Schichten in Google Kalender, Apple Kalender oder einem anderen iCal-Client.",
+        "urlLabel": "Feed-URL",
+        "copy": "Kopieren",
+        "copied": "Kopiert!",
+        "rotate": "URL erneuern",
+        "rotateConfirmTitle": "Kalender-URL erneuern?",
+        "rotateConfirmDescription": "Dadurch wird die aktuelle URL ungültig. Sie müssen sich in Ihrer Kalender-App neu anmelden.",
+        "rotateConfirmCancel": "Abbrechen",
+        "rotateConfirmAction": "Erneuern",
+        "rotating": "Erneuern…",
+        "generate": "Feed-URL abrufen",
+        "generating": "Generieren…",
+        "errorGenerate": "Feed-URL konnte nicht generiert werden.",
+        "errorRotate": "URL konnte nicht erneuert werden."
       }
     },
     "venueType": {
@@ -542,6 +596,16 @@
       "delete": "Löschen",
       "deleted": "Raumart gelöscht.",
       "saved": "Raumart gespeichert."
+    },
+    "profile": {
+      "title": "Mein Profil",
+      "firstNameLabel": "Vorname",
+      "lastNameLabel": "Nachname",
+      "jobTitleLabel": "Berufsbezeichnung",
+      "jobTitlePlaceholder": "z.B. Chefkoch, Barkeeper, Manager",
+      "save": "Speichern",
+      "saving": "Speichern…",
+      "saved": "Profil aktualisiert."
     }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -182,7 +182,8 @@
       "themeSystem": "System",
       "themeLight": "Light",
       "themeDark": "Dark",
-      "mySchedule": "My schedule"
+      "mySchedule": "My schedule",
+      "profile": "My Profile"
     },
     "join": {
       "homeAria": "Home",
@@ -709,6 +710,16 @@
         "errorGenerate": "Could not generate feed URL.",
         "errorRotate": "Could not rotate feed URL."
       }
+    },
+    "profile": {
+      "title": "My Profile",
+      "firstNameLabel": "First name",
+      "lastNameLabel": "Last name",
+      "jobTitleLabel": "Job title",
+      "jobTitlePlaceholder": "e.g. Head chef, Barman, Manager",
+      "save": "Save",
+      "saving": "Saving…",
+      "saved": "Profile updated."
     },
     "venueType": {
       "title": "Venue Types",

--- a/messages/es.json
+++ b/messages/es.json
@@ -77,7 +77,9 @@
     "nav": {
       "signOut": "Cerrar sesión",
       "skipToContent": "Saltar al contenido principal",
-      "today": "Hoy"
+      "today": "Hoy",
+      "mySchedule": "Mi horario",
+      "profile": "Mi perfil"
     },
     "join": {
       "homeAria": "Inicio",
@@ -374,7 +376,9 @@
       "cityUnexpectedResponse": "Respuesta inesperada del servicio de geocodificación.",
       "clearLocationAria": "Borrar ubicación",
       "locationCoordsHint": "Borra las coordenadas de arriba para buscar una ciudad por nombre.",
-      "staffScheduleDisabled": "La planificación de personal está desactivada para este establecimiento por un administrador de la plataforma."
+      "staffScheduleDisabled": "La planificación de personal está desactivada para este establecimiento por un administrador de la plataforma.",
+      "tabStaffRoster": "Cuadrante",
+      "tabMySchedule": "Mi horario"
     },
     "checklists": {
       "title": "Listas de verificación",
@@ -525,6 +529,56 @@
         "delete": "Eliminar",
         "deleting": "Eliminando…",
         "deleted": "Turno eliminado."
+      },
+      "actuals": {
+        "clockIn": "Fichar entrada",
+        "clockOut": "Fichar salida",
+        "clockedIn": "Entrada fichada.",
+        "clockedOut": "Salida fichada.",
+        "scheduled": "Previsto",
+        "actual": "Real",
+        "editActualsAria": "Editar horas reales",
+        "title": "Editar horas reales",
+        "actualStart": "Inicio real",
+        "actualEnd": "Fin real",
+        "cancel": "Cancelar",
+        "save": "Guardar",
+        "saving": "Guardando…",
+        "saved": "Horas actualizadas."
+      },
+      "roster": {
+        "title": "Cuadrante",
+        "prevWeek": "Semana anterior",
+        "nextWeek": "Semana siguiente",
+        "today": "Hoy",
+        "staffColumn": "Miembro del equipo",
+        "noStaff": "Aún no hay miembros.",
+        "addShiftAria": "Añadir turno para {name} el {date}"
+      },
+      "mySchedule": {
+        "title": "Mi horario",
+        "empty": "No hay turnos próximos.",
+        "emptyPast": "No hay turnos pasados.",
+        "showPast": "Mostrar turnos pasados",
+        "hidePast": "Ocultar turnos pasados",
+        "loadingPast": "Cargando…"
+      },
+      "icalFeed": {
+        "title": "Feed de calendario",
+        "description": "Suscríbase a sus turnos en Google Calendar, Apple Calendar o cualquier cliente iCal.",
+        "urlLabel": "URL del feed",
+        "copy": "Copiar",
+        "copied": "¡Copiado!",
+        "rotate": "Renovar URL",
+        "rotateConfirmTitle": "¿Renovar URL del calendario?",
+        "rotateConfirmDescription": "Esto invalida la URL actual. Tendrá que volver a suscribirse en su aplicación de calendario.",
+        "rotateConfirmCancel": "Cancelar",
+        "rotateConfirmAction": "Renovar",
+        "rotating": "Renovando…",
+        "generate": "Obtener URL del feed",
+        "generating": "Generando…",
+        "errorGenerate": "No se pudo generar la URL del feed.",
+        "errorRotate": "No se pudo renovar la URL."
       }
     },
     "venueType": {
@@ -542,6 +596,16 @@
       "delete": "Eliminar",
       "deleted": "Tipo de espacio eliminado.",
       "saved": "Tipo de espacio guardado."
+    },
+    "profile": {
+      "title": "Mi perfil",
+      "firstNameLabel": "Nombre",
+      "lastNameLabel": "Apellido",
+      "jobTitleLabel": "Cargo",
+      "jobTitlePlaceholder": "p.ej. Jefe de cocina, Camarero, Gerente",
+      "save": "Guardar",
+      "saving": "Guardando…",
+      "saved": "Perfil actualizado."
     }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -181,7 +181,9 @@
       "settings": "Paramètres",
       "themeSystem": "Système",
       "themeLight": "Clair",
-      "themeDark": "Sombre"
+      "themeDark": "Sombre",
+      "mySchedule": "Mon planning",
+      "profile": "Mon profil"
     },
     "join": {
       "homeAria": "Accueil",
@@ -502,7 +504,9 @@
       "cityUnexpectedResponse": "Réponse inattendue du service de géocodage.",
       "clearLocationAria": "Effacer le lieu",
       "locationCoordsHint": "Effacez les coordonnées ci-dessus pour rechercher une ville par son nom.",
-      "staffScheduleDisabled": "La planification du personnel est désactivée pour cet établissement par un administrateur."
+      "staffScheduleDisabled": "La planification du personnel est désactivée pour cet établissement par un administrateur.",
+      "tabStaffRoster": "Tableau de service",
+      "tabMySchedule": "Mon planning"
     },
     "checklists": {
       "title": "Checklists",
@@ -653,6 +657,56 @@
         "delete": "Supprimer",
         "deleting": "Suppression…",
         "deleted": "Shift supprimé."
+      },
+      "actuals": {
+        "clockIn": "Pointer à l'arrivée",
+        "clockOut": "Pointer au départ",
+        "clockedIn": "Arrivée pointée.",
+        "clockedOut": "Départ pointé.",
+        "scheduled": "Prévu",
+        "actual": "Réel",
+        "editActualsAria": "Modifier les heures réelles",
+        "title": "Modifier les heures réelles",
+        "actualStart": "Début réel",
+        "actualEnd": "Fin réelle",
+        "cancel": "Annuler",
+        "save": "Enregistrer",
+        "saving": "Enregistrement…",
+        "saved": "Heures mises à jour."
+      },
+      "roster": {
+        "title": "Tableau de service",
+        "prevWeek": "Semaine précédente",
+        "nextWeek": "Semaine suivante",
+        "today": "Aujourd'hui",
+        "staffColumn": "Membre d'équipe",
+        "noStaff": "Aucun membre pour l'instant.",
+        "addShiftAria": "Ajouter un quart pour {name} le {date}"
+      },
+      "mySchedule": {
+        "title": "Mon planning",
+        "empty": "Aucun quart à venir.",
+        "emptyPast": "Aucun quart passé.",
+        "showPast": "Afficher les quarts passés",
+        "hidePast": "Masquer les quarts passés",
+        "loadingPast": "Chargement…"
+      },
+      "icalFeed": {
+        "title": "Calendrier",
+        "description": "Abonnez-vous à vos quarts dans Google Agenda, Apple Calendrier ou tout client iCal.",
+        "urlLabel": "URL du flux",
+        "copy": "Copier",
+        "copied": "Copié !",
+        "rotate": "Renouveler l'URL",
+        "rotateConfirmTitle": "Renouveler l'URL du calendrier ?",
+        "rotateConfirmDescription": "Cela invalide l'URL actuelle. Vous devrez vous réabonner dans votre application de calendrier.",
+        "rotateConfirmCancel": "Annuler",
+        "rotateConfirmAction": "Renouveler",
+        "rotating": "Renouvellement…",
+        "generate": "Obtenir l'URL du flux",
+        "generating": "Génération…",
+        "errorGenerate": "Impossible de générer l'URL du flux.",
+        "errorRotate": "Impossible de renouveler l'URL."
       }
     },
     "venueType": {
@@ -670,6 +724,16 @@
       "delete": "Supprimer",
       "deleted": "Type de lieu supprimé.",
       "saved": "Type de lieu enregistré."
+    },
+    "profile": {
+      "title": "Mon profil",
+      "firstNameLabel": "Prénom",
+      "lastNameLabel": "Nom",
+      "jobTitleLabel": "Intitulé de poste",
+      "jobTitlePlaceholder": "ex. Chef de rang, Barman, Directeur",
+      "save": "Enregistrer",
+      "saving": "Enregistrement…",
+      "saved": "Profil mis à jour."
     }
   }
 }

--- a/supabase/migrations/00045_add_membership_profile_fields.sql
+++ b/supabase/migrations/00045_add_membership_profile_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE memberships
+  ADD COLUMN first_name TEXT,
+  ADD COLUMN last_name  TEXT,
+  ADD COLUMN job_title  TEXT;

--- a/types/index.ts
+++ b/types/index.ts
@@ -68,6 +68,7 @@ export type ShiftAssignee = {
   user_id: string
   email: string
   display_name: string
+  job_title?: string | null
 }
 
 // ── Venue type ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Missing translations (fr/de/es):** Staff schedule keys were present in `en.json` but missing from all other locales — causing raw key IDs to display for French/German/Spanish venues. Added `staff.actuals`, `staff.roster`, `staff.mySchedule`, `staff.icalFeed`, `settings.tabStaffRoster`, `settings.tabMySchedule`, and `nav.mySchedule` to all three files.
- **Member profiles:** Migration 00045 adds `first_name`, `last_name`, `job_title` to the `memberships` table. Shift pickers and shift cards now display full name (falls back to email local-part). All three columns are nullable — no data migration needed.
- **Shift role auto-fill:** When selecting a team member in the shift form, the `role` field is auto-populated from their `job_title` if the field is currently empty.
- **Profile page `/profile`:** Any tenant member (editor or staff) can set their first/last name and job title. Linked from the desktop header, settings dropdown, settings mobile drawer, and the staff mobile nav.

## Test plan

- [ ] Set tenant language to French/German/Spanish — verify staff schedule shows translated text, not raw keys
- [ ] Add `first_name`/`last_name` via `/profile` — verify name appears in shift picker dropdown and shift cards instead of email local-part
- [ ] Add `job_title` via `/profile` — verify selecting that member in the shift form auto-fills the Role field
- [ ] Verify profile page is accessible to both editors and staff members
- [ ] Verify profile link appears in desktop header, settings dropdown (editors), and mobile nav (staff)

https://claude.ai/code/session_01Bykz1pKk3SYe9vJjC3MQ2Y
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bykz1pKk3SYe9vJjC3MQ2Y)_