### PR TITLE
feat(staff): staffing forecast badge + shifts in daily brief (issue #173)

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -141,6 +141,8 @@ function DayViewEditor({
   venueTypes,
   authState,
   shiftAssignees,
+  staffRecommended,
+  staffForecastBreakdown,
   live,
   showStaffSchedule,
 }: DayViewProps & {
@@ -473,6 +475,8 @@ function DayViewEditor({
           assignees={shiftAssignees}
           isEditor={authState.isEditor}
           onShiftsChange={setShifts}
+          recommendedCount={staffRecommended}
+          forecastBreakdown={staffForecastBreakdown}
         />
       )}
 

--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -38,6 +38,7 @@ import { getWeatherForDay } from '@/app/actions/weather'
 import type { WeatherData } from '@/app/actions/weather'
 import { getFeatureFlags } from '@/app/actions/feature-flags'
 import { dayHasPlannedContent } from '@/lib/daily-brief-generate'
+import { recommendStaffCount } from '@/lib/staffing-forecast'
 
 // Inline stale check to avoid pulling the LLM-generation server action onto
 // the request critical path. Mirrors the helper in app/actions/daily-brief.ts.
@@ -84,6 +85,8 @@ export type DayViewProps = {
   authState: AuthState
   shifts: ShiftWithAssignee[]
   shiftAssignees: ShiftAssignee[]
+  staffRecommended: number
+  staffForecastBreakdown: { source: string; count: number }[]
 }
 
 const YMD_REGEX = /^\d{4}-\d{2}-\d{2}$/
@@ -170,6 +173,16 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
     flags.reservations ? reservations : [],
     flags.breakfast_config ? breakfastConfigs : []
   )
+
+  const { recommended: staffRecommended, breakdown: staffForecastBreakdown } = recommendStaffCount({
+    activitiesCovers: activities.reduce((s, a) => s + (a.expected_covers ?? 0), 0),
+    reservationsCovers: flags.reservations
+      ? reservations.reduce((s, r) => s + (r.guest_count ?? 0), 0)
+      : 0,
+    breakfastCovers: flags.breakfast_config
+      ? breakfastConfigs.reduce((s, b) => s + (b.total_guests ?? 0), 0)
+      : 0,
+  })
   const dailyBrief = dailyBriefOn ? existingBrief : null
   const briefStale =
     dailyBriefOn && dailyBrief
@@ -205,6 +218,8 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
         authState={authState}
         shifts={shifts}
         shiftAssignees={shiftAssignees}
+        staffRecommended={staffRecommended}
+        staffForecastBreakdown={staffForecastBreakdown}
       />
     </Suspense>
   )

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -230,3 +230,53 @@ export async function getTenantAssigneesList(tenantId: string): Promise<ShiftAss
   const map = await getTenantAssignees(tenantId)
   return [...map.values()].sort((a, b) => a.display_name.localeCompare(b.display_name))
 }
+
+export async function getShiftsForDayWithClient(
+  supabase: AppSupabaseClient,
+  tenantId: string,
+  dayId: string
+): Promise<ShiftWithAssignee[]> {
+  const { data } = await supabase
+    .from('shift')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .order('start_time', { nullsFirst: true })
+
+  const rows = (data ?? []) as unknown as Array<Omit<ShiftWithAssignee, 'assignee'>>
+  if (rows.length === 0) return []
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: memberships } = await (supabase.from('memberships') as any)
+    .select('user_id, first_name, last_name, job_title')
+    .eq('tenant_id', tenantId)
+
+  const memberRows = (memberships ?? []) as Array<{
+    user_id: string
+    first_name: string | null
+    last_name: string | null
+    job_title: string | null
+  }>
+
+  const memberMap = new Map<string, { display_name: string; job_title: string | null }>()
+  for (const m of memberRows) {
+    const fullName = [m.first_name, m.last_name].filter(Boolean).join(' ')
+    memberMap.set(m.user_id, {
+      display_name: fullName || m.user_id.slice(0, 8),
+      job_title: m.job_title ?? null,
+    })
+  }
+
+  return rows.map((s) => {
+    const member = memberMap.get(s.user_id)
+    return {
+      ...s,
+      assignee: {
+        user_id: s.user_id,
+        email: '',
+        display_name: member?.display_name ?? '—',
+        job_title: member?.job_title ?? null,
+      },
+    }
+  })
+}

--- a/app/actions/daily-brief.ts
+++ b/app/actions/daily-brief.ts
@@ -10,9 +10,11 @@
  * - Breakfast group_name, total_guests, times, allergens, truncated notes.
  * - Day note text only (author omitted); may still hold PII if editors typed names.
  *
