### PR TITLE
feat(staff): pay rates per member and weekly labor cost rollup

### DIFF
--- a/app/[tenant]/admin/settings/labor-cost/page.tsx
+++ b/app/[tenant]/admin/settings/labor-cost/page.tsx
@@ -1,0 +1,54 @@
+import { notFound } from 'next/navigation'
+import { format, startOfISOWeek, parseISO, isValid } from 'date-fns'
+import { getTranslations } from 'next-intl/server'
+import { requireTenantEditor } from '@/lib/guards'
+import { getTenantFromHeaders } from '@/lib/tenant'
+import { getFeatureFlags } from '@/app/actions/feature-flags'
+import { getWeeklyLaborCost } from '@/lib/labor-cost'
+import { LaborCostWeek } from '@/components/labor-cost-week'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+const YMD_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+function resolveWeekStart(raw: string | undefined): string {
+  if (raw && YMD_REGEX.test(raw)) {
+    const parsed = parseISO(raw)
+    if (isValid(parsed)) {
+      return format(startOfISOWeek(parsed), 'yyyy-MM-dd')
+    }
+  }
+  return format(startOfISOWeek(new Date()), 'yyyy-MM-dd')
+}
+
+export default async function LaborCostPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ week?: string }>
+}) {
+  const [tenant, { user }] = await Promise.all([
+    getTenantFromHeaders(),
+    requireTenantEditor(),
+  ] as const)
+
+  const flags = await getFeatureFlags(tenant.id)
+  if (!flags.staff_schedule) notFound()
+
+  const { week } = await searchParams
+  const weekStart = resolveWeekStart(week)
+
+  const [data, t] = await Promise.all([
+    getWeeklyLaborCost(tenant.id, weekStart),
+    getTranslations('Tenant.staff.laborCost'),
+  ])
+
+  void user
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-8">
+      <h1 className="mb-6 text-2xl font-semibold">{t('title')}</h1>
+      <LaborCostWeek weekStart={weekStart} data={data} basePath={`/admin/settings/labor-cost`} />
+    </div>
+  )
+}

--- a/app/[tenant]/schedule/[weekStart]/page.tsx
+++ b/app/[tenant]/schedule/[weekStart]/page.tsx
@@ -7,6 +7,8 @@ import { ensureDaysRange } from '@/app/actions/days'
 import { getWeekShifts } from '@/app/actions/shifts'
 import { getTenantAssigneesList } from '@/app/[tenant]/day/[date]/queries'
 import { RosterGrid } from '@/components/roster-grid'
