### PR TITLE
feat: migrate Quick Add LLM to anthropic/claude-haiku-4-5

### DIFF
--- a/lib/quick-add-generate.ts
+++ b/lib/quick-add-generate.ts
@@ -9,7 +9,7 @@ import { type AllergenCode, filterAllergenCodes, isAllergenCode } from '@/lib/al
 import { PROMPT_VERSION, QUICK_ADD_SYSTEM, buildUserPrompt } from './quick-add-prompt'
 import type { QuickAddParseData, QuickAddGapId } from '@/lib/quick-add-types'
 
-export const QUICK_ADD_MODEL_ID = 'openai/gpt-5.4' as const
+export const QUICK_ADD_MODEL_ID = 'anthropic/claude-haiku-4-5' as const
 
 function hasGatewayAuth(): boolean {
   return Boolean(process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces `openai/gpt-5.4` with `anthropic/claude-haiku-4-5` in `QUICK_ADD_MODEL_ID` (`lib/quick-add-generate.ts:12`)
- No prompt changes, no schema changes, no rate-limit logic touched
- Model is passed through the existing AI Gateway client unchanged

Closes #165

## Test plan

- [ ] CI unit tests pass (`pnpm test:run`)
- [ ] Manual smoke: paste an activity, a reservation, and a breakfast description — all classify correctly

https://claude.ai/code/session_01HUuy5MjkobMAsoxKX73azd
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUuy5MjkobMAsoxKX73azd)_