+ * Included (when staff_schedule flag is on):
+ * - Staff display names, shift role, start/end times.
+ *
  * Excluded:
  * - Reservation guest_name, table_breakdown (may identify guests).
- * - Staff/shifts (names).
  * - Raw POC / internal IDs.
  *
  * Instruct model: do not invent counts; do not repeat personal names from notes;
@@ -31,6 +33,7 @@ import {
   getBreakfastConfigsForDay,
   getDayNotesForDay,
   getDailyBriefForDayWithClient,
+  getShiftsForDay,
 } from '@/app/[tenant]/day/[date]/queries'
 import { getWeatherForDay } from '@/app/actions/weather'
 import {
@@ -41,7 +44,12 @@ import {
 import { redis } from '@/lib/redis'
 import type { ActionResponse } from '@/types/actions'
 import type { DailyBriefRecord } from '@/types/daily-brief'
-import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
+import type {
+  Activity,
+  Reservation,
+  BreakfastConfiguration,
+  ShiftWithAssignee,
+} from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
 import type { WeatherData } from '@/app/actions/weather'
 
@@ -89,8 +97,19 @@ export async function ensureDailyBrief(args: {
   breakfasts: BreakfastConfiguration[]
   dayNotes: DayNote[]
   weather: WeatherData | null
+  shifts?: ShiftWithAssignee[]
 }): Promise<EnsureDailyBriefResult> {
-  const { tenantId, dayId, dateIso, activities, reservations, breakfasts, dayNotes, weather } = args
+  const {
+    tenantId,
+    dayId,
+    dateIso,
+    activities,
+    reservations,
+    breakfasts,
+    dayNotes,
+    weather,
+    shifts,
+  } = args
 
   if (!(await isFeatureEnabled(tenantId, 'daily_brief'))) return { status: 'empty' }
 
@@ -141,6 +160,7 @@ export async function ensureDailyBrief(args: {
       breakfasts,
       dayNotes,
       weather,
+      shifts,
     })
     if (!result.success) return { status: 'error', error: result.error }
     return { status: 'ok', brief: result.data, stale: false }
@@ -214,12 +234,15 @@ export async function generateDailyBrief(
   if (!dayResult.success) return { success: false, error: dayResult.error }
   const dayId = dayResult.data.id
 
-  const [activities, reservations, breakfasts, dayNotes, weather] = await Promise.all([
+  const staffScheduleOn = await isFeatureEnabled(tenantId, 'staff_schedule')
+
+  const [activities, reservations, breakfasts, dayNotes, weather, shifts] = await Promise.all([
     getProgramItemsForDay(tenantId, dayId),
     getReservationsForDay(tenantId, dayId),
     getBreakfastConfigsForDay(tenantId, dayId),
     getDayNotesForDay(tenantId, dayId),
     getWeatherForDay(dateIso),
+    staffScheduleOn ? getShiftsForDay(tenantId, dayId) : Promise.resolve([]),
   ])
 
   const { supabase } = await createTenantClient()
@@ -233,5 +256,6 @@ export async function generateDailyBrief(
     breakfasts,
     dayNotes,
     weather,
+    shifts: staffScheduleOn ? shifts : undefined,
   })
 }

--- a/components/staff-schedule-section.tsx
+++ b/components/staff-schedule-section.tsx
@@ -6,6 +6,7 @@ import { Plus } from 'lucide-react'
 import { ShiftCard } from '@/components/shift-card'
 import { ShiftForm } from '@/components/shift-form'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ShiftAssignee, ShiftWithAssignee } from '@/types/index'
 
 type Props = {
@@ -14,6 +15,8 @@ type Props = {
   assignees: ShiftAssignee[]
   isEditor: boolean
   onShiftsChange: React.Dispatch<React.SetStateAction<ShiftWithAssignee[]>>
+  recommendedCount: number
+  forecastBreakdown: { source: string; count: number }[]
 }
 
 function parseMinutes(time: string): number {
@@ -47,8 +50,11 @@ export function StaffScheduleSection({
   assignees,
   isEditor,
   onShiftsChange,
+  recommendedCount,
+  forecastBreakdown,
 }: Props) {
   const t = useTranslations('Tenant.staff.section')
+  const tForecast = useTranslations('Tenant.staff.forecast')
   const [formOpen, setFormOpen] = useState(false)
   const [editShift, setEditShift] = useState<ShiftWithAssignee | null>(null)
 
@@ -86,11 +92,42 @@ export function StaffScheduleSection({
     onShiftsChange((prev) => prev.map((s) => (s.id === item.id ? item : s)))
   }
 
+  const scheduledCount = shifts.length
+  const isMet = scheduledCount >= recommendedCount
+  const showForecastBadge = isEditor && recommendedCount > 0
+
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between gap-2">
         <div className="min-w-0 space-y-0.5">
-          <h2 className="font-semibold">{t('title')}</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="font-semibold">{t('title')}</h2>
+            {showForecastBadge && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className={`inline-flex cursor-default items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                      isMet
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                        : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'
+                    }`}
+                  >
+                    {tForecast('badge', {
+                      recommended: recommendedCount,
+                      scheduled: scheduledCount,
+                    })}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <ul className="space-y-0.5 text-xs">
+                    {forecastBreakdown.map((b) => (
+                      <li key={b.source}>{tForecast(`tooltip_${b.source}`, { count: b.count })}</li>
+                    ))}
+                  </ul>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
           {shifts.length > 0 && (
             <p className="text-muted-foreground text-xs">
               {t('scheduledSummary', { hours: fmtHours(totalScheduled) })}

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -10,7 +10,12 @@ import type {
   DailyBriefAllergenRollupEntry,
   DailyBriefCovers,
 } from '@/types/daily-brief'
-import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
+import type {
+  Activity,
+  Reservation,
+  BreakfastConfiguration,
+  ShiftWithAssignee,
+} from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
 
 const PROMPT_VERSION = 'v1'
@@ -117,6 +122,7 @@ function llmPayload(args: {
   dayNotes: DayNote[]
   covers: DailyBriefCovers
   allergenRollup: DailyBriefAllergenRollupEntry[]
+  shifts?: ShiftWithAssignee[]
 }) {
   return {
     date: args.dateIso,
@@ -156,6 +162,12 @@ function llmPayload(args: {
     dayNotes: args.dayNotes.map((n) => ({
       content: truncateNote(n.content),
     })),
+    staff: (args.shifts ?? []).map((s) => ({
+      name: s.assignee.display_name,
+      role: s.role || undefined,
+      start: s.start_time,
+      end: s.end_time,
+    })),
   }
 }
 
@@ -188,6 +200,7 @@ export async function generateAndPersistDailyBrief(
     breakfasts: BreakfastConfiguration[]
     dayNotes: DayNote[]
     weather: WeatherData | null
+    shifts?: ShiftWithAssignee[]
   }
 ): Promise<ActionResponse<DailyBriefRecord>> {
   if (!hasGatewayAuth()) {
@@ -208,6 +221,7 @@ export async function generateAndPersistDailyBrief(
     dayNotes: args.dayNotes,
     covers,
     allergenRollup,
+    shifts: args.shifts,
   })
 
   let narrative: z.infer<typeof narrativeSchema>

--- a/lib/morning-brief-cron.ts
+++ b/lib/morning-brief-cron.ts
@@ -13,10 +13,43 @@ import {
   getBreakfastConfigsForDayWithClient,
   getDayNotesForDayWithClient,
   getDailyBriefForDayWithClient,
+  getShiftsForDayWithClient,
 } from '@/app/[tenant]/day/[date]/queries'
+import type { ShiftWithAssignee } from '@/types/index'
 import { getWeatherForTenantId } from '@/app/actions/weather'
 import { dayHasPlannedContent, generateAndPersistDailyBrief } from '@/lib/daily-brief-generate'
 import type { DailyBriefRecord } from '@/types/daily-brief'
+
+function fmtShiftTime(t: string | null | undefined): string {
+  if (!t) return ''
+  return t.slice(0, 5)
+}
+
+function staffSectionHtml(shifts: ShiftWithAssignee[]): string {
+  if (shifts.length === 0) return ''
+  const items = shifts
+    .map((s) => {
+      const role = s.role ? ` (${escapeHtml(s.role)})` : ''
+      const start = fmtShiftTime(s.start_time)
+      const end = fmtShiftTime(s.end_time)
+      const times = start || end ? ` ${start}–${end}` : ''
+      return `<p style="margin:4px 0 4px 12px;">• ${escapeHtml(s.assignee.display_name)}${role}${escapeHtml(times)}</p>`
+    })
+    .join('')
+  return `<h2 style="font-size:15px;margin:20px 0 8px;">Staff today</h2>${items}`
+}
+
+function staffSectionText(shifts: ShiftWithAssignee[]): string {
+  if (shifts.length === 0) return ''
+  const lines = shifts.map((s) => {
+    const role = s.role ? ` (${s.role})` : ''
+    const start = fmtShiftTime(s.start_time)
+    const end = fmtShiftTime(s.end_time)
+    const times = start || end ? ` ${start}–${end}` : ''
+    return `- ${s.assignee.display_name}${role}${times}`
+  })
+  return `\n## Staff today\n${lines.join('\n')}`
+}
 
 function escapeHtml(value: string): string {
   return value
@@ -31,7 +64,8 @@ function briefToHtml(
   brief: DailyBriefRecord,
   tenantName: string,
   dayUrl: string,
-  dateLabel: string
+  dateLabel: string,
+  shifts: ShiftWithAssignee[]
 ) {
   const body = formatDailyBriefMarkdown(brief.content)
     .split('\n')
@@ -54,6 +88,7 @@ function briefToHtml(
     <div style="font-family: system-ui, -apple-system, Segoe UI, sans-serif; font-size: 14px; color: #111; max-width: 560px;">
       <p style="color:#555; font-size:13px; margin:0 0 16px;">${escapeHtml(tenantName)} · ${escapeHtml(dateLabel)}</p>
       ${body}
+      ${staffSectionHtml(shifts)}
       <p style="margin-top: 24px;"><a href="${escapeHtml(dayUrl)}" style="color: #2563eb;">Open day in Courseday</a></p>
     </div>
   `
@@ -132,11 +167,16 @@ export async function runMorningBriefEmailCron(): Promise<MorningBriefCronResult
     }
     const dayId = dayRes.data.id
 
-    const [activities, reservations, breakfasts, dayNotes] = await Promise.all([
+    const staffScheduleOn = flags.staff_schedule
+
+    const [activities, reservations, breakfasts, dayNotes, shifts] = await Promise.all([
       getProgramItemsForDayWithClient(supabase, tenant.id, dayId),
       getReservationsForDayWithClient(supabase, tenant.id, dayId),
       getBreakfastConfigsForDayWithClient(supabase, tenant.id, dayId),
       getDayNotesForDayWithClient(supabase, tenant.id, dayId),
+      staffScheduleOn
+        ? getShiftsForDayWithClient(supabase, tenant.id, dayId)
+        : Promise.resolve<ShiftWithAssignee[]>([]),
     ])
 
     if (!dayHasPlannedContent(activities, reservations, breakfasts)) {
@@ -166,6 +206,7 @@ export async function runMorningBriefEmailCron(): Promise<MorningBriefCronResult
         breakfasts,
         dayNotes,
         weather,
+        shifts: staffScheduleOn ? shifts : undefined,
       })
       if (!gen.success) {
         errors.push(`${tenant.slug}: ${gen.error}`)
@@ -222,8 +263,17 @@ export async function runMorningBriefEmailCron(): Promise<MorningBriefCronResult
         }
         const to = u.user.email
         const subject = `Daily brief — ${tenant.name} — ${dateLabel}`
-        const text = formatDailyBriefMarkdown(brief.content) + `\n\n${dayUrl}\n`
-        const html = briefToHtml(brief, tenant.name, dayUrl, dateLabel)
+        const text =
+          formatDailyBriefMarkdown(brief.content) +
+          (staffScheduleOn ? staffSectionText(shifts) : '') +
+          `\n\n${dayUrl}\n`
+        const html = briefToHtml(
+          brief,
+          tenant.name,
+          dayUrl,
+          dateLabel,
+          staffScheduleOn ? shifts : []
+        )
         const tenantFromName =
           (tenant as { email_from_name?: string | null }).email_from_name ?? tenant.name
         const tenantReplyTo =

--- a/lib/staffing-forecast.test.ts
+++ b/lib/staffing-forecast.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { recommendStaffCount } from './staffing-forecast'
+
+describe('recommendStaffCount', () => {
+  it('empty input returns 0', () => {
+    expect(
+      recommendStaffCount({ activitiesCovers: 0, reservationsCovers: 0, breakfastCovers: 0 })
+    ).toMatchObject({ recommended: 0 })
+  })
+
+  it('all zeros returns 0', () => {
+    expect(
+      recommendStaffCount({ activitiesCovers: 0, reservationsCovers: 0, breakfastCovers: 0 })
+    ).toMatchObject({ recommended: 0 })
+  })
+
+  it('1 cover returns 1', () => {
+    expect(
+      recommendStaffCount({ activitiesCovers: 1, reservationsCovers: 0, breakfastCovers: 0 })
+    ).toMatchObject({ recommended: 1 })
+  })
+
+  it('25 covers returns 1', () => {
+    expect(
+      recommendStaffCount({ activitiesCovers: 25, reservationsCovers: 0, breakfastCovers: 0 })
+    ).toMatchObject({ recommended: 1 })
+  })
+
+  it('26 covers returns 2', () => {
+    expect(
+      recommendStaffCount({ activitiesCovers: 26, reservationsCovers: 0, breakfastCovers: 0 })
+    ).toMatchObject({ recommended: 2 })
+  })
+
+  it('mixed sources sum correctly', () => {
+    const result = recommendStaffCount({
+      activitiesCovers: 10,
+      reservationsCovers: 10,
+      breakfastCovers: 10,
+    })
+    // total = 30 → ceil(30/25) = 2
+    expect(result).toMatchObject({ recommended: 2 })
+    expect(result.breakdown).toHaveLength(3)
+  })
+})

--- a/lib/staffing-forecast.ts
+++ b/lib/staffing-forecast.ts
@@ -1,0 +1,16 @@
+// Heuristic: 1 staff per 25 expected covers across activities + reservations + breakfasts.
+// Round up. Minimum 1 if any covers exist; 0 if all inputs are zero.
+export function recommendStaffCount(input: {
+  activitiesCovers: number
+  reservationsCovers: number
+  breakfastCovers: number
+}): { recommended: number; breakdown: { source: string; count: number }[] } {
+  const total = input.activitiesCovers + input.reservationsCovers + input.breakfastCovers
+  if (total === 0) return { recommended: 0, breakdown: [] }
+  const breakdown = [
+    { source: 'activities', count: input.activitiesCovers },
+    { source: 'reservations', count: input.reservationsCovers },
+    { source: 'breakfast', count: input.breakfastCovers },
+  ].filter((b) => b.count > 0)
+  return { recommended: Math.max(1, Math.ceil(total / 25)), breakdown }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -638,6 +638,12 @@
       "bannerDismiss": "Dismiss"
     },
     "staff": {
+      "forecast": {
+        "badge": "Recommended {recommended} · Scheduled {scheduled}",
+        "tooltip_activities": "Activities: {count} covers",
+        "tooltip_reservations": "Reservations: {count} covers",
+        "tooltip_breakfast": "Breakfast: {count} covers"
+      },
       "section": {
         "title": "Staff schedule",
         "addShift": "Add shift",


### PR DESCRIPTION
## Summary

- **`lib/staffing-forecast.ts`**: `recommendStaffCount` — 1 staff per 25 covers (activities + reservations + breakfast), rounded up, min 1 if any covers, 0 if all zero
- **`lib/staffing-forecast.test.ts`**: Vitest unit tests covering all spec cases (empty, 1, 25, 26, mixed sources)
- **`lib/daily-brief-generate.ts`**: accepts optional `shifts` and includes them in the LLM prompt payload (name, role, start/end)
- **`app/actions/daily-brief.ts`**: fetches shifts when `staff_schedule` flag is on, passes to LLM generation; updates prompt contract comment
- **`app/[tenant]/day/[date]/queries.ts`**: adds `getShiftsForDayWithClient` for use in cron (no cookie-based auth)
- **`lib/morning-brief-cron.ts`**: fetches shifts when flag on; appends **Staff today** section to both HTML and plain-text email; passes shifts to LLM generation
- **`components/staff-schedule-section.tsx`**: adds `Recommended N · Scheduled M` badge in section header — green when scheduled ≥ recommended, amber otherwise; editor-only; tooltip lists per-source breakdown
- **`app/[tenant]/day/[date]/page.tsx`**: computes `staffRecommended` / `staffForecastBreakdown` from covers, adds to `DayViewProps`, passes to client
- **`messages/en.json`**: `Tenant.staff.forecast.*` keys (badge, tooltip per source)

## Test plan

- [ ] `pnpm test:run` — all `staffing-forecast.test.ts` cases pass
- [ ] Day view with `staff_schedule` on and some activities/reservations/breakfasts: badge appears in Staff schedule section header
- [ ] Badge is green when shifts scheduled ≥ recommended, amber when under
- [ ] Tooltip lists breakdown by source
- [ ] Badge hidden when `staff_schedule` flag is off
- [ ] Badge hidden for viewer role (editor-only)
- [ ] Morning brief email includes "Staff today" section when shifts exist and flag is on
- [ ] Daily brief LLM prompt includes staff names/times when flag is on

Closes #173

https://claude.ai/code/session_01BDgxHuCynf9noTBBUcktXf

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDgxHuCynf9noTBBUcktXf)_