+import { getWeeklyLaborCost } from '@/lib/labor-cost'
+import { LaborCostSummaryCard } from '@/components/labor-cost-week'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -35,23 +37,27 @@ export default async function ScheduleWeekPage({
 
   const weekEnd = format(addDays(parseISO(weekStart), 6), 'yyyy-MM-dd')
 
-  const [daysResult, shifts, assignees] = await Promise.all([
+  const [daysResult, shifts, assignees, laborCost] = await Promise.all([
     ensureDaysRange(weekStart, weekEnd),
     getWeekShifts(weekStart),
     getTenantAssigneesList(tenant.id),
+    getWeeklyLaborCost(tenant.id, weekStart).catch(() => null),
   ])
 
   const days = daysResult.success ? daysResult.data : []
   const isEditor = role === 'editor'
 
   return (
-    <RosterGrid
-      weekStart={weekStart}
-      weekEnd={weekEnd}
-      days={days}
-      shifts={shifts}
-      assignees={assignees}
-      isEditor={isEditor}
-    />
+    <div className="space-y-4">
+      {isEditor && laborCost && <LaborCostSummaryCard data={laborCost} />}
+      <RosterGrid
+        weekStart={weekStart}
+        weekEnd={weekEnd}
+        days={days}
+        shifts={shifts}
+        assignees={assignees}
+        isEditor={isEditor}
+      />
+    </div>
   )
 }

--- a/app/actions/memberships.ts
+++ b/app/actions/memberships.ts
@@ -15,6 +15,8 @@ export interface Member {
   email: string
   role: MemberRole
   created_at: string
+  hourly_rate: number | null
+  currency: string | null
 }
 
 export interface PendingInvitation {
@@ -85,24 +87,33 @@ export async function getMembers(): Promise<ActionResponse<Member[]>> {
   if (role !== 'editor') return { success: false, error: 'Not authorized.' }
 
   const { supabase } = await createTenantClient()
-  const { data: memberships, error } = await supabase
-    .from('memberships')
-    .select('id, user_id, role, created_at')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: memberships, error } = await (supabase.from('memberships') as any)
+    .select('id, user_id, role, created_at, hourly_rate, currency')
     .eq('tenant_id', tenantId)
     .order('created_at')
 
   if (error) return { success: false, error: error.message }
   if (!memberships?.length) return { success: true, data: [] }
 
+  const rows = memberships as Array<{
+    id: string
+    user_id: string
+    role: string
+    created_at: string
+    hourly_rate: number | null
+    currency: string | null
+  }>
+
   const serviceClient = createSupabaseServiceClient()
   // Use allSettled so one failed lookup doesn't crash the whole list.
   const emailResults = await Promise.allSettled(
-    memberships.map((m) => serviceClient.auth.admin.getUserById(m.user_id))
+    rows.map((m) => serviceClient.auth.admin.getUserById(m.user_id))
   )
 
   return {
     success: true,
-    data: memberships.map((m, i) => {
+    data: rows.map((m, i) => {
       const settled = emailResults[i]
       const email =
         settled && settled.status === 'fulfilled' ? (settled.value.data.user?.email ?? '') : ''
@@ -112,6 +123,8 @@ export async function getMembers(): Promise<ActionResponse<Member[]>> {
         email,
         role: m.role as MemberRole,
         created_at: m.created_at,
+        hourly_rate: m.hourly_rate,
+        currency: m.currency,
       }
     }),
   }

--- a/app/actions/pay-rates.ts
+++ b/app/actions/pay-rates.ts
@@ -1,0 +1,41 @@
+'use server'
+
+import { createTenantClient } from '@/lib/supabase-server'
+import { getTenantId } from '@/lib/tenant'
+import { requireEditor } from '@/lib/membership'
+import { isFeatureEnabled } from '@/app/actions/feature-flags'
+import type { ActionResponse } from '@/types/actions'
+
+export interface PayRateData {
+  hourly_rate: number | null
+  currency: string | null
+}
+
+export async function updateMemberPayRate(
+  membershipId: string,
+  data: PayRateData
+): Promise<ActionResponse> {
+  const tenantId = await getTenantId()
+  await requireEditor(tenantId)
+
+  if (!(await isFeatureEnabled(tenantId, 'staff_schedule'))) {
+    return { success: false, error: 'Staff scheduling is disabled.' }
+  }
+
+  if (data.currency !== null && !/^[A-Z]{3}$/.test(data.currency)) {
+    return { success: false, error: 'Currency must be a 3-letter ISO code (e.g. EUR).' }
+  }
+
+  const { supabase } = await createTenantClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from('memberships') as any)
+    .update({
+      hourly_rate: data.hourly_rate,
+      currency: data.currency,
+    })
+    .eq('id', membershipId)
+    .eq('tenant_id', tenantId)
+
+  if (error) return { success: false, error: error.message }
+  return { success: true, data: undefined }
+}

--- a/components/labor-cost-week.tsx
+++ b/components/labor-cost-week.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { addDays, format, parseISO, subDays } from 'date-fns'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import type { WeeklyLaborCost } from '@/lib/labor-cost'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+function formatMoney(amount: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount)
+}
+
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
+}
+
+interface Props {
+  weekStart: string
+  data: WeeklyLaborCost
+  basePath: string
+}
+
+export function LaborCostWeek({ weekStart, data, basePath }: Props) {
+  const t = useTranslations('Tenant.staff.laborCost')
+  const router = useRouter()
+  const weekEnd = format(addDays(parseISO(weekStart), 6), 'yyyy-MM-dd')
+  const prevWeek = format(subDays(parseISO(weekStart), 7), 'yyyy-MM-dd')
+  const nextWeek = format(addDays(parseISO(weekStart), 7), 'yyyy-MM-dd')
+  const todayWeek = format(
+    parseISO(
+      format(
+        (() => {
+          const d = new Date()
+          const day = d.getDay()
+          const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+          d.setDate(diff)
+          return d
+        })(),
+        'yyyy-MM-dd'
+      )
+    ),
+    'yyyy-MM-dd'
+  )
+
+  const hasActuals = data.totalActualCost !== undefined
+
+  return (
+    <div className="space-y-6">
+      {/* Week navigation */}
+      <div className="flex items-center gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push(`${basePath}?week=${prevWeek}`)}
+        >
+          <ChevronLeft className="size-4" />
+          {t('prevWeek')}
+        </Button>
+        <span className="text-sm font-medium tabular-nums">
+          {weekStart} – {weekEnd}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push(`${basePath}?week=${nextWeek}`)}
+        >
+          {t('nextWeek')}
+          <ChevronRight className="size-4" />
+        </Button>
+        {weekStart !== todayWeek && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => router.push(`${basePath}?week=${todayWeek}`)}
+          >
+            {t('thisWeek')}
+          </Button>
+        )}
+      </div>
+
+      {/* Summary cards */}
+      <div className="flex flex-wrap gap-4">
+        <Card className="min-w-[12rem] flex-1 shadow-sm">
+          <CardContent className="pt-6">
+            <p className="text-muted-foreground text-xs tracking-wide uppercase">
+              {t('totalScheduled')}
+            </p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums">
+              {formatMoney(data.totalScheduledCost, data.currency)}
+            </p>
+            <p className="text-muted-foreground mt-0.5 text-sm">
+              {formatMinutes(data.totalScheduledMinutes)}
+            </p>
+          </CardContent>
+        </Card>
+        {hasActuals && (
+          <Card className="min-w-[12rem] flex-1 shadow-sm">
+            <CardContent className="pt-6">
+              <p className="text-muted-foreground text-xs tracking-wide uppercase">
+                {t('totalActual')}
+              </p>
+              <p className="mt-1 text-2xl font-semibold tabular-nums">
+                {formatMoney(data.totalActualCost!, data.currency)}
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      {/* Per-member table */}
+      <Card className="gap-0 overflow-hidden py-0 shadow-sm">
+        <CardHeader className="bg-muted/40 border-b px-5 py-4 sm:px-6">
+          <CardTitle className="text-base">{t('breakdown')}</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {data.perMember.length === 0 ? (
+            <p className="text-muted-foreground px-6 py-10 text-center text-sm">{t('noMembers')}</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead className="h-11 min-w-[10rem] pl-6 font-medium">
+                      {t('member')}
+                    </TableHead>
+                    <TableHead className="h-11 w-32 font-medium">{t('scheduledHours')}</TableHead>
+                    <TableHead className="h-11 w-36 font-medium">{t('scheduledCost')}</TableHead>
+                    {hasActuals && (
+                      <>
+                        <TableHead className="h-11 w-32 font-medium">{t('actualHours')}</TableHead>
+                        <TableHead className="h-11 w-36 pr-6 font-medium">
+                          {t('actualCost')}
+                        </TableHead>
+                      </>
+                    )}
+                    {!hasActuals && <TableHead className="h-11 pr-6" aria-hidden />}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.perMember.map((m) => (
+                    <TableRow key={m.user_id} className="hover:bg-muted/40">
+                      <TableCell className="py-3 pl-6 font-medium">{m.name}</TableCell>
+                      <TableCell className="text-muted-foreground py-3 text-sm tabular-nums">
+                        {formatMinutes(m.scheduledMinutes)}
+                      </TableCell>
+                      <TableCell className="py-3 text-sm tabular-nums">
+                        {m.hasRate ? (
+                          formatMoney(m.cost, data.currency)
+                        ) : (
+                          <span className="text-muted-foreground">{t('noRate')}</span>
+                        )}
+                      </TableCell>
+                      {hasActuals && (
+                        <>
+                          <TableCell className="text-muted-foreground py-3 text-sm tabular-nums">
+                            {formatMinutes(m.actualMinutes)}
+                          </TableCell>
+                          <TableCell className="py-3 pr-6 text-sm tabular-nums">
+                            {m.hasRate ? (
+                              formatMoney(m.actualCost, data.currency)
+                            ) : (
+                              <span className="text-muted-foreground">{t('noRate')}</span>
+                            )}
+                          </TableCell>
+                        </>
+                      )}
+                      {!hasActuals && <TableCell className="pr-6" />}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Compact summary card for the roster page
+// ---------------------------------------------------------------------------
+
+interface SummaryCardProps {
+  data: WeeklyLaborCost
+}
+
+export function LaborCostSummaryCard({ data }: SummaryCardProps) {
+  const t = useTranslations('Tenant.staff.laborCost')
+
+  if (data.totalScheduledMinutes === 0 && data.totalScheduledCost === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      <div className="bg-muted/50 rounded-md px-4 py-2.5">
+        <p className="text-muted-foreground text-xs">{t('totalScheduled')}</p>
+        <p className="text-sm font-semibold tabular-nums">
+          {formatMoney(data.totalScheduledCost, data.currency)}{' '}
+          <span className="text-muted-foreground font-normal">
+            ({formatMinutes(data.totalScheduledMinutes)})
+          </span>
+        </p>
+      </div>
+      {data.totalActualCost !== undefined && (
+        <div className="bg-muted/50 rounded-md px-4 py-2.5">
+          <p className="text-muted-foreground text-xs">{t('totalActual')}</p>
+          <p className="text-sm font-semibold tabular-nums">
+            {formatMoney(data.totalActualCost, data.currency)}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/member-management.tsx
+++ b/components/member-management.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react'
 import { toast } from 'sonner'
-import { Trash2, UserPlus } from 'lucide-react'
+import { Check, Pencil, Trash2, UserPlus, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import {
   getMembers,
@@ -13,6 +13,7 @@ import {
   cancelInvitation,
 } from '@/app/actions/memberships'
 import type { Member, PendingInvitation, MemberRole } from '@/app/actions/memberships'
+import { updateMemberPayRate } from '@/app/actions/pay-rates'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -48,6 +49,120 @@ function RoleBadge({ role, label }: { role: MemberRole; label: string }) {
     <Badge variant={role === 'editor' ? 'default' : 'secondary'} className="font-normal">
       {label}
     </Badge>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Pay rate inline editor
+// ---------------------------------------------------------------------------
+
+function PayRateEditor({
+  member,
+  onSaved,
+}: {
+  member: Member
+  onSaved: (id: string, rate: number | null, currency: string | null) => void
+}) {
+  const t = useTranslations('Tenant.members')
+  const [editing, setEditing] = useState(false)
+  const [rateStr, setRateStr] = useState(member.hourly_rate?.toString() ?? '')
+  const [currency, setCurrency] = useState(member.currency ?? 'EUR')
+  const [isPending, startTransition] = useTransition()
+
+  function handleEdit() {
+    setRateStr(member.hourly_rate?.toString() ?? '')
+    setCurrency(member.currency ?? 'EUR')
+    setEditing(true)
+  }
+
+  function handleCancel() {
+    setEditing(false)
+  }
+
+  function handleSave() {
+    const parsed = rateStr.trim() === '' ? null : parseFloat(rateStr)
+    if (parsed !== null && (isNaN(parsed) || parsed < 0)) {
+      toast.error(t('payRate.invalidRate'))
+      return
+    }
+    const cur = currency.trim().toUpperCase()
+    if (cur && !/^[A-Z]{3}$/.test(cur)) {
+      toast.error(t('payRate.invalidCurrency'))
+      return
+    }
+    startTransition(async () => {
+      const result = await updateMemberPayRate(member.id, {
+        hourly_rate: parsed,
+        currency: cur || null,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(t('payRate.saved'))
+      onSaved(member.id, parsed, cur || null)
+      setEditing(false)
+    })
+  }
+
+  if (!editing) {
+    const display =
+      member.hourly_rate !== null
+        ? `${member.hourly_rate} ${member.currency ?? ''}`
+        : t('payRate.notSet')
+    return (
+      <div className="flex items-center gap-1.5">
+        <span className="text-muted-foreground text-sm tabular-nums">{display}</span>
+        <Button
+          variant="ghost"
+          size="iconXs"
+          onClick={handleEdit}
+          aria-label={t('payRate.editAria')}
+        >
+          <Pencil className="size-3.5" />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Input
+        type="number"
+        min={0}
+        step="0.01"
+        value={rateStr}
+        onChange={(e) => setRateStr(e.target.value)}
+        placeholder="0.00"
+        className="h-8 w-20 text-sm"
+        aria-label={t('payRate.rateLabel')}
+      />
+      <Input
+        value={currency}
+        onChange={(e) => setCurrency(e.target.value.toUpperCase().slice(0, 3))}
+        placeholder="EUR"
+        className="h-8 w-16 text-sm uppercase"
+        aria-label={t('payRate.currencyLabel')}
+        maxLength={3}
+      />
+      <Button
+        variant="ghost"
+        size="iconXs"
+        disabled={isPending}
+        onClick={handleSave}
+        aria-label={t('payRate.saveAria')}
+      >
+        <Check className="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="iconXs"
+        onClick={handleCancel}
+        aria-label={t('payRate.cancelAria')}
+      >
+        <X className="size-3.5" />
+      </Button>
+    </div>
   )
 }
 
@@ -165,6 +280,10 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
     refresh().finally(() => setLoading(false))
   }, [])
 
+  function handlePayRateSaved(id: string, rate: number | null, currency: string | null) {
+    setMembers((prev) => prev.map((m) => (m.id === id ? { ...m, hourly_rate: rate, currency } : m)))
+  }
+
   function handleRoleChange(member: Member, newRole: MemberRole) {
     startRemoveTransition(async () => {
       const result = await updateMemberRole(member.id, newRole)
@@ -231,6 +350,7 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
                       {t('role')}
                     </TableHead>
                     <TableHead className="h-11 w-36 font-medium">{t('joined')}</TableHead>
+                    <TableHead className="h-11 w-40 font-medium">{t('payRate.header')}</TableHead>
                     <TableHead className="h-11 w-14 pr-6" aria-hidden />
                   </TableRow>
                 </TableHeader>
@@ -266,6 +386,9 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
                         </TableCell>
                         <TableCell className="text-muted-foreground py-3 text-sm tabular-nums">
                           {new Date(member.created_at).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell className="py-3">
+                          <PayRateEditor member={member} onSaved={handlePayRateSaved} />
                         </TableCell>
                         <TableCell className="py-3 pr-6 text-right">
                           {!isSelf && (

--- a/lib/labor-cost.test.ts
+++ b/lib/labor-cost.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { scheduledMinutesFromTimes, actualMinutesFromTimestamps } from './labor-cost'
+
+describe('scheduledMinutesFromTimes', () => {
+  it('computes normal shift duration', () => {
+    expect(scheduledMinutesFromTimes('08:00', '16:00')).toBe(480)
+  })
+
+  it('computes partial hour shift', () => {
+    expect(scheduledMinutesFromTimes('09:30', '11:45')).toBe(135)
+  })
+
+  it('handles overnight shift (end < start)', () => {
+    expect(scheduledMinutesFromTimes('22:00', '06:00')).toBe(480)
+  })
+
+  it('handles zero-length shift', () => {
+    expect(scheduledMinutesFromTimes('10:00', '10:00')).toBe(0)
+  })
+
+  it('returns 0 when start is null', () => {
+    expect(scheduledMinutesFromTimes(null, '16:00')).toBe(0)
+  })
+
+  it('returns 0 when end is null', () => {
+    expect(scheduledMinutesFromTimes('08:00', null)).toBe(0)
+  })
+
+  it('returns 0 when both null', () => {
+    expect(scheduledMinutesFromTimes(null, null)).toBe(0)
+  })
+})
+
+describe('actualMinutesFromTimestamps', () => {
+  it('computes duration from ISO timestamps', () => {
+    expect(actualMinutesFromTimestamps('2026-05-05T08:00:00Z', '2026-05-05T16:00:00Z')).toBe(480)
+  })
+
+  it('handles sub-minute rounding', () => {
+    expect(actualMinutesFromTimestamps('2026-05-05T08:00:00Z', '2026-05-05T08:01:30Z')).toBe(2)
+  })
+
+  it('returns 0 when start is null', () => {
+    expect(actualMinutesFromTimestamps(null, '2026-05-05T16:00:00Z')).toBe(0)
+  })
+
+  it('returns 0 when end is null', () => {
+    expect(actualMinutesFromTimestamps('2026-05-05T08:00:00Z', null)).toBe(0)
+  })
+
+  it('returns 0 for negative duration', () => {
+    expect(actualMinutesFromTimestamps('2026-05-05T16:00:00Z', '2026-05-05T08:00:00Z')).toBe(0)
+  })
+})
+
+describe('cost math', () => {
+  it('computes hourly cost from scheduled minutes', () => {
+    const minutes = scheduledMinutesFromTimes('08:00', '16:00') // 480
+    const cost = (minutes / 60) * 15 // 8h * €15 = €120
+    expect(cost).toBeCloseTo(120)
+  })
+
+  it('computes zero cost when rate is null (treat as 0)', () => {
+    const minutes = scheduledMinutesFromTimes('08:00', '16:00') // 480
+    const rate = null
+    const cost = (minutes / 60) * (rate ?? 0)
+    expect(cost).toBe(0)
+  })
+})

--- a/lib/labor-cost.ts
+++ b/lib/labor-cost.ts
@@ -1,0 +1,171 @@
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { addDays, format, parseISO } from 'date-fns'
+
+export interface LaborCostMember {
+  user_id: string
+  name: string
+  scheduledMinutes: number
+  cost: number
+  hasRate: boolean
+  actualMinutes: number
+  actualCost: number
+}
+
+export interface WeeklyLaborCost {
+  totalScheduledMinutes: number
+  totalScheduledCost: number
+  perMember: LaborCostMember[]
+  currency: string
+  totalActualCost?: number
+}
+
+function parseHHMM(t: string): number {
+  const parts = t.split(':')
+  const h = parseInt(parts[0] ?? '0', 10)
+  const m = parseInt(parts[1] ?? '0', 10)
+  return h * 60 + m
+}
+
+export function scheduledMinutesFromTimes(
+  startTime: string | null,
+  endTime: string | null
+): number {
+  if (!startTime || !endTime) return 0
+  const start = parseHHMM(startTime)
+  let end = parseHHMM(endTime)
+  if (end < start) end += 24 * 60
+  return Math.max(0, end - start)
+}
+
+export function actualMinutesFromTimestamps(
+  actualStart: string | null,
+  actualEnd: string | null
+): number {
+  if (!actualStart || !actualEnd) return 0
+  const diff = new Date(actualEnd).getTime() - new Date(actualStart).getTime()
+  return Math.max(0, Math.round(diff / 60000))
+}
+
+type MemberRow = {
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+  hourly_rate: number | null
+  currency: string | null
+}
+
+type ShiftRow = {
+  user_id: string
+  start_time: string | null
+  end_time: string | null
+  actual_start?: string | null
+  actual_end?: string | null
+}
+
+export async function getWeeklyLaborCost(
+  tenantId: string,
+  weekStartISO: string
+): Promise<WeeklyLaborCost> {
+  const weekEnd = format(addDays(parseISO(weekStartISO), 6), 'yyyy-MM-dd')
+  const supabase = await createSupabaseServerClient()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: memberships } = await (supabase.from('memberships') as any)
+    .select('user_id, first_name, last_name, hourly_rate, currency')
+    .eq('tenant_id', tenantId)
+
+  const memberRows: MemberRow[] = (memberships ?? []) as MemberRow[]
+
+  const currency = memberRows.find((m) => m.currency)?.currency ?? 'EUR'
+
+  const { data: days } = await supabase
+    .from('day')
+    .select('id')
+    .eq('tenant_id', tenantId)
+    .gte('date_iso', weekStartISO)
+    .lte('date_iso', weekEnd)
+
+  const dayIds = (days ?? []).map((d) => d.id)
+
+  const emptyResult = (rows: MemberRow[]): WeeklyLaborCost => ({
+    totalScheduledMinutes: 0,
+    totalScheduledCost: 0,
+    perMember: rows.map((m) => ({
+      user_id: m.user_id,
+      name: memberName(m),
+      scheduledMinutes: 0,
+      cost: 0,
+      hasRate: m.hourly_rate !== null,
+      actualMinutes: 0,
+      actualCost: 0,
+    })),
+    currency,
+  })
+
+  if (dayIds.length === 0) return emptyResult(memberRows)
+
+  const { data: shifts } = await supabase
+    .from('shift')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .in('day_id', dayIds)
+
+  const shiftRows: ShiftRow[] = (shifts ?? []) as unknown as ShiftRow[]
+
+  const acc = new Map<string, { scheduled: number; actual: number }>()
+  for (const m of memberRows) {
+    acc.set(m.user_id, { scheduled: 0, actual: 0 })
+  }
+  for (const s of shiftRows) {
+    const entry = acc.get(s.user_id) ?? { scheduled: 0, actual: 0 }
+    entry.scheduled += scheduledMinutesFromTimes(s.start_time, s.end_time)
+    entry.actual += actualMinutesFromTimestamps(s.actual_start ?? null, s.actual_end ?? null)
+    acc.set(s.user_id, entry)
+  }
+
+  let totalScheduledMinutes = 0
+  let totalScheduledCost = 0
+  let totalActualCost = 0
+  let hasAnyActuals = false
+
+  const perMember: LaborCostMember[] = memberRows.map((m) => {
+    const entry = acc.get(m.user_id) ?? { scheduled: 0, actual: 0 }
+    const hasRate = m.hourly_rate !== null
+    const rate = m.hourly_rate ?? 0
+    const cost = (entry.scheduled / 60) * rate
+    const actualCost = (entry.actual / 60) * rate
+
+    totalScheduledMinutes += entry.scheduled
+    totalScheduledCost += cost
+    if (entry.actual > 0) hasAnyActuals = true
+    totalActualCost += actualCost
+
+    return {
+      user_id: m.user_id,
+      name: memberName(m),
+      scheduledMinutes: entry.scheduled,
+      cost,
+      hasRate,
+      actualMinutes: entry.actual,
+      actualCost,
+    }
+  })
+
+  const result: WeeklyLaborCost = {
+    totalScheduledMinutes,
+    totalScheduledCost,
+    perMember,
+    currency,
+  }
+
+  if (hasAnyActuals) {
+    result.totalActualCost = totalActualCost
+  }
+
+  return result
+}
+
+function memberName(m: MemberRow): string {
+  const full = [m.first_name, m.last_name].filter(Boolean).join(' ')
+  return full || m.user_id.slice(0, 8)
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -587,7 +587,19 @@
       "removing": "Removing…",
       "removed": "Member removed.",
       "roleUpdated": "Role updated.",
-      "loading": "Loading…"
+      "loading": "Loading…",
+      "payRate": {
+        "header": "Pay rate",
+        "notSet": "—",
+        "editAria": "Edit pay rate",
+        "saveAria": "Save pay rate",
+        "cancelAria": "Cancel",
+        "rateLabel": "Hourly rate",
+        "currencyLabel": "Currency",
+        "saved": "Pay rate saved.",
+        "invalidRate": "Rate must be a positive number.",
+        "invalidCurrency": "Currency must be a 3-letter ISO code (e.g. EUR)."
+      }
     },
     "featureRequests": {
       "title": "Your requests",
@@ -709,6 +721,22 @@
         "generating": "Generating…",
         "errorGenerate": "Could not generate feed URL.",
         "errorRotate": "Could not rotate feed URL."
+      },
+      "laborCost": {
+        "title": "Labor cost",
+        "prevWeek": "Previous week",
+        "nextWeek": "Next week",
+        "thisWeek": "This week",
+        "totalScheduled": "Scheduled cost",
+        "totalActual": "Actual cost",
+        "breakdown": "Per-member breakdown",
+        "member": "Team member",
+        "scheduledHours": "Scheduled",
+        "scheduledCost": "Scheduled cost",
+        "actualHours": "Actual",
+        "actualCost": "Actual cost",
+        "noRate": "No rate set",
+        "noMembers": "No team members yet."
       }
     },
     "profile": {

--- a/supabase/migrations/00048_add_membership_pay_rate.sql
+++ b/supabase/migrations/00048_add_membership_pay_rate.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE memberships
+  ADD COLUMN hourly_rate numeric(10,2),
+  ADD COLUMN currency    text;
+
+ALTER TABLE memberships
+  ADD CONSTRAINT memberships_currency_format_check
+  CHECK (currency IS NULL OR currency ~ '^[A-Z]{3}$');
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Adds `hourly_rate numeric(10,2)` and `currency text` columns to `memberships` (migration `00048`)
- New `app/actions/pay-rates.ts` with `updateMemberPayRate` — editor-only, gated on `staff_schedule` flag, validates ISO-3 currency
- New `lib/labor-cost.ts` exporting `getWeeklyLaborCost` — sums scheduled and actual shift durations, computes cost per member, includes `totalActualCost` when actuals exist
- `lib/labor-cost.test.ts` — unit tests for duration math and cost calculations
- `components/member-management.tsx` gains inline pay rate + currency editor per row (editor-only)
- New `components/labor-cost-week.tsx` — week navigation + per-member breakdown table + compact `LaborCostSummaryCard`
- New `app/[tenant]/admin/settings/labor-cost/page.tsx` — editor-only, `notFound()` when `staff_schedule` off, week controlled via `?week=` search param
- Compact labor cost summary card added to roster page (`app/[tenant]/schedule/[weekStart]/page.tsx`)
- `messages/en.json` — `Tenant.staff.laborCost.*` and `Tenant.members.payRate.*` keys added

## Test plan

- [ ] Visit Settings → Team: pay rate column appears, inline editor opens, saves and reflects updated value
- [ ] Visit Settings → Labor cost: shows current week, prev/next navigation works, per-member breakdown renders
- [ ] Visit Schedule (roster) as editor: compact cost summary card appears at top
- [ ] Disable `staff_schedule` flag for a tenant: labor cost settings page returns 404
- [ ] Member with no rate: shows "No rate set" in breakdown, contributes 0 to totals but still listed
- [ ] CI: typecheck, lint, unit tests, build pass

Closes #167

https://claude.ai/code/session_01UWmoambjHCPUuCANStE53Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWmoambjHCPUuCANStE53Q)_