### PR TITLE
feat(daily-brief): stream generation via useObject

### DIFF
--- a/app/api/daily-brief/stream/route.ts
+++ b/app/api/daily-brief/stream/route.ts
@@ -1,0 +1,125 @@
+import { after } from 'next/server'
+import { streamObject } from 'ai'
+import { gateway } from '@ai-sdk/gateway'
+import { createTenantClient } from '@/lib/supabase-server'
+import { getTenantFromHeaders } from '@/lib/tenant'
+import { getUserRole } from '@/lib/membership'
+import { getUser } from '@/app/actions/auth'
+import { isFeatureEnabled } from '@/app/actions/feature-flags'
+import { dailyBriefRateLimit } from '@/lib/rate-limit'
+import { ensureDayExists } from '@/app/actions/days'
+import {
+  getProgramItemsForDay,
+  getReservationsForDay,
+  getBreakfastConfigsForDay,
+  getDayNotesForDay,
+} from '@/app/[tenant]/day/[date]/queries'
+import { getWeatherForDay } from '@/app/actions/weather'
+import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
+import {
+  buildCovers,
+  buildAllergenRollup,
+  llmPayload,
+  BRIEF_SYSTEM,
+  DAILY_BRIEF_MODEL_ID,
+  PROMPT_VERSION,
+} from '@/lib/daily-brief-generate'
+
+export async function POST(request: Request) {
+  let tenantId: string
+  try {
+    const tenant = await getTenantFromHeaders()
+    tenantId = tenant.id
+  } catch {
+    return new Response('Tenant context required', { status: 400 })
+  }
+
+  if (!(await isFeatureEnabled(tenantId, 'daily_brief'))) {
+    return new Response(JSON.stringify({ error: 'Feature disabled' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const user = await getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+  const role = await getUserRole(tenantId)
+  if (role !== 'editor') return new Response('Forbidden', { status: 403 })
+
+  let body: { dateIso?: string }
+  try {
+    body = (await request.json()) as { dateIso?: string }
+  } catch {
+    return new Response('Invalid JSON', { status: 400 })
+  }
+  const { dateIso } = body
+  if (!dateIso || typeof dateIso !== 'string') {
+    return new Response('Missing dateIso', { status: 400 })
+  }
+
+  const rl = await dailyBriefRateLimit(tenantId, dateIso)
+  if (!rl.success) {
+    return new Response(JSON.stringify({ error: 'Rate limit reached. Try again tomorrow.' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const dayResult = await ensureDayExists(dateIso)
+  if (!dayResult.success) return new Response(dayResult.error, { status: 500 })
+  const dayId = dayResult.data.id
+
+  const [activities, reservations, breakfasts, dayNotes, weather] = await Promise.all([
+    getProgramItemsForDay(tenantId, dayId),
+    getReservationsForDay(tenantId, dayId),
+    getBreakfastConfigsForDay(tenantId, dayId),
+    getDayNotesForDay(tenantId, dayId),
+    getWeatherForDay(dateIso),
+  ])
+
+  const covers = buildCovers(activities, reservations, breakfasts)
+  const allergenRollup = buildAllergenRollup(activities, reservations, breakfasts)
+  const payload = llmPayload({
+    dateIso,
+    weather,
+    activities,
+    reservations,
+    breakfasts,
+    dayNotes,
+    covers,
+    allergenRollup,
+  })
+
+  const result = streamObject({
+    model: gateway(DAILY_BRIEF_MODEL_ID),
+    schema: dailyBriefContentSchema,
+    system: BRIEF_SYSTEM,
+    prompt: `Produce a daily briefing from this JSON. The covers and allergenRollup values in the input are authoritative — echo them back verbatim:\n${JSON.stringify(payload)}`,
+    maxOutputTokens: 2048,
+  })
+
+  // Persist the final validated object after the stream completes.
+  // `after()` runs after the streaming response is fully sent to the client.
+  after(async () => {
+    try {
+      const streamed = await result.object
+      // Override LLM-produced covers/allergenRollup with deterministically computed values
+      const content = { ...streamed, covers, allergenRollup }
+      const { supabase } = await createTenantClient()
+      const row: Record<string, unknown> = {
+        tenant_id: tenantId,
+        day_id: dayId,
+        content,
+        generated_at: new Date().toISOString(),
+        model: DAILY_BRIEF_MODEL_ID,
+        prompt_version: PROMPT_VERSION,
+        generated_by: user.id,
+      }
+      await supabase.from('daily_brief').upsert(row as never, { onConflict: 'tenant_id,day_id' })
+    } catch {
+      // best-effort persist; client refreshes on finish
+    }
+  })
+
+  return result.toTextStreamResponse()
+}

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -5,8 +5,9 @@ import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
+import { useObject } from '@ai-sdk/react'
 import { Button } from '@/components/ui/button'
-import { generateDailyBrief } from '@/app/actions/daily-brief'
+import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
 import type { DailyBriefRecord } from '@/types/daily-brief'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
 
@@ -33,41 +34,66 @@ export function DailyBriefCard({
   const router = useRouter()
   const [brief, setBrief] = useState<DailyBriefRecord | null>(initialBrief)
   const [stale, setStale] = useState(initialBriefStale)
-  const [loading, setLoading] = useState(false)
   const lastRegenerateAt = useRef(0)
+
+  const {
+    object: streamedObject,
+    submit,
+    isLoading,
+    error: streamError,
+  } = useObject({
+    api: '/api/daily-brief/stream',
+    schema: dailyBriefContentSchema,
+    onFinish({ object }) {
+      if (object) {
+        setBrief({
+          id: '',
+          content: {
+            headline: object.headline ?? '',
+            summary: object.summary ?? '',
+            covers: object.covers ?? { breakfast: 0, activities: 0, reservations: 0 },
+            vipNotes: object.vipNotes ?? [],
+            allergenRollup: object.allergenRollup ?? [],
+            risks: object.risks ?? [],
+            suggestedActions: object.suggestedActions ?? [],
+          },
+          generated_at: new Date().toISOString(),
+          model: '',
+          prompt_version: 'v1',
+        })
+        setStale(false)
+        toast.success(t('generated'))
+        router.refresh()
+      }
+    },
+    onError(err) {
+      toast.error(err.message || 'Brief generation failed.')
+    },
+  })
 
   useEffect(() => {
     setBrief(initialBrief)
     setStale(initialBriefStale)
   }, [initialBrief, initialBriefStale, dayId])
 
-  const runRegenerate = useCallback(async () => {
+  useEffect(() => {
+    if (streamError) toast.error(streamError.message || 'Brief generation failed.')
+  }, [streamError])
+
+  const runRegenerate = useCallback(() => {
     const now = Date.now()
     if (now - lastRegenerateAt.current < REGENERATE_DEBOUNCE_MS) {
       toast.message(t('debounced'))
       return
     }
     lastRegenerateAt.current = now
-
-    setLoading(true)
-    try {
-      const result = await generateDailyBrief(dateIso)
-      if (!result.success) {
-        toast.error(result.error)
-        return
-      }
-      setBrief(result.data)
-      setStale(false)
-      toast.success(t('generated'))
-      router.refresh()
-    } finally {
-      setLoading(false)
-    }
-  }, [dateIso, router, t])
+    submit({ dateIso })
+  }, [dateIso, submit, t])
 
   const copyMarkdown = useCallback(() => {
-    if (!brief) return
-    const md = formatDailyBriefMarkdown(brief.content)
+    const content = brief?.content
+    if (!content) return
+    const md = formatDailyBriefMarkdown(content)
     void navigator.clipboard.writeText(md).then(
       () => toast.success(t('copied')),
       () => toast.error(t('copyFailed'))
@@ -75,6 +101,8 @@ export function DailyBriefCard({
   }, [brief, t])
 
   const hasBrief = brief !== null
+  const streaming = isLoading && !hasBrief
+  const covers = streamedObject?.covers
 
   return (
     <section className="bg-card text-card-foreground overflow-hidden rounded-xl border shadow-sm">
@@ -98,10 +126,10 @@ export function DailyBriefCard({
               type="button"
               variant="outline"
               size="sm"
-              onClick={() => void runRegenerate()}
-              disabled={loading}
+              onClick={runRegenerate}
+              disabled={isLoading}
             >
-              {loading ? (
+              {isLoading ? (
                 <Loader2 className="mr-1 h-4 w-4 animate-spin" />
               ) : (
                 <RefreshCw className="mr-1 h-4 w-4" />
@@ -113,15 +141,15 @@ export function DailyBriefCard({
       </div>
 
       <div className="space-y-3 p-4">
-        {stale && isEditor && (
+        {stale && isEditor && !isLoading && (
           <div className="flex items-center justify-between gap-2 rounded-md border border-amber-200/60 bg-amber-50 px-2.5 py-2 dark:border-amber-900/50 dark:bg-amber-950/40">
             <p className="text-xs text-amber-800/90 dark:text-amber-200/90">{t('stale')}</p>
             <Button
               type="button"
               size="xs"
               variant="outline"
-              onClick={() => void runRegenerate()}
-              disabled={loading}
+              onClick={runRegenerate}
+              disabled={isLoading}
               className="shrink-0"
             >
               <RefreshCw className="mr-1 h-3 w-3" />
@@ -132,18 +160,52 @@ export function DailyBriefCard({
 
         {briefIsEmpty && <p className="text-muted-foreground text-sm">{t('empty')}</p>}
 
-        {!hasBrief && !briefIsEmpty && !loading && (
+        {!hasBrief && !briefIsEmpty && !isLoading && (
           <p className="text-muted-foreground text-sm">{t('emptyViewer')}</p>
         )}
 
-        {loading && !hasBrief && (
-          <p className="text-muted-foreground flex items-center gap-2 text-sm">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {t('generating')}
-          </p>
+        {/* Progressive streaming skeleton */}
+        {streaming && (
+          <div className="space-y-3">
+            {streamedObject?.headline ? (
+              <p className="animate-in fade-in text-base leading-snug font-semibold duration-300">
+                {streamedObject.headline}
+              </p>
+            ) : (
+              <div className="bg-muted h-5 w-3/4 animate-pulse rounded" />
+            )}
+
+            {streamedObject?.summary ? (
+              <p className="text-muted-foreground animate-in fade-in text-sm whitespace-pre-wrap duration-300">
+                {streamedObject.summary}
+              </p>
+            ) : (
+              <div className="space-y-1">
+                <div className="bg-muted h-4 w-full animate-pulse rounded" />
+                <div className="bg-muted h-4 w-5/6 animate-pulse rounded" />
+              </div>
+            )}
+
+            {covers && (
+              <div className="animate-in fade-in grid grid-cols-3 gap-2 text-center text-sm duration-300">
+                <div className="bg-muted/50 rounded-md py-2">
+                  <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
+                  <div className="font-semibold tabular-nums">{covers.breakfast ?? '—'}</div>
+                </div>
+                <div className="bg-muted/50 rounded-md py-2">
+                  <div className="text-muted-foreground text-xs">{t('coversActivities')}</div>
+                  <div className="font-semibold tabular-nums">{covers.activities ?? '—'}</div>
+                </div>
+                <div className="bg-muted/50 rounded-md py-2">
+                  <div className="text-muted-foreground text-xs">{t('coversReservations')}</div>
+                  <div className="font-semibold tabular-nums">{covers.reservations ?? '—'}</div>
+                </div>
+              </div>
+            )}
+          </div>
         )}
 
-        {brief && (
+        {hasBrief && (
           <div className="space-y-3">
             <div>
               <p className="text-base leading-snug font-semibold">{brief.content.headline}</p>
@@ -179,12 +241,14 @@ export function DailyBriefCard({
                 <AllergenBlock rollup={brief.content.allergenRollup} t={t} />
                 <ListBlock title={t('risks')} items={brief.content.risks} />
                 <ListBlock title={t('actions')} items={brief.content.suggestedActions} />
-                <p className="text-muted-foreground pt-1 text-xs">
-                  {t('meta', {
-                    time: new Date(brief.generated_at).toLocaleString(),
-                    model: brief.model,
-                  })}
-                </p>
+                {brief.generated_at && brief.model && (
+                  <p className="text-muted-foreground pt-1 text-xs">
+                    {t('meta', {
+                      time: new Date(brief.generated_at).toLocaleString(),
+                      model: brief.model,
+                    })}
+                  </p>
+                )}
               </div>
             </details>
           </div>

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -5,10 +5,10 @@ import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
-import { useObject } from '@ai-sdk/react'
+import { experimental_useObject as useObject } from '@ai-sdk/react'
 import { Button } from '@/components/ui/button'
 import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
-import type { DailyBriefRecord } from '@/types/daily-brief'
+import type { DailyBriefContent, DailyBriefRecord } from '@/types/daily-brief'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
 
 const REGENERATE_DEBOUNCE_MS = 2000
@@ -44,7 +44,7 @@ export function DailyBriefCard({
   } = useObject({
     api: '/api/daily-brief/stream',
     schema: dailyBriefContentSchema,
-    onFinish({ object }) {
+    onFinish({ object }: { object: DailyBriefContent | undefined }) {
       if (object) {
         setBrief({
           id: '',
@@ -66,7 +66,7 @@ export function DailyBriefCard({
         router.refresh()
       }
     },
-    onError(err) {
+    onError(err: Error) {
       toast.error(err.message || 'Brief generation failed.')
     },
   })

--- a/components/day-info-banner.tsx
+++ b/components/day-info-banner.tsx
@@ -5,13 +5,13 @@ import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import { useObject } from '@ai-sdk/react'
+import { experimental_useObject as useObject } from '@ai-sdk/react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
 import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
 import type { WeatherData } from '@/app/actions/weather'
-import type { DailyBriefRecord } from '@/types/daily-brief'
+import type { DailyBriefContent, DailyBriefRecord } from '@/types/daily-brief'
 
 const REGENERATE_DEBOUNCE_MS = 2000
 
@@ -107,7 +107,7 @@ export function DayInfoBanner({
   } = useObject({
     api: '/api/daily-brief/stream',
     schema: dailyBriefContentSchema,
-    onFinish({ object }) {
+    onFinish({ object }: { object: DailyBriefContent | undefined }) {
       if (object) {
         setBrief({
           // id and generated_at will be refreshed from server; use placeholders
@@ -131,7 +131,7 @@ export function DayInfoBanner({
         router.refresh()
       }
     },
-    onError(err) {
+    onError(err: Error) {
       toast.error(err.message || 'Brief generation failed.')
     },
   })

--- a/components/day-info-banner.tsx
+++ b/components/day-info-banner.tsx
@@ -5,10 +5,11 @@ import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
+import { useObject } from '@ai-sdk/react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { generateDailyBrief } from '@/app/actions/daily-brief'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
+import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
 import type { WeatherData } from '@/app/actions/weather'
 import type { DailyBriefRecord } from '@/types/daily-brief'
 
@@ -72,6 +73,12 @@ function AllergenBlock({
   )
 }
 
+/** Fades in a section when it first receives content during streaming. */
+function StreamSection({ show, children }: { show: boolean; children: React.ReactNode }) {
+  if (!show) return null
+  return <div className="animate-in fade-in duration-300">{children}</div>
+}
+
 export function DayInfoBanner({
   weather,
   showWeather,
@@ -88,38 +95,61 @@ export function DayInfoBanner({
   const router = useRouter()
   const [brief, setBrief] = useState<DailyBriefRecord | null>(initialBrief)
   const [stale, setStale] = useState(briefStale)
-  const [loading, setLoading] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
   const lastGenerateAt = useRef(0)
-  // One-shot guard so we never auto-fire generation more than once per
-  // (dayId, mount) pair.
   const autoFiredFor = useRef<string | null>(null)
 
-  const hasWeather = showWeather && weather !== null
-  const hasBrief = brief !== null
+  const {
+    object: streamedObject,
+    submit,
+    isLoading,
+    error: streamError,
+  } = useObject({
+    api: '/api/daily-brief/stream',
+    schema: dailyBriefContentSchema,
+    onFinish({ object }) {
+      if (object) {
+        setBrief({
+          // id and generated_at will be refreshed from server; use placeholders
+          id: '',
+          content: {
+            headline: object.headline ?? '',
+            summary: object.summary ?? '',
+            covers: object.covers ?? { breakfast: 0, activities: 0, reservations: 0 },
+            vipNotes: object.vipNotes ?? [],
+            allergenRollup: object.allergenRollup ?? [],
+            risks: object.risks ?? [],
+            suggestedActions: object.suggestedActions ?? [],
+          },
+          generated_at: new Date().toISOString(),
+          model: '',
+          prompt_version: 'v1',
+        })
+        setStale(false)
+        toast.success(t('generated'))
+        // Refresh to hydrate from DB (gets real id, model, generated_at)
+        router.refresh()
+      }
+    },
+    onError(err) {
+      toast.error(err.message || 'Brief generation failed.')
+    },
+  })
 
-  const runRegenerate = useCallback(async () => {
+  useEffect(() => {
+    setBrief(initialBrief)
+    setStale(briefStale)
+  }, [initialBrief, briefStale, dayId])
+
+  const runGenerate = useCallback(() => {
     const now = Date.now()
     if (now - lastGenerateAt.current < REGENERATE_DEBOUNCE_MS) {
       toast.message(t('debounced'))
       return
     }
     lastGenerateAt.current = now
-    setLoading(true)
-    try {
-      const result = await generateDailyBrief(dateIso)
-      if (!result.success) {
-        toast.error(result.error)
-        return
-      }
-      setBrief(result.data)
-      setStale(false)
-      toast.success(t('generated'))
-      router.refresh()
-    } finally {
-      setLoading(false)
-    }
-  }, [dateIso, router, t])
+    submit({ dateIso })
+  }, [dateIso, submit, t])
 
   const copyMarkdown = useCallback(() => {
     if (!brief) return
@@ -130,18 +160,28 @@ export function DayInfoBanner({
     )
   }, [brief, t])
 
-  // Auto-generate a brief when the page loads with no brief yet for an editor.
-  // The previous server-side ensureDailyBrief call blocked rendering on the
-  // LLM round-trip; now the page renders fast and the brief streams in.
+  // Auto-generate when the page loads with no brief yet (editor only).
   useEffect(() => {
     if (!showBrief || !isEditor) return
     if (brief) return
     if (!dayHasContent) return
-    if (loading) return
+    if (isLoading) return
     if (autoFiredFor.current === dayId) return
     autoFiredFor.current = dayId
-    void runRegenerate()
-  }, [showBrief, isEditor, brief, dayHasContent, loading, dayId, runRegenerate])
+    runGenerate()
+  }, [showBrief, isEditor, brief, dayHasContent, isLoading, dayId, runGenerate])
+
+  // Dismiss stream error on re-render if brief was set
+  useEffect(() => {
+    if (streamError) toast.error(streamError.message || 'Brief generation failed.')
+  }, [streamError, t])
+
+  const hasWeather = showWeather && weather !== null
+  const hasBrief = brief !== null
+  // Show streaming partial content while loading and no settled brief
+  const streaming = isLoading && !hasBrief
+  const streamedHeadline = streamedObject?.headline
+  const streamedSummary = streamedObject?.summary
 
   if (!hasWeather && !showBrief) return null
 
@@ -178,7 +218,34 @@ export function DayInfoBanner({
           </div>
         )}
 
-        {showBrief && !hasBrief && !briefIsEmpty && !hasWeather && <div className="flex-1" />}
+        {showBrief && streaming && (
+          <div
+            className={`min-w-0 flex-1 ${hasWeather ? 'border-l pl-3' : ''}`}
+            onClick={() => setDialogOpen(true)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && setDialogOpen(true)}
+          >
+            {streamedHeadline ? (
+              <p className="animate-in fade-in truncate text-sm font-medium duration-300">
+                {streamedHeadline}
+              </p>
+            ) : (
+              <div className="bg-muted h-4 w-40 animate-pulse rounded" />
+            )}
+            {streamedSummary ? (
+              <p className="text-muted-foreground animate-in fade-in line-clamp-1 text-xs duration-300">
+                {streamedSummary}
+              </p>
+            ) : (
+              <div className="bg-muted mt-1 h-3 w-24 animate-pulse rounded" />
+            )}
+          </div>
+        )}
+
+        {showBrief && !hasBrief && !streaming && !briefIsEmpty && !hasWeather && (
+          <div className="flex-1" />
+        )}
 
         {showBrief && briefIsEmpty && (
           <div className={`min-w-0 flex-1 ${hasWeather ? 'border-l pl-3' : ''}`}>
@@ -186,7 +253,7 @@ export function DayInfoBanner({
           </div>
         )}
 
-        {showBrief && hasBrief && (
+        {showBrief && (hasBrief || streaming) && (
           <Button
             type="button"
             variant="ghost"
@@ -194,7 +261,7 @@ export function DayInfoBanner({
             className="text-muted-foreground hover:text-foreground shrink-0"
             onClick={() => setDialogOpen(true)}
           >
-            {loading ? (
+            {isLoading ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : stale ? (
               <RefreshCw className="h-4 w-4 text-amber-500" />
@@ -205,7 +272,7 @@ export function DayInfoBanner({
         )}
       </div>
 
-      {showBrief && hasBrief && (
+      {showBrief && (hasBrief || streaming) && (
         <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
           <DialogContent className="max-h-[80vh] max-w-lg overflow-y-auto">
             <DialogHeader>
@@ -216,7 +283,7 @@ export function DayInfoBanner({
             </DialogHeader>
 
             <div className="space-y-4">
-              {stale && (
+              {stale && !isLoading && (
                 <p className="rounded-md border border-amber-200/60 bg-amber-50 px-2.5 py-2 text-xs text-amber-800/90 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-200/90">
                   {t('stale')}
                 </p>
@@ -234,10 +301,10 @@ export function DayInfoBanner({
                     type="button"
                     size="sm"
                     variant="outline"
-                    onClick={() => void runRegenerate()}
-                    disabled={loading}
+                    onClick={runGenerate}
+                    disabled={isLoading}
                   >
-                    {loading ? (
+                    {isLoading ? (
                       <Loader2 className="mr-1 h-4 w-4 animate-spin" />
                     ) : (
                       <RefreshCw className="mr-1 h-4 w-4" />
@@ -247,67 +314,127 @@ export function DayInfoBanner({
                 )}
               </div>
 
-              {loading && (
-                <p className="text-muted-foreground flex items-center gap-2 text-sm">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  {t('generating')}
-                </p>
-              )}
+              {/* Progressive streaming content */}
+              {isLoading && <StreamingBriefContent object={streamedObject} t={t} />}
 
-              {brief && (
-                <div className="space-y-3">
-                  <div>
-                    <p className="text-base leading-snug font-semibold">{brief.content.headline}</p>
-                    <p className="text-muted-foreground mt-2 text-sm whitespace-pre-wrap">
-                      {brief.content.summary}
-                    </p>
-                  </div>
-
-                  <div className="grid grid-cols-3 gap-2 text-center text-sm">
-                    <div className="bg-muted/50 rounded-md py-2">
-                      <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
-                      <div className="font-semibold tabular-nums">
-                        {brief.content.covers.breakfast}
-                      </div>
-                    </div>
-                    <div className="bg-muted/50 rounded-md py-2">
-                      <div className="text-muted-foreground text-xs">{t('coversActivities')}</div>
-                      <div className="font-semibold tabular-nums">
-                        {brief.content.covers.activities}
-                      </div>
-                    </div>
-                    <div className="bg-muted/50 rounded-md py-2">
-                      <div className="text-muted-foreground text-xs">{t('coversReservations')}</div>
-                      <div className="font-semibold tabular-nums">
-                        {brief.content.covers.reservations}
-                      </div>
-                    </div>
-                  </div>
-
-                  <details className="group text-sm">
-                    <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer list-none items-center gap-1 py-1 font-medium [&::-webkit-details-marker]:hidden">
-                      <span className="group-open:hidden">{t('more')}</span>
-                      <span className="hidden group-open:inline">{t('less')}</span>
-                    </summary>
-                    <div className="space-y-3 pt-2">
-                      <ListBlock title={t('vip')} items={brief.content.vipNotes} />
-                      <AllergenBlock rollup={brief.content.allergenRollup} t={t} />
-                      <ListBlock title={t('risks')} items={brief.content.risks} />
-                      <ListBlock title={t('actions')} items={brief.content.suggestedActions} />
-                      <p className="text-muted-foreground pt-1 text-xs">
-                        {t('meta', {
-                          time: new Date(brief.generated_at).toLocaleString(),
-                          model: brief.model,
-                        })}
-                      </p>
-                    </div>
-                  </details>
-                </div>
-              )}
+              {/* Settled brief */}
+              {hasBrief && !isLoading && <SettledBriefContent brief={brief} t={t} />}
             </div>
           </DialogContent>
         </Dialog>
       )}
     </>
+  )
+}
+
+type StreamPartial =
+  | {
+      headline?: string
+      summary?: string
+      covers?: { breakfast?: number; activities?: number; reservations?: number }
+    }
+  | undefined
+
+function StreamingBriefContent({
+  object,
+  t,
+}: {
+  object: StreamPartial
+  t: ReturnType<typeof useTranslations<'Tenant.dailyBrief'>>
+}) {
+  const covers = object?.covers
+  return (
+    <div className="space-y-3">
+      {object?.headline ? (
+        <p className="animate-in fade-in text-base leading-snug font-semibold duration-300">
+          {object.headline}
+        </p>
+      ) : (
+        <div className="bg-muted h-5 w-3/4 animate-pulse rounded" />
+      )}
+
+      {object?.summary ? (
+        <p className="text-muted-foreground animate-in fade-in text-sm whitespace-pre-wrap duration-300">
+          {object.summary}
+        </p>
+      ) : (
+        <div className="space-y-1">
+          <div className="bg-muted h-4 w-full animate-pulse rounded" />
+          <div className="bg-muted h-4 w-5/6 animate-pulse rounded" />
+        </div>
+      )}
+
+      <StreamSection show={Boolean(covers)}>
+        <div className="grid grid-cols-3 gap-2 text-center text-sm">
+          <div className="bg-muted/50 rounded-md py-2">
+            <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
+            <div className="font-semibold tabular-nums">{covers?.breakfast ?? '—'}</div>
+          </div>
+          <div className="bg-muted/50 rounded-md py-2">
+            <div className="text-muted-foreground text-xs">{t('coversActivities')}</div>
+            <div className="font-semibold tabular-nums">{covers?.activities ?? '—'}</div>
+          </div>
+          <div className="bg-muted/50 rounded-md py-2">
+            <div className="text-muted-foreground text-xs">{t('coversReservations')}</div>
+            <div className="font-semibold tabular-nums">{covers?.reservations ?? '—'}</div>
+          </div>
+        </div>
+      </StreamSection>
+    </div>
+  )
+}
+
+function SettledBriefContent({
+  brief,
+  t,
+}: {
+  brief: DailyBriefRecord
+  t: ReturnType<typeof useTranslations<'Tenant.dailyBrief'>>
+}) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <p className="text-base leading-snug font-semibold">{brief.content.headline}</p>
+        <p className="text-muted-foreground mt-2 text-sm whitespace-pre-wrap">
+          {brief.content.summary}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 text-center text-sm">
+        <div className="bg-muted/50 rounded-md py-2">
+          <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
+          <div className="font-semibold tabular-nums">{brief.content.covers.breakfast}</div>
+        </div>
+        <div className="bg-muted/50 rounded-md py-2">
+          <div className="text-muted-foreground text-xs">{t('coversActivities')}</div>
+          <div className="font-semibold tabular-nums">{brief.content.covers.activities}</div>
+        </div>
+        <div className="bg-muted/50 rounded-md py-2">
+          <div className="text-muted-foreground text-xs">{t('coversReservations')}</div>
+          <div className="font-semibold tabular-nums">{brief.content.covers.reservations}</div>
+        </div>
+      </div>
+
+      <details className="group text-sm">
+        <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer list-none items-center gap-1 py-1 font-medium [&::-webkit-details-marker]:hidden">
+          <span className="group-open:hidden">{t('more')}</span>
+          <span className="hidden group-open:inline">{t('less')}</span>
+        </summary>
+        <div className="space-y-3 pt-2">
+          <ListBlock title={t('vip')} items={brief.content.vipNotes} />
+          <AllergenBlock rollup={brief.content.allergenRollup} t={t} />
+          <ListBlock title={t('risks')} items={brief.content.risks} />
+          <ListBlock title={t('actions')} items={brief.content.suggestedActions} />
+          {brief.generated_at && brief.model && (
+            <p className="text-muted-foreground pt-1 text-xs">
+              {t('meta', {
+                time: new Date(brief.generated_at).toLocaleString(),
+                model: brief.model,
+              })}
+            </p>
+          )}
+        </div>
+      </details>
+    </div>
   )
 }

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -1,6 +1,5 @@
 import { generateObject } from 'ai'
 import { gateway } from '@ai-sdk/gateway'
-import { z } from 'zod'
 import type { AppSupabaseClient } from '@/app/[tenant]/day/[date]/queries'
 import type { WeatherData } from '@/app/actions/weather'
 import type { ActionResponse } from '@/types/actions'
@@ -13,7 +12,10 @@ import type {
 import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
 
-const PROMPT_VERSION = 'v1'
+export { narrativeSchema, dailyBriefContentSchema } from '@/lib/daily-brief-schema'
+import { narrativeSchema } from '@/lib/daily-brief-schema'
+
+export const PROMPT_VERSION = 'v1'
 export const DAILY_BRIEF_MODEL_ID = 'openai/gpt-5.4' as const
 const NOTE_MAX = 200
 
@@ -21,43 +23,14 @@ function hasGatewayAuth(): boolean {
   return Boolean(process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN)
 }
 
-const narrativeSchema = z.object({
-  headline: z.string(),
-  summary: z.string(),
-  vipNotes: z.array(z.string()),
-  risks: z.array(z.string()),
-  suggestedActions: z.array(z.string()),
-})
-
-export const dailyBriefContentSchema = z.object({
-  headline: z.string(),
-  summary: z.string(),
-  covers: z.object({
-    breakfast: z.number(),
-    activities: z.number(),
-    reservations: z.number(),
-  }),
-  vipNotes: z.array(z.string()),
-  allergenRollup: z.array(
-    z.object({
-      code: z.string(),
-      inActivities: z.number(),
-      inReservations: z.number(),
-      inBreakfast: z.number(),
-    })
-  ),
-  risks: z.array(z.string()),
-  suggestedActions: z.array(z.string()),
-})
-
-function truncateNote(text: string | null | undefined): string | undefined {
+export function truncateNote(text: string | null | undefined): string | undefined {
   if (!text?.trim()) return undefined
   const t = text.trim()
   if (t.length <= NOTE_MAX) return t
   return `${t.slice(0, NOTE_MAX)}…`
 }
 
-function buildCovers(
+export function buildCovers(
   activities: Activity[],
   reservations: Reservation[],
   breakfasts: BreakfastConfiguration[]
@@ -69,7 +42,7 @@ function buildCovers(
   }
 }
 
-function buildAllergenRollup(
+export function buildAllergenRollup(
   activities: Activity[],
   reservations: Reservation[],
   breakfasts: BreakfastConfiguration[]
@@ -108,7 +81,7 @@ function buildAllergenRollup(
     .sort((x, y) => x.code.localeCompare(y.code))
 }
 
-function llmPayload(args: {
+export function llmPayload(args: {
   dateIso: string
   weather: WeatherData | null
   activities: Activity[]
@@ -159,7 +132,7 @@ function llmPayload(args: {
   }
 }
 
-const BRIEF_SYSTEM = `You write concise operational day briefings for venue staff.
+export const BRIEF_SYSTEM = `You write concise operational day briefings for venue staff.
 Rules:
 - Use British English spelling if unsure; keep tone professional and calm.
 - Do not invent numbers. Covers and allergen counts in the input are authoritative; reflect them in prose only as appropriate.

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -1,5 +1,6 @@
 import { generateObject } from 'ai'
 import { gateway } from '@ai-sdk/gateway'
+import type { z } from 'zod'
 import type { AppSupabaseClient } from '@/app/[tenant]/day/[date]/queries'
 import type { WeatherData } from '@/app/actions/weather'
 import type { ActionResponse } from '@/types/actions'
@@ -11,9 +12,9 @@ import type {
 } from '@/types/daily-brief'
 import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
+import { narrativeSchema, dailyBriefContentSchema } from '@/lib/daily-brief-schema'
 
-export { narrativeSchema, dailyBriefContentSchema } from '@/lib/daily-brief-schema'
-import { narrativeSchema } from '@/lib/daily-brief-schema'
+export { narrativeSchema, dailyBriefContentSchema }
 
 export const PROMPT_VERSION = 'v1'
 export const DAILY_BRIEF_MODEL_ID = 'openai/gpt-5.4' as const

--- a/lib/daily-brief-schema.ts
+++ b/lib/daily-brief-schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+export const narrativeSchema = z.object({
+  headline: z.string(),
+  summary: z.string(),
+  vipNotes: z.array(z.string()),
+  risks: z.array(z.string()),
+  suggestedActions: z.array(z.string()),
+})
+
+export const dailyBriefContentSchema = z.object({
+  headline: z.string(),
+  summary: z.string(),
+  covers: z.object({
+    breakfast: z.number(),
+    activities: z.number(),
+    reservations: z.number(),
+  }),
+  vipNotes: z.array(z.string()),
+  allergenRollup: z.array(
+    z.object({
+      code: z.string(),
+      inActivities: z.number(),
+      inReservations: z.number(),
+      inBreakfast: z.number(),
+    })
+  ),
+  risks: z.array(z.string()),
+  suggestedActions: z.array(z.string()),
+})

--- a/middleware.ts
+++ b/middleware.ts
@@ -236,5 +236,9 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next|[\\w-]+\\.\\w+).*)', '/api/mutations/:path*'],
+  matcher: [
+    '/((?!api|_next|[\\w-]+\\.\\w+).*)',
+    '/api/mutations/:path*',
+    '/api/daily-brief/:path*',
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@ai-sdk/gateway": "^3.0.104",
+    "@ai-sdk/react": "^3.0.179",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-label": "^2.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ai-sdk/gateway':
         specifier: ^3.0.104
         version: 3.0.104(zod@4.3.6)
+      '@ai-sdk/react':
+        specifier: ^3.0.179
+        version: 3.0.179(react@19.1.0)(zod@4.3.6)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.1.0))
@@ -195,15 +198,37 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.112':
+    resolution: {integrity: sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.23':
     resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.179':
+    resolution: {integrity: sha512-wq3gqDrwi6QvwHQuVrTpjeUQI/LHZ5ysokWTIS1hOFw0UIIX8eVpri5iVvqQuq5CeQw/6bYXSI15SfMtZJixpQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2303,6 +2328,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  ai@6.0.177:
+    resolution: {integrity: sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -4112,6 +4143,11 @@ packages:
   svix@1.90.0:
     resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4127,6 +4163,10 @@ packages:
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
   tinybench@2.9.0:
@@ -4464,6 +4504,13 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
+  '@ai-sdk/gateway@3.0.112(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -4471,9 +4518,30 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.179(react@19.1.0)(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      ai: 6.0.177(zod@4.3.6)
+      react: 19.1.0
+      swr: 2.4.1(react@19.1.0)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -6472,6 +6540,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
+  ai@6.0.177(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.112(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -8466,6 +8542,12 @@ snapshots:
       standardwebhooks: 1.0.0
       uuid: 10.0.0
 
+  swr@2.4.1(react@19.1.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.1.0
+      use-sync-external-store: 1.6.0(react@19.1.0)
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.3.0: {}
@@ -8482,6 +8564,8 @@ snapshots:
       minizlib: 3.0.2
       mkdirp: 3.0.1
       yallist: 5.0.0
+
+  throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/tests/api/daily-brief-stream.test.ts
+++ b/tests/api/daily-brief-stream.test.ts
@@ -120,10 +120,12 @@ describe('POST /api/daily-brief/stream', () => {
     const response = await POST(makeRequest())
     expect(response.status).toBe(200)
     expect(streamObject).toHaveBeenCalledOnce()
-    const call = vi.mocked(streamObject).mock.calls[0][0]
-    expect(call.schema).toBeDefined()
-    expect(typeof call.prompt).toBe('string')
-    expect(call.prompt).toContain('daily briefing')
+    expect(streamObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema: expect.anything(),
+        prompt: expect.stringContaining('daily briefing'),
+      })
+    )
   })
 
   it('returns 403 when feature flag is disabled', async () => {

--- a/tests/api/daily-brief-stream.test.ts
+++ b/tests/api/daily-brief-stream.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/app/actions/feature-flags', () => ({
+  isFeatureEnabled: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantFromHeaders: vi.fn().mockResolvedValue({ id: 'tenant-1', slug: 'test' }),
+}))
+
+vi.mock('@/app/actions/auth', () => ({
+  getUser: vi.fn().mockResolvedValue({ id: 'user-1', email: 'editor@test.com' }),
+}))
+
+vi.mock('@/lib/membership', () => ({
+  getUserRole: vi.fn().mockResolvedValue('editor'),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  dailyBriefRateLimit: vi.fn().mockResolvedValue({ success: true }),
+}))
+
+vi.mock('@/app/actions/days', () => ({
+  ensureDayExists: vi.fn().mockResolvedValue({ success: true, data: { id: 'day-1' } }),
+}))
+
+vi.mock('@/app/[tenant]/day/[date]/queries', () => ({
+  getProgramItemsForDay: vi
+    .fn()
+    .mockResolvedValue([
+      { id: 'a-1', expected_covers: 10, allergens: ['gluten'], updated_at: '2026-05-09T08:00:00Z' },
+    ]),
+  getReservationsForDay: vi
+    .fn()
+    .mockResolvedValue([
+      { id: 'r-1', guest_count: 4, allergens: [], updated_at: '2026-05-09T08:00:00Z' },
+    ]),
+  getBreakfastConfigsForDay: vi.fn().mockResolvedValue([]),
+  getDayNotesForDay: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('@/app/actions/weather', () => ({
+  getWeatherForDay: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@/lib/supabase-server', () => ({
+  createTenantClient: vi.fn().mockResolvedValue({
+    supabase: {
+      from: vi.fn().mockReturnValue({
+        upsert: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    },
+    tenantId: 'tenant-1',
+  }),
+}))
+
+// Mock streamObject to return a controlled stream
+const mockStreamedObject = {
+  headline: 'A Busy Day Ahead',
+  summary: 'Ten guests expected for activities, four for lunch reservations.',
+  covers: { breakfast: 0, activities: 10, reservations: 4 },
+  vipNotes: ['Large party at noon'],
+  allergenRollup: [{ code: 'gluten', inActivities: 1, inReservations: 0, inBreakfast: 0 }],
+  risks: [],
+  suggestedActions: [],
+}
+
+vi.mock('ai', () => ({
+  streamObject: vi.fn().mockReturnValue({
+    toTextStreamResponse: vi
+      .fn()
+      .mockReturnValue(
+        new Response('streamed', { status: 200, headers: { 'Content-Type': 'text/plain' } })
+      ),
+    object: Promise.resolve(mockStreamedObject),
+  }),
+}))
+
+vi.mock('@ai-sdk/gateway', () => ({
+  gateway: vi.fn().mockReturnValue('mocked-model'),
+}))
+
+vi.mock('next/server', () => ({
+  after: vi.fn((fn: () => Promise<void>) => {
+    // Execute the callback synchronously in tests so we can assert on it
+    return fn()
+  }),
+}))
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { isFeatureEnabled } from '@/app/actions/feature-flags'
+import { getTenantFromHeaders } from '@/lib/tenant'
+import { getUser } from '@/app/actions/auth'
+import { getUserRole } from '@/lib/membership'
+import { dailyBriefRateLimit } from '@/lib/rate-limit'
+import { streamObject } from 'ai'
+import { POST } from '@/app/api/daily-brief/stream/route'
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+function makeRequest(body: Record<string, unknown> = { dateIso: '2026-05-09' }) {
+  return new Request('http://localhost/api/daily-brief/stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/daily-brief/stream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isFeatureEnabled).mockResolvedValue(true)
+    vi.mocked(getTenantFromHeaders).mockResolvedValue({ id: 'tenant-1', slug: 'test' })
+    vi.mocked(getUser).mockResolvedValue({ id: 'user-1', email: 'editor@test.com' } as never)
+    vi.mocked(getUserRole).mockResolvedValue('editor')
+    vi.mocked(dailyBriefRateLimit).mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: 0,
+    })
+  })
+
+  it('happy-path: returns 200 streaming response and calls streamObject', async () => {
+    const response = await POST(makeRequest())
+    expect(response.status).toBe(200)
+    expect(streamObject).toHaveBeenCalledOnce()
+    const call = vi.mocked(streamObject).mock.calls[0][0]
+    expect(call.schema).toBeDefined()
+    expect(typeof call.prompt).toBe('string')
+    expect(call.prompt).toContain('daily briefing')
+  })
+
+  it('returns 403 when feature flag is disabled', async () => {
+    vi.mocked(isFeatureEnabled).mockResolvedValue(false)
+    const response = await POST(makeRequest())
+    expect(response.status).toBe(403)
+    expect(streamObject).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    vi.mocked(getUser).mockResolvedValue(null)
+    const response = await POST(makeRequest())
+    expect(response.status).toBe(401)
+    expect(streamObject).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when user is not an editor', async () => {
+    vi.mocked(getUserRole).mockResolvedValue('staff')
+    const response = await POST(makeRequest())
+    expect(response.status).toBe(403)
+    expect(streamObject).not.toHaveBeenCalled()
+  })
+
+  it('returns 429 when rate limit is exceeded', async () => {
+    vi.mocked(dailyBriefRateLimit).mockResolvedValue({
+      success: false,
+      limit: 5,
+      remaining: 0,
+      reset: 0,
+    })
+    const response = await POST(makeRequest())
+    expect(response.status).toBe(429)
+    expect(streamObject).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when dateIso is missing', async () => {
+    const response = await POST(makeRequest({}))
+    expect(response.status).toBe(400)
+    expect(streamObject).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when tenant context is missing', async () => {
+    vi.mocked(getTenantFromHeaders).mockRejectedValue(new Error('no tenant'))
+    const response = await POST(makeRequest())
+    expect(response.status).toBe(400)
+    expect(streamObject).not.toHaveBeenCalled()
+  })
+})

--- a/tests/api/daily-brief-stream.test.ts
+++ b/tests/api/daily-brief-stream.test.ts
@@ -56,17 +56,6 @@ vi.mock('@/lib/supabase-server', () => ({
   }),
 }))
 
-// Mock streamObject to return a controlled stream
-const mockStreamedObject = {
-  headline: 'A Busy Day Ahead',
-  summary: 'Ten guests expected for activities, four for lunch reservations.',
-  covers: { breakfast: 0, activities: 10, reservations: 4 },
-  vipNotes: ['Large party at noon'],
-  allergenRollup: [{ code: 'gluten', inActivities: 1, inReservations: 0, inBreakfast: 0 }],
-  risks: [],
-  suggestedActions: [],
-}
-
 vi.mock('ai', () => ({
   streamObject: vi.fn().mockReturnValue({
     toTextStreamResponse: vi
@@ -74,7 +63,15 @@ vi.mock('ai', () => ({
       .mockReturnValue(
         new Response('streamed', { status: 200, headers: { 'Content-Type': 'text/plain' } })
       ),
-    object: Promise.resolve(mockStreamedObject),
+    object: Promise.resolve({
+      headline: 'A Busy Day Ahead',
+      summary: 'Ten guests expected for activities, four for lunch reservations.',
+      covers: { breakfast: 0, activities: 10, reservations: 4 },
+      vipNotes: ['Large party at noon'],
+      allergenRollup: [{ code: 'gluten', inActivities: 1, inReservations: 0, inBreakfast: 0 }],
+      risks: [],
+      suggestedActions: [],
+    }),
   }),
 }))
 
@@ -116,12 +113,7 @@ describe('POST /api/daily-brief/stream', () => {
     vi.mocked(getTenantFromHeaders).mockResolvedValue({ id: 'tenant-1', slug: 'test' })
     vi.mocked(getUser).mockResolvedValue({ id: 'user-1', email: 'editor@test.com' } as never)
     vi.mocked(getUserRole).mockResolvedValue('editor')
-    vi.mocked(dailyBriefRateLimit).mockResolvedValue({
-      success: true,
-      limit: 5,
-      remaining: 4,
-      reset: 0,
-    })
+    vi.mocked(dailyBriefRateLimit).mockResolvedValue({ success: true })
   })
 
   it('happy-path: returns 200 streaming response and calls streamObject', async () => {
@@ -156,12 +148,7 @@ describe('POST /api/daily-brief/stream', () => {
   })
 
   it('returns 429 when rate limit is exceeded', async () => {
-    vi.mocked(dailyBriefRateLimit).mockResolvedValue({
-      success: false,
-      limit: 5,
-      remaining: 0,
-      reset: 0,
-    })
+    vi.mocked(dailyBriefRateLimit).mockResolvedValue({ success: false })
     const response = await POST(makeRequest())
     expect(response.status).toBe(429)
     expect(streamObject).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- Adds `POST /api/daily-brief/stream` route using `streamObject` from the AI SDK; persists the final validated object via `after()` from `next/server`
- Extracts zod schemas to `lib/daily-brief-schema.ts` so client components don't import server-only gateway code
- Updates `day-info-banner.tsx` and `daily-brief-card.tsx` to use `useObject` from `@ai-sdk/react` — shows skeleton placeholders while the headline/summary/covers stream in, then fades each section with `animate-in`
- `generateObject` in `lib/daily-brief-generate.ts` and the cron path are unchanged
- Adds `/api/daily-brief/:path*` to the middleware matcher so tenant headers (`x-tenant-id`) are injected into the route
- Adds `@ai-sdk/react` dependency

## Test plan

- [ ] Open a day view as editor with content but no brief — brief streams in progressively (headline first, then summary, then covers)
- [ ] Open dialog during streaming — skeleton placeholders visible; sections fade in as they arrive
- [ ] Manual regenerate button streams new content, stale banner hides during generation
- [ ] Stale-warning banner still shows when brief exists but content has changed; unchanged after regenerate
- [ ] Viewer sees brief content normally (no generation triggered, `isEditor={false}`)
- [ ] Cron path (`generateAndPersistDailyBrief`) still uses `generateObject` — unchanged
- [ ] `tests/api/daily-brief-stream.test.ts` passes: happy-path returns 200, auth/rate-limit guards return correct status codes

Closes #175

https://claude.ai/code/session_01PXdtcA9J1jkL3vKE2HYgaN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXdtcA9J1jkL3vKE2HYgaN)_