### PR TITLE
feat: per-section regenerate buttons on Daily Brief (#176)

### DIFF
--- a/app/actions/daily-brief.ts
+++ b/app/actions/daily-brief.ts
@@ -23,7 +23,7 @@ import { createTenantClient } from '@/lib/supabase-server'
 import { getTenantId } from '@/lib/tenant'
 import { getUserRole, requireEditor } from '@/lib/membership'
 import { isFeatureEnabled } from '@/app/actions/feature-flags'
-import { dailyBriefRateLimit } from '@/lib/rate-limit'
+import { dailyBriefRateLimit, briefSectionRateLimit } from '@/lib/rate-limit'
 import { ensureDayExists } from '@/app/actions/days'
 import {
   getProgramItemsForDay,
@@ -36,16 +36,17 @@ import { getWeatherForDay } from '@/app/actions/weather'
 import {
   dailyBriefContentSchema,
   generateAndPersistDailyBrief,
+  generateAndPersistBriefSection,
   dayHasPlannedContent,
 } from '@/lib/daily-brief-generate'
 import { redis } from '@/lib/redis'
 import type { ActionResponse } from '@/types/actions'
-import type { DailyBriefRecord } from '@/types/daily-brief'
+import type { DailyBriefRecord, BriefSection } from '@/types/daily-brief'
 import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
 import type { WeatherData } from '@/app/actions/weather'
 
-export type { DailyBriefContent, DailyBriefRecord } from '@/types/daily-brief'
+export type { DailyBriefContent, DailyBriefRecord, BriefSection } from '@/types/daily-brief'
 
 export type EnsureDailyBriefResult =
   | { status: 'empty' }
@@ -233,5 +234,69 @@ export async function generateDailyBrief(
     breakfasts,
     dayNotes,
     weather,
+  })
+}
+
+const ALLOWED_SECTIONS = new Set(['vipNotes', 'risks', 'suggestedActions'])
+
+export async function regenerateBriefSection(
+  dateIso: string,
+  section: string
+): Promise<ActionResponse<DailyBriefRecord>> {
+  if (!ALLOWED_SECTIONS.has(section)) {
+    return { success: false, error: 'Invalid section.' }
+  }
+
+  const tenantId = await getTenantId()
+  if (!(await isFeatureEnabled(tenantId, 'daily_brief'))) {
+    return { success: false, error: 'Daily brief is disabled for this venue.' }
+  }
+  const user = await requireEditor(tenantId)
+
+  if (!process.env.AI_GATEWAY_API_KEY) {
+    return {
+      success: false,
+      error: 'AI brief is not configured (missing AI_GATEWAY_API_KEY).',
+    }
+  }
+
+  const rl = await briefSectionRateLimit(tenantId, dateIso, section)
+  if (!rl.success) {
+    return {
+      success: false,
+      error: `Section regeneration limit reached for today. Try again tomorrow.`,
+    }
+  }
+
+  const dayResult = await ensureDayExists(dateIso)
+  if (!dayResult.success) return { success: false, error: dayResult.error }
+  const dayId = dayResult.data.id
+
+  const { supabase } = await createTenantClient()
+  const existing = await getDailyBriefForDayWithClient(supabase, tenantId, dayId)
+  if (!existing) {
+    return { success: false, error: 'No brief exists for this day. Generate a full brief first.' }
+  }
+
+  const [activities, reservations, breakfasts, dayNotes, weather] = await Promise.all([
+    getProgramItemsForDay(tenantId, dayId),
+    getReservationsForDay(tenantId, dayId),
+    getBreakfastConfigsForDay(tenantId, dayId),
+    getDayNotesForDay(tenantId, dayId),
+    getWeatherForDay(dateIso),
+  ])
+
+  return generateAndPersistBriefSection(supabase, {
+    tenantId,
+    dayId,
+    dateIso,
+    section: section as BriefSection,
+    existingContent: existing.content,
+    activities,
+    reservations,
+    breakfasts,
+    dayNotes,
+    weather,
+    generatedBy: user.id,
   })
 }

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -6,8 +6,8 @@ import { useRouter } from 'next/navigation'
 import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { generateDailyBrief } from '@/app/actions/daily-brief'
