### PR TITLE
feat: shift notifications + next-day reminder cron (#170)

### DIFF
--- a/app/actions/shifts.ts
+++ b/app/actions/shifts.ts
@@ -11,6 +11,13 @@ import type { Shift, ShiftWithAssignee } from '@/types/index'
 import { getTenantAssignees } from '@/app/[tenant]/day/[date]/queries'
 import { isFeatureEnabled } from '@/app/actions/feature-flags'
 import { addDays, format, parseISO } from 'date-fns'
+import { awaitNotifications } from '@/lib/notifications'
+import {
+  notifyShiftAssigned,
+  notifyShiftUpdatedSameUser,
+  notifyShiftReassigned,
+  notifyShiftCancelled,
+} from '@/lib/shift-notifications'
 
 export type MyShiftWithDate = ShiftWithAssignee & { date_iso: string }
 
@@ -89,6 +96,25 @@ export async function createShift(
     .single()
 
   if (error) return { success: false, error: error.message }
+
+  if (await isFeatureEnabled(tenantId, 'staff_schedule')) {
+    const actor = await getUser()
+    const actorId = actor?.id ?? ''
+    await awaitNotifications(
+      [
+        notifyShiftAssigned({
+          tenantId,
+          actorId,
+          assigneeId: parsed.data.user_id,
+          dayId,
+          startTime: normaliseTime(parsed.data.start_time),
+          endTime: normaliseTime(parsed.data.end_time),
+        }),
+      ],
+      'shift:create'
+    )
+  }
+
   return { success: true, data: data as Shift }
 }
 
@@ -114,6 +140,14 @@ export async function updateShift(
   )
   if (!check.ok) return { success: false, error: check.error }
 
+  const { data: oldShift } = await supabase
+    .from('shift')
+    .select('user_id')
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .maybeSingle()
+  const oldUserId: string | null = (oldShift as { user_id: string } | null)?.user_id ?? null
+
   const { data, error } = await supabase
     .from('shift')
     .update({
@@ -131,6 +165,41 @@ export async function updateShift(
     .single()
 
   if (error) return { success: false, error: error.message }
+
+  if (await isFeatureEnabled(tenantId, 'staff_schedule')) {
+    const actor = await getUser()
+    const actorId = actor?.id ?? ''
+    const newUserId = parsed.data.user_id
+    const notifTasks: Promise<void>[] = []
+
+    if (oldUserId && oldUserId !== newUserId) {
+      notifTasks.push(
+        notifyShiftReassigned({
+          tenantId,
+          actorId,
+          newAssigneeId: newUserId,
+          oldAssigneeId: oldUserId,
+          dayId,
+          startTime: normaliseTime(parsed.data.start_time),
+          endTime: normaliseTime(parsed.data.end_time),
+        })
+      )
+    } else {
+      notifTasks.push(
+        notifyShiftUpdatedSameUser({
+          tenantId,
+          actorId,
+          assigneeId: newUserId,
+          dayId,
+          startTime: normaliseTime(parsed.data.start_time),
+          endTime: normaliseTime(parsed.data.end_time),
+        })
+      )
+    }
+
+    await awaitNotifications(notifTasks, 'shift:update')
+  }
+
   return { success: true, data: data as Shift }
 }
 
@@ -139,6 +208,15 @@ export async function deleteShift(id: string, dayId: string): Promise<ActionResp
   await requireEditor(tenantId)
 
   const { supabase } = await createTenantClient()
+
+  const { data: existing } = await supabase
+    .from('shift')
+    .select('user_id')
+    .eq('id', id)
+    .eq('tenant_id', tenantId)
+    .maybeSingle()
+  const assigneeId: string | null = (existing as { user_id: string } | null)?.user_id ?? null
+
   const { error } = await supabase
     .from('shift')
     .delete()
@@ -147,6 +225,16 @@ export async function deleteShift(id: string, dayId: string): Promise<ActionResp
     .eq('day_id', dayId)
 
   if (error) return { success: false, error: error.message }
+
+  if (assigneeId && (await isFeatureEnabled(tenantId, 'staff_schedule'))) {
+    const actor = await getUser()
+    const actorId = actor?.id ?? ''
+    await awaitNotifications(
+      [notifyShiftCancelled({ tenantId, actorId, assigneeId, dayId })],
+      'shift:cancel'
+    )
+  }
+
   return { success: true, data: undefined }
 }
 

--- a/app/api/cron/shift-reminders/route.ts
+++ b/app/api/cron/shift-reminders/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import { runShiftRemindersCron } from '@/lib/shift-reminders-cron'
+
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+export async function GET(request: Request) {
+  if (!process.env.CRON_SECRET) {
+    return NextResponse.json({ error: 'CRON_SECRET not set on server.' }, { status: 500 })
+  }
+  const auth = request.headers.get('authorization')
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const result = await runShiftRemindersCron()
+  return NextResponse.json(result)
+}

--- a/lib/shift-notifications.ts
+++ b/lib/shift-notifications.ts
@@ -1,0 +1,109 @@
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+
+async function resolveDateIso(dayId: string): Promise<string> {
+  const svc = createSupabaseServiceClient()
+  const { data } = await svc.from('day').select('date_iso').eq('id', dayId).maybeSingle()
+  return (data as { date_iso: string } | null)?.date_iso ?? dayId
+}
+
+function fmt(t: string | null | undefined): string {
+  return t ?? '—'
+}
+
+export async function notifyShiftAssigned(params: {
+  tenantId: string
+  actorId: string
+  assigneeId: string
+  dayId: string
+  startTime?: string | null
+  endTime?: string | null
+}): Promise<void> {
+  if (params.actorId === params.assigneeId) return
+  const dateIso = await resolveDateIso(params.dayId)
+  const svc = createSupabaseServiceClient()
+  await svc.from('notifications').insert({
+    tenant_id: params.tenantId,
+    user_id: params.assigneeId,
+    title: `New shift on ${dateIso}`,
+    body: `${fmt(params.startTime)} – ${fmt(params.endTime)}`,
+    link: `/day/${dateIso}`,
+  })
+}
+
+export async function notifyShiftUpdatedSameUser(params: {
+  tenantId: string
+  actorId: string
+  assigneeId: string
+  dayId: string
+  startTime?: string | null
+  endTime?: string | null
+}): Promise<void> {
+  if (params.actorId === params.assigneeId) return
+  const dateIso = await resolveDateIso(params.dayId)
+  const svc = createSupabaseServiceClient()
+  await svc.from('notifications').insert({
+    tenant_id: params.tenantId,
+    user_id: params.assigneeId,
+    title: `Shift updated on ${dateIso}`,
+    body: `${fmt(params.startTime)} – ${fmt(params.endTime)}`,
+    link: `/day/${dateIso}`,
+  })
+}
+
+export async function notifyShiftReassigned(params: {
+  tenantId: string
+  actorId: string
+  newAssigneeId: string
+  oldAssigneeId: string
+  dayId: string
+  startTime?: string | null
+  endTime?: string | null
+}): Promise<void> {
+  const dateIso = await resolveDateIso(params.dayId)
+  const svc = createSupabaseServiceClient()
+  const rows: {
+    tenant_id: string
+    user_id: string
+    title: string
+    body: string | null
+    link: string | null
+  }[] = []
+
+  if (params.oldAssigneeId !== params.actorId) {
+    rows.push({
+      tenant_id: params.tenantId,
+      user_id: params.oldAssigneeId,
+      title: `Shift removed on ${dateIso}`,
+      body: null,
+      link: null,
+    })
+  }
+  if (params.newAssigneeId !== params.actorId) {
+    rows.push({
+      tenant_id: params.tenantId,
+      user_id: params.newAssigneeId,
+      title: `New shift on ${dateIso}`,
+      body: `${fmt(params.startTime)} – ${fmt(params.endTime)}`,
+      link: `/day/${dateIso}`,
+    })
+  }
+  if (rows.length > 0) await svc.from('notifications').insert(rows)
+}
+
+export async function notifyShiftCancelled(params: {
+  tenantId: string
+  actorId: string
+  assigneeId: string
+  dayId: string
+}): Promise<void> {
+  if (params.actorId === params.assigneeId) return
+  const dateIso = await resolveDateIso(params.dayId)
+  const svc = createSupabaseServiceClient()
+  await svc.from('notifications').insert({
+    tenant_id: params.tenantId,
+    user_id: params.assigneeId,
+    title: `Shift cancelled on ${dateIso}`,
+    body: null,
+    link: null,
+  })
+}

--- a/lib/shift-reminders-cron.ts
+++ b/lib/shift-reminders-cron.ts
@@ -1,0 +1,82 @@
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { getFeatureFlags } from '@/app/actions/feature-flags'
+import { getTenantToday } from '@/lib/day-utils'
+import { addDays, format, parseISO } from 'date-fns'
+
+export type ShiftRemindersCronResult = {
+  ok: true
+  tenantsProcessed: number
+  notificationsSent: number
+  errors: string[]
+}
+
+export async function runShiftRemindersCron(): Promise<ShiftRemindersCronResult> {
+  const supabase = createSupabaseServiceClient()
+
+  const { data: tenants, error: tenantsError } = await supabase
+    .from('tenants')
+    .select('id, slug, timezone')
+
+  if (tenantsError || !tenants) {
+    return {
+      ok: true,
+      tenantsProcessed: 0,
+      notificationsSent: 0,
+      errors: [tenantsError?.message ?? 'No tenants.'],
+    }
+  }
+
+  const errors: string[] = []
+  let tenantsProcessed = 0
+  let notificationsSent = 0
+
+  for (const tenant of tenants) {
+    const flags = await getFeatureFlags(tenant.id)
+    if (!flags.staff_schedule) continue
+
+    tenantsProcessed += 1
+
+    const tz = (tenant as { timezone?: string | null }).timezone || 'UTC'
+    const today = getTenantToday(tz)
+    const tomorrow = format(addDays(parseISO(today), 1), 'yyyy-MM-dd')
+
+    const { data: dayRow } = await supabase
+      .from('day')
+      .select('id')
+      .eq('tenant_id', tenant.id)
+      .eq('date_iso', tomorrow)
+      .maybeSingle()
+
+    if (!dayRow) continue
+
+    const { data: shifts } = await supabase
+      .from('shift')
+      .select('user_id, start_time')
+      .eq('tenant_id', tenant.id)
+      .eq('day_id', dayRow.id)
+
+    if (!shifts?.length) continue
+
+    const rows = (shifts as { user_id: string; start_time: string | null }[]).map((s) => ({
+      tenant_id: tenant.id,
+      user_id: s.user_id,
+      title: `Reminder: shift tomorrow at ${s.start_time ?? '—'}`,
+      body: null,
+      link: `/my-schedule`,
+    }))
+
+    const { error: insertErr } = await supabase.from('notifications').insert(rows)
+    if (insertErr) {
+      errors.push(`${tenant.slug}: ${insertErr.message}`)
+      continue
+    }
+    notificationsSent += rows.length
+  }
+
+  return {
+    ok: true,
+    tenantsProcessed,
+    notificationsSent,
+    errors,
+  }
+}

--- a/tests/actions/shifts.test.ts
+++ b/tests/actions/shifts.test.ts
@@ -13,16 +13,36 @@ vi.mock('@/app/actions/feature-flags', () => ({
 vi.mock('@/lib/supabase-server', () => ({
   createTenantClient: vi.fn(),
   createSupabaseServerClient: vi.fn(),
+  createSupabaseServiceClient: vi.fn(),
 }))
-vi.mock('@/app/actions/auth', () => ({ getUser: vi.fn().mockResolvedValue(null) }))
+vi.mock('@/app/actions/auth', () => ({
+  getUser: vi.fn().mockResolvedValue({ id: 'actor-user-id' }),
+}))
 vi.mock('@/app/[tenant]/day/[date]/queries', () => ({
   getTenantAssignees: vi.fn().mockResolvedValue(new Map()),
+}))
+vi.mock('@/lib/notifications', () => ({
+  awaitNotifications: vi.fn().mockResolvedValue(undefined),
+  getDayDate: vi.fn().mockResolvedValue('2026-05-10'),
+}))
+vi.mock('@/lib/shift-notifications', () => ({
+  notifyShiftAssigned: vi.fn().mockResolvedValue(undefined),
+  notifyShiftUpdatedSameUser: vi.fn().mockResolvedValue(undefined),
+  notifyShiftReassigned: vi.fn().mockResolvedValue(undefined),
+  notifyShiftCancelled: vi.fn().mockResolvedValue(undefined),
 }))
 
 // ── Imports ───────────────────────────────────────────────────────────────────
 
 import { isFeatureEnabled } from '@/app/actions/feature-flags'
 import { createTenantClient, createSupabaseServerClient } from '@/lib/supabase-server'
+import { awaitNotifications } from '@/lib/notifications'
+import {
+  notifyShiftAssigned,
+  notifyShiftUpdatedSameUser,
+  notifyShiftReassigned,
+  notifyShiftCancelled,
+} from '@/lib/shift-notifications'
 import {
   createShift,
   updateShift,
@@ -73,6 +93,7 @@ function mockClient(fromFn: ReturnType<typeof vi.fn>) {
 const SHIFT_ID = 'shift-1'
 const DAY_ID = 'day-1'
 const USER_UUID = '123e4567-e89b-12d3-a456-426614174000'
+const OTHER_UUID = '223e4567-e89b-12d3-a456-426614174001'
 
 const VALID_SHIFT_DATA = {
   user_id: USER_UUID,
@@ -104,7 +125,6 @@ beforeEach(() => {
 
 describe('createShift', () => {
   it('creates a shift and returns it', async () => {
-    // assertDayAndMemberBelongToTenant: day check → membership check → insert
     const dayChain = makeChain({ data: { id: DAY_ID }, error: null })
     const memberChain = makeChain({ data: { id: 'member-1' }, error: null })
     const insertChain = makeChain({ data: SHIFT_ROW, error: null })
@@ -118,6 +138,46 @@ describe('createShift', () => {
     const result = await createShift(DAY_ID, VALID_SHIFT_DATA)
     assertSuccess(result)
     expect(result.data).toMatchObject({ role: 'Chef' })
+  })
+
+  it('calls notifyShiftAssigned after success when flag is on', async () => {
+    const dayChain = makeChain({ data: { id: DAY_ID }, error: null })
+    const memberChain = makeChain({ data: { id: 'member-1' }, error: null })
+    const insertChain = makeChain({ data: SHIFT_ROW, error: null })
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(dayChain)
+      .mockReturnValueOnce(memberChain)
+      .mockReturnValueOnce(insertChain)
+    mockClient(from)
+
+    await createShift(DAY_ID, VALID_SHIFT_DATA)
+
+    expect(awaitNotifications).toHaveBeenCalledOnce()
+    expect(notifyShiftAssigned).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        assigneeId: USER_UUID,
+        dayId: DAY_ID,
+      })
+    )
+  })
+
+  it('skips notifyShiftAssigned when staff_schedule flag is off', async () => {
+    vi.mocked(isFeatureEnabled).mockResolvedValue(false)
+    const dayChain = makeChain({ data: { id: DAY_ID }, error: null })
+    const memberChain = makeChain({ data: { id: 'member-1' }, error: null })
+    const insertChain = makeChain({ data: SHIFT_ROW, error: null })
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(dayChain)
+      .mockReturnValueOnce(memberChain)
+      .mockReturnValueOnce(insertChain)
+    mockClient(from)
+
+    await createShift(DAY_ID, VALID_SHIFT_DATA)
+
+    expect(notifyShiftAssigned).not.toHaveBeenCalled()
   })
 
   it('returns validation error for invalid user_id', async () => {
@@ -143,17 +203,85 @@ describe('updateShift', () => {
   it('updates a shift and returns it', async () => {
     const dayChain = makeChain({ data: { id: DAY_ID }, error: null })
     const memberChain = makeChain({ data: { id: 'member-1' }, error: null })
+    const oldShiftChain = makeChain({ data: { user_id: USER_UUID }, error: null })
     const updateChain = makeChain({ data: { ...SHIFT_ROW, role: 'Manager' }, error: null })
     const from = vi
       .fn()
       .mockReturnValueOnce(dayChain)
       .mockReturnValueOnce(memberChain)
+      .mockReturnValueOnce(oldShiftChain)
       .mockReturnValueOnce(updateChain)
     mockClient(from)
 
     const result = await updateShift(SHIFT_ID, DAY_ID, { ...VALID_SHIFT_DATA, role: 'Manager' })
     assertSuccess(result)
     expect(result.data).toMatchObject({ role: 'Manager' })
+  })
+
+  it('calls notifyShiftUpdatedSameUser when user unchanged', async () => {
+    const dayChain = makeChain({ data: { id: DAY_ID }, error: null })
+    const memberChain = makeChain({ data: { id: 'member-1' }, error: null })
+    const oldShiftChain = makeChain({ data: { user_id: USER_UUID }, error: null })
+    const updateChain = makeChain({ data: SHIFT_ROW, error: null })
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(dayChain)
+      .mockReturnValueOnce(memberChain)
+      .mockReturnValueOnce(oldShiftChain)
+      .mockReturnValueOnce(updateChain)
+    mockClient(from)
+
+    await updateShift(SHIFT_ID, DAY_ID, VALID_SHIFT_DATA)
+
+    expect(notifyShiftUpdatedSameUser).toHaveBeenCalledWith(
+      expect.objectContaining({ assigneeId: USER_UUID, dayId: DAY_ID })
+    )
+    expect(notifyShiftReassigned).not.toHaveBeenCalled()
+  })
+
+  it('calls notifyShiftReassigned when user changes', async () => {
+    const dayChain = makeChain({ data: { id: DAY_ID }, error: null })
+    const memberChain = makeChain({ data: { id: 'member-1' }, error: null })
+    const oldShiftChain = makeChain({ data: { user_id: OTHER_UUID }, error: null })
+    const updateChain = makeChain({ data: { ...SHIFT_ROW, user_id: USER_UUID }, error: null })
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(dayChain)
+      .mockReturnValueOnce(memberChain)
+      .mockReturnValueOnce(oldShiftChain)
+      .mockReturnValueOnce(updateChain)
+    mockClient(from)
+
+    await updateShift(SHIFT_ID, DAY_ID, VALID_SHIFT_DATA)
+
+    expect(notifyShiftReassigned).toHaveBeenCalledWith(
+      expect.objectContaining({
+        newAssigneeId: USER_UUID,
+        oldAssigneeId: OTHER_UUID,
+        dayId: DAY_ID,
+      })
+    )
+    expect(notifyShiftUpdatedSameUser).not.toHaveBeenCalled()
+  })
+
+  it('skips notification when staff_schedule flag is off', async () => {
+    vi.mocked(isFeatureEnabled).mockResolvedValue(false)
+    const dayChain = makeChain({ data: { id: DAY_ID }, error: null })
+    const memberChain = makeChain({ data: { id: 'member-1' }, error: null })
+    const oldShiftChain = makeChain({ data: { user_id: USER_UUID }, error: null })
+    const updateChain = makeChain({ data: SHIFT_ROW, error: null })
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(dayChain)
+      .mockReturnValueOnce(memberChain)
+      .mockReturnValueOnce(oldShiftChain)
+      .mockReturnValueOnce(updateChain)
+    mockClient(from)
+
+    await updateShift(SHIFT_ID, DAY_ID, VALID_SHIFT_DATA)
+
+    expect(notifyShiftUpdatedSameUser).not.toHaveBeenCalled()
+    expect(notifyShiftReassigned).not.toHaveBeenCalled()
   })
 
   it('returns validation error for invalid user_id', async () => {
@@ -169,17 +297,44 @@ describe('updateShift', () => {
 
 describe('deleteShift', () => {
   it('deletes the shift and returns success', async () => {
-    const chain = makeChain({ data: null, error: null })
-    const from = vi.fn().mockReturnValue(chain)
+    const existingChain = makeChain({ data: { user_id: USER_UUID }, error: null })
+    const deleteChain = makeChain({ data: null, error: null })
+    const from = vi.fn().mockReturnValueOnce(existingChain).mockReturnValueOnce(deleteChain)
     mockClient(from)
 
     const result = await deleteShift(SHIFT_ID, DAY_ID)
     expect(result.success).toBe(true)
   })
 
+  it('calls notifyShiftCancelled after delete', async () => {
+    const existingChain = makeChain({ data: { user_id: USER_UUID }, error: null })
+    const deleteChain = makeChain({ data: null, error: null })
+    const from = vi.fn().mockReturnValueOnce(existingChain).mockReturnValueOnce(deleteChain)
+    mockClient(from)
+
+    await deleteShift(SHIFT_ID, DAY_ID)
+
+    expect(notifyShiftCancelled).toHaveBeenCalledWith(
+      expect.objectContaining({ assigneeId: USER_UUID, dayId: DAY_ID })
+    )
+  })
+
+  it('skips notification when staff_schedule flag is off', async () => {
+    vi.mocked(isFeatureEnabled).mockResolvedValue(false)
+    const existingChain = makeChain({ data: { user_id: USER_UUID }, error: null })
+    const deleteChain = makeChain({ data: null, error: null })
+    const from = vi.fn().mockReturnValueOnce(existingChain).mockReturnValueOnce(deleteChain)
+    mockClient(from)
+
+    await deleteShift(SHIFT_ID, DAY_ID)
+
+    expect(notifyShiftCancelled).not.toHaveBeenCalled()
+  })
+
   it('surfaces DB error', async () => {
-    const chain = makeChain({ data: null, error: { message: 'DB error' } })
-    const from = vi.fn().mockReturnValue(chain)
+    const existingChain = makeChain({ data: null, error: null })
+    const deleteChain = makeChain({ data: null, error: { message: 'DB error' } })
+    const from = vi.fn().mockReturnValueOnce(existingChain).mockReturnValueOnce(deleteChain)
     mockClient(from)
 
     const result = await deleteShift(SHIFT_ID, DAY_ID)

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/morning-brief",
       "schedule": "0 5 * * *"
+    },
+    {
+      "path": "/api/cron/shift-reminders",
+      "schedule": "0 17 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `lib/shift-notifications.ts` with helpers (`notifyShiftAssigned`, `notifyShiftUpdatedSameUser`, `notifyShiftReassigned`, `notifyShiftCancelled`) that insert rows into the `notifications` table via service client
- Wires notifications into `createShift`, `updateShift`, `deleteShift` — skips self-notifications and skips entirely when `staff_schedule` flag is off; fetches old `user_id` in `updateShift` to detect reassignments
- Adds `lib/shift-reminders-cron.ts` + `app/api/cron/shift-reminders/route.ts`: iterates tenants with `staff_schedule` on, finds tomorrow's shifts, inserts a reminder notification per assignee
- Registers `/api/cron/shift-reminders` at `0 17 * * *` UTC in `vercel.json`
- Extends `tests/actions/shifts.test.ts` with notification assertion cases for all three mutating actions

## Test plan

- [ ] CI unit tests pass (notification functions are mocked; `from` call order updated for `updateShift`/`deleteShift` pre-fetch)
- [ ] CI typecheck passes
- [ ] CI lint passes

Closes #170

https://claude.ai/code/session_014M5HRm2SebCzL3uSJcuhmW

---
_Generated by [Claude Code](https://claude.ai/code/session_014M5HRm2SebCzL3uSJcuhmW)_