-import type { DailyBriefRecord } from '@/types/daily-brief'
+import { generateDailyBrief, regenerateBriefSection } from '@/app/actions/daily-brief'
+import type { BriefSection, DailyBriefRecord } from '@/types/daily-brief'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
 
 const REGENERATE_DEBOUNCE_MS = 2000
@@ -19,6 +19,21 @@ type Props = {
   isEditor: boolean
   briefStale?: boolean
   briefIsEmpty?: boolean
+}
+
+type SectionState = {
+  loading: boolean
+  error: string | null
+}
+
+const REGEN_SECTIONS: BriefSection[] = ['vipNotes', 'risks', 'suggestedActions']
+
+function initialSectionState(): Record<BriefSection, SectionState> {
+  return {
+    vipNotes: { loading: false, error: null },
+    risks: { loading: false, error: null },
+    suggestedActions: { loading: false, error: null },
+  }
 }
 
 export function DailyBriefCard({
@@ -34,11 +49,13 @@ export function DailyBriefCard({
   const [brief, setBrief] = useState<DailyBriefRecord | null>(initialBrief)
   const [stale, setStale] = useState(initialBriefStale)
   const [loading, setLoading] = useState(false)
+  const [sections, setSections] = useState<Record<BriefSection, SectionState>>(initialSectionState)
   const lastRegenerateAt = useRef(0)
 
   useEffect(() => {
     setBrief(initialBrief)
     setStale(initialBriefStale)
+    setSections(initialSectionState())
   }, [initialBrief, initialBriefStale, dayId])
 
   const runRegenerate = useCallback(async () => {
@@ -58,12 +75,44 @@ export function DailyBriefCard({
       }
       setBrief(result.data)
       setStale(false)
+      setSections(initialSectionState())
       toast.success(t('generated'))
       router.refresh()
     } finally {
       setLoading(false)
     }
   }, [dateIso, router, t])
+
+  const runRegenerateSection = useCallback(
+    async (section: BriefSection) => {
+      setSections((prev) => ({
+        ...prev,
+        [section]: { loading: true, error: null },
+      }))
+      try {
+        const result = await regenerateBriefSection(dateIso, section)
+        if (!result.success) {
+          setSections((prev) => ({
+            ...prev,
+            [section]: { loading: false, error: result.error },
+          }))
+          return
+        }
+        setBrief(result.data)
+        setSections((prev) => ({
+          ...prev,
+          [section]: { loading: false, error: null },
+        }))
+        toast.success(t('sectionRegenerated'))
+      } catch {
+        setSections((prev) => ({
+          ...prev,
+          [section]: { loading: false, error: t('sectionRegenFailed') },
+        }))
+      }
+    },
+    [dateIso, t]
+  )
 
   const copyMarkdown = useCallback(() => {
     if (!brief) return
@@ -75,6 +124,7 @@ export function DailyBriefCard({
   }, [brief, t])
 
   const hasBrief = brief !== null
+  const anySectionLoading = REGEN_SECTIONS.some((s) => sections[s].loading)
 
   return (
     <section className="bg-card text-card-foreground overflow-hidden rounded-xl border shadow-sm">
@@ -99,7 +149,7 @@ export function DailyBriefCard({
               variant="outline"
               size="sm"
               onClick={() => void runRegenerate()}
-              disabled={loading}
+              disabled={loading || anySectionLoading}
             >
               {loading ? (
                 <Loader2 className="mr-1 h-4 w-4 animate-spin" />
@@ -175,10 +225,27 @@ export function DailyBriefCard({
                 <span className="hidden group-open:inline">{t('less')}</span>
               </summary>
               <div className="space-y-3 pt-2">
-                <ListBlock title={t('vip')} items={brief.content.vipNotes} />
+                <ListBlock
+                  title={t('vip')}
+                  items={brief.content.vipNotes}
+                  sectionState={sections.vipNotes}
+                  onRegenerate={isEditor ? () => void runRegenerateSection('vipNotes') : undefined}
+                />
                 <AllergenBlock rollup={brief.content.allergenRollup} t={t} />
-                <ListBlock title={t('risks')} items={brief.content.risks} />
-                <ListBlock title={t('actions')} items={brief.content.suggestedActions} />
+                <ListBlock
+                  title={t('risks')}
+                  items={brief.content.risks}
+                  sectionState={sections.risks}
+                  onRegenerate={isEditor ? () => void runRegenerateSection('risks') : undefined}
+                />
+                <ListBlock
+                  title={t('actions')}
+                  items={brief.content.suggestedActions}
+                  sectionState={sections.suggestedActions}
+                  onRegenerate={
+                    isEditor ? () => void runRegenerateSection('suggestedActions') : undefined
+                  }
+                />
                 <p className="text-muted-foreground pt-1 text-xs">
                   {t('meta', {
                     time: new Date(brief.generated_at).toLocaleString(),
@@ -194,16 +261,49 @@ export function DailyBriefCard({
   )
 }
 
-function ListBlock({ title, items }: { title: string; items: string[] }) {
-  if (items.length === 0) return null
+function ListBlock({
+  title,
+  items,
+  sectionState,
+  onRegenerate,
+}: {
+  title: string
+  items: string[]
+  sectionState?: SectionState
+  onRegenerate?: () => void
+}) {
+  const isLoading = sectionState?.loading ?? false
+  const error = sectionState?.error ?? null
+
+  if (items.length === 0 && !onRegenerate) return null
   return (
-    <div>
-      <div className="text-foreground mb-1 font-medium">{title}</div>
-      <ul className="text-muted-foreground list-disc space-y-0.5 pl-5">
-        {items.map((x, i) => (
-          <li key={i}>{x}</li>
-        ))}
-      </ul>
+    <div className={isLoading ? 'opacity-60' : ''}>
+      <div className="text-foreground mb-1 flex items-center justify-between gap-2 font-medium">
+        <span>{title}</span>
+        {onRegenerate && (
+          <Button
+            type="button"
+            size="iconMicro"
+            variant="ghost"
+            onClick={onRegenerate}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+          </Button>
+        )}
+      </div>
+      {error && <p className="text-destructive mb-1 text-xs">{error}</p>}
+      {items.length > 0 && (
+        <ul className="text-muted-foreground list-disc space-y-0.5 pl-5">
+          {items.map((x, i) => (
+            <li key={i}>{x}</li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -9,6 +9,7 @@ import type {
   DailyBriefRecord,
   DailyBriefAllergenRollupEntry,
   DailyBriefCovers,
+  BriefSection,
 } from '@/types/daily-brief'
 import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
@@ -48,7 +49,20 @@ export const dailyBriefContentSchema = z.object({
   ),
   risks: z.array(z.string()),
   suggestedActions: z.array(z.string()),
+  sectionTimestamps: z
+    .object({
+      vipNotes: z.string().optional(),
+      risks: z.string().optional(),
+      suggestedActions: z.string().optional(),
+    })
+    .optional(),
 })
+
+const sectionSchemas = {
+  vipNotes: z.object({ vipNotes: z.array(z.string()) }),
+  risks: z.object({ risks: z.array(z.string()) }),
+  suggestedActions: z.object({ suggestedActions: z.array(z.string()) }),
+} as const
 
 function truncateNote(text: string | null | undefined): string | undefined {
   if (!text?.trim()) return undefined
@@ -251,6 +265,115 @@ export async function generateAndPersistDailyBrief(
   const { data, error } = await supabase
     .from('daily_brief')
     .upsert(row as never, { onConflict: 'tenant_id,day_id' })
+    .select('id, content, generated_at, model, prompt_version')
+    .single()
+
+  if (error) return { success: false, error: error.message }
+
+  const parsed = dailyBriefContentSchema.safeParse(data.content)
+  if (!parsed.success) return { success: false, error: 'Could not validate saved brief.' }
+
+  return {
+    success: true,
+    data: {
+      id: data.id,
+      content: parsed.data,
+      generated_at: data.generated_at,
+      model: data.model,
+      prompt_version: data.prompt_version,
+    },
+  }
+}
+
+/** Merge a single regenerated section into existing brief content. */
+export function mergeBriefSection(
+  existing: DailyBriefContent,
+  section: BriefSection,
+  value: string[]
+): DailyBriefContent {
+  return {
+    ...existing,
+    [section]: value,
+    sectionTimestamps: {
+      ...existing.sectionTimestamps,
+      [section]: new Date().toISOString(),
+    },
+  }
+}
+
+/** Run model for one section + persist. Caller supplies loaded rows and weather. */
+export async function generateAndPersistBriefSection(
+  supabase: AppSupabaseClient,
+  args: {
+    tenantId: string
+    dayId: string
+    dateIso: string
+    section: BriefSection
+    existingContent: DailyBriefContent
+    activities: Activity[]
+    reservations: Reservation[]
+    breakfasts: BreakfastConfiguration[]
+    dayNotes: DayNote[]
+    weather: WeatherData | null
+    generatedBy: string | null
+  }
+): Promise<ActionResponse<DailyBriefRecord>> {
+  if (!hasGatewayAuth()) {
+    return {
+      success: false,
+      error: 'AI brief is not configured (set AI_GATEWAY_API_KEY or run `vercel env pull`).',
+    }
+  }
+
+  const covers = buildCovers(args.activities, args.reservations, args.breakfasts)
+  const allergenRollup = buildAllergenRollup(args.activities, args.reservations, args.breakfasts)
+  const payload = llmPayload({
+    dateIso: args.dateIso,
+    weather: args.weather,
+    activities: args.activities,
+    reservations: args.reservations,
+    breakfasts: args.breakfasts,
+    dayNotes: args.dayNotes,
+    covers,
+    allergenRollup,
+  })
+
+  const schema = sectionSchemas[args.section]
+  let sectionValue: string[]
+  try {
+    const result = await generateObject({
+      model: gateway(DAILY_BRIEF_MODEL_ID),
+      schema,
+      system: BRIEF_SYSTEM,
+      prompt: `Produce only the "${args.section}" field for a daily briefing from this JSON:\n${JSON.stringify(payload)}`,
+      maxOutputTokens: 512,
+    })
+    sectionValue = (result.object as Record<string, string[]>)[args.section]
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Generation failed.'
+    return {
+      success: false,
+      error:
+        msg.length > 200
+          ? 'Section generation failed. Check AI Gateway configuration and try again.'
+          : msg,
+    }
+  }
+
+  const merged = mergeBriefSection(args.existingContent, args.section, sectionValue)
+  const now = new Date().toISOString()
+
+  const updateRow: Record<string, unknown> = {
+    content: merged,
+    generated_at: now,
+  }
+  if (args.generatedBy) updateRow.generated_by = args.generatedBy
+
+  const { data, error } = await supabase
+    .from('daily_brief')
+    .update(updateRow as never)
+    .eq('tenant_id', args.tenantId)
+    .eq('day_id', args.dayId)
     .select('id, content, generated_at, model, prompt_version')
     .single()
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -64,6 +64,22 @@ export async function dailyBriefRateLimit(
   return checkLimit(`daily-brief:${tenantId}:${dateIso}`, DAILY_BRIEF_LIMIT, DAILY_BRIEF_WINDOW_SEC)
 }
 
+/** Per-section brief regeneration: 5 per calendar day per tenant per section. */
+const BRIEF_SECTION_LIMIT = 5
+const BRIEF_SECTION_WINDOW_SEC = 86400
+
+export async function briefSectionRateLimit(
+  tenantId: string,
+  dateIso: string,
+  section: string
+): Promise<{ success: boolean }> {
+  return checkLimit(
+    `daily-brief-section:${tenantId}:${dateIso}:${section}`,
+    BRIEF_SECTION_LIMIT,
+    BRIEF_SECTION_WINDOW_SEC
+  )
+}
+
 /** LLM quick-add parse: 30 per minute per user (separate from mutation cap). */
 const QUICK_ADD_LIMIT = 30
 const QUICK_ADD_WINDOW_SEC = 60

--- a/messages/de.json
+++ b/messages/de.json
@@ -159,7 +159,9 @@
       "srcBreakfast": "{n} Frühstück(e)",
       "risks": "Risiken",
       "actions": "Vorgeschlagene Maßnahmen",
-      "meta": "Erzeugt {time} · {model}"
+      "meta": "Erzeugt {time} · {model}",
+      "sectionRegenerated": "Abschnitt aktualisiert",
+      "sectionRegenFailed": "Abschnittsregenerierung fehlgeschlagen. Erneut versuchen."
     },
     "quickAdd": {
       "openButton": "Schnell hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -263,7 +263,9 @@
       "srcBreakfast": "{n} breakfast(s)",
       "risks": "Risks",
       "actions": "Suggested actions",
-      "meta": "Generated {time} · {model}"
+      "meta": "Generated {time} · {model}",
+      "sectionRegenerated": "Section updated",
+      "sectionRegenFailed": "Section regeneration failed. Try again."
     },
     "quickAdd": {
       "openButton": "Quick add",

--- a/messages/es.json
+++ b/messages/es.json
@@ -159,7 +159,9 @@
       "srcBreakfast": "{n} desayuno(s)",
       "risks": "Riesgos",
       "actions": "Acciones sugeridas",
-      "meta": "Generado {time} · {model}"
+      "meta": "Generado {time} · {model}",
+      "sectionRegenerated": "Sección actualizada",
+      "sectionRegenFailed": "Error al regenerar la sección. Inténtelo de nuevo."
     },
     "quickAdd": {
       "openButton": "Añadir rápido",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -263,7 +263,9 @@
       "srcBreakfast": "{n} petit(s)-déjeuner",
       "risks": "Risques",
       "actions": "Actions suggérées",
-      "meta": "Généré {time} · {model}"
+      "meta": "Généré {time} · {model}",
+      "sectionRegenerated": "Section mise à jour",
+      "sectionRegenFailed": "Échec de la régénération de la section. Réessayez."
     },
     "quickAdd": {
       "openButton": "Ajout rapide",

--- a/tests/lib/daily-brief-generate.test.ts
+++ b/tests/lib/daily-brief-generate.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mergeBriefSection } from '@/lib/daily-brief-generate'
+import type { DailyBriefContent } from '@/types/daily-brief'
+
+// Freeze time so sectionTimestamps is deterministic in tests
+const FIXED_NOW = '2026-05-09T10:00:00.000Z'
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(FIXED_NOW))
+})
+
+const BASE: DailyBriefContent = {
+  headline: 'Busy Saturday',
+  summary: 'A full day ahead.',
+  covers: { breakfast: 10, activities: 20, reservations: 15 },
+  vipNotes: ['Large party in terrace'],
+  allergenRollup: [],
+  risks: ['Rain expected'],
+  suggestedActions: ['Pre-set terrace tables'],
+}
+
+describe('mergeBriefSection', () => {
+  it('replaces vipNotes and stamps timestamp', () => {
+    const result = mergeBriefSection(BASE, 'vipNotes', ['Updated VIP note'])
+    expect(result.vipNotes).toEqual(['Updated VIP note'])
+    expect(result.sectionTimestamps?.vipNotes).toBe(FIXED_NOW)
+    // other sections untouched
+    expect(result.risks).toEqual(BASE.risks)
+    expect(result.suggestedActions).toEqual(BASE.suggestedActions)
+    expect(result.headline).toBe(BASE.headline)
+    expect(result.covers).toEqual(BASE.covers)
+  })
+
+  it('replaces risks and stamps timestamp', () => {
+    const result = mergeBriefSection(BASE, 'risks', ['Flooding on 18th hole'])
+    expect(result.risks).toEqual(['Flooding on 18th hole'])
+    expect(result.sectionTimestamps?.risks).toBe(FIXED_NOW)
+    expect(result.vipNotes).toEqual(BASE.vipNotes)
+  })
+
+  it('replaces suggestedActions and stamps timestamp', () => {
+    const result = mergeBriefSection(BASE, 'suggestedActions', ['Brief all staff at 07:00'])
+    expect(result.suggestedActions).toEqual(['Brief all staff at 07:00'])
+    expect(result.sectionTimestamps?.suggestedActions).toBe(FIXED_NOW)
+    expect(result.risks).toEqual(BASE.risks)
+  })
+
+  it('preserves existing sectionTimestamps for untouched sections', () => {
+    const withTimestamps: DailyBriefContent = {
+      ...BASE,
+      sectionTimestamps: { vipNotes: '2026-05-09T08:00:00.000Z' },
+    }
+    const result = mergeBriefSection(withTimestamps, 'risks', ['New risk'])
+    expect(result.sectionTimestamps?.vipNotes).toBe('2026-05-09T08:00:00.000Z')
+    expect(result.sectionTimestamps?.risks).toBe(FIXED_NOW)
+  })
+
+  it('does not mutate the original content', () => {
+    const original = { ...BASE, vipNotes: ['Original'] }
+    mergeBriefSection(original, 'vipNotes', ['New'])
+    expect(original.vipNotes).toEqual(['Original'])
+  })
+
+  it('accepts an empty array for a section', () => {
+    const result = mergeBriefSection(BASE, 'risks', [])
+    expect(result.risks).toEqual([])
+    expect(result.sectionTimestamps?.risks).toBe(FIXED_NOW)
+  })
+})

--- a/types/daily-brief.ts
+++ b/types/daily-brief.ts
@@ -11,6 +11,8 @@ export type DailyBriefAllergenRollupEntry = {
   inBreakfast: number
 }
 
+export type BriefSection = 'vipNotes' | 'risks' | 'suggestedActions'
+
 export type DailyBriefContent = {
   headline: string
   summary: string
@@ -19,6 +21,11 @@ export type DailyBriefContent = {
   allergenRollup: DailyBriefAllergenRollupEntry[]
   risks: string[]
   suggestedActions: string[]
+  sectionTimestamps?: {
+    vipNotes?: string
+    risks?: string
+    suggestedActions?: string
+  }
 }
 
 export type DailyBriefRecord = {


### PR DESCRIPTION
## Summary

- Adds per-section regenerate buttons (refresh icon) next to VIP notes, Risks, and Suggested actions headers — editor-only, hidden from viewers
- Each section regen has its own 5/day rate limit per tenant per section (separate from the whole-brief limit)
- Optimistic UI: section greys out + spinner while regen runs; inline error shown on failure, old content retained
- Persisted brief merges only the requested section; `generated_at` updated + per-section timestamp added inside content JSON for traceability
- Whole-brief regenerate button disabled while any section regen is in flight

## Test plan

- [ ] Open a day with an existing brief as an editor
- [ ] Expand "Details" section
- [ ] Click the refresh icon next to "VIP / priority" — confirm section greys + spinner appears, then updates
- [ ] Click refresh on "Risks" and "Suggested actions" — confirm other sections are untouched
- [ ] Confirm viewer sees no refresh icons
- [ ] Trigger rate limit (6 regens of same section in one day) — confirm inline error
- [ ] Confirm unit tests pass: `pnpm test:run tests/lib/daily-brief-generate.test.ts`

https://claude.ai/code/session_01PQDAsyBob6VAoaxGtSK8Et

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQDAsyBob6VAoaxGtSK8Et)_