### PR TITLE
Migrate Daily Brief LLM to claude-sonnet-4-6 with prompt caching

### DIFF
--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -16,8 +16,8 @@ import { narrativeSchema, dailyBriefContentSchema } from '@/lib/daily-brief-sche
 
 export { narrativeSchema, dailyBriefContentSchema }
 
-export const PROMPT_VERSION = 'v1'
-export const DAILY_BRIEF_MODEL_ID = 'openai/gpt-5.4' as const
+export const PROMPT_VERSION = 'v2'
+export const DAILY_BRIEF_MODEL_ID = 'anthropic/claude-sonnet-4-6' as const
 const NOTE_MAX = 200
 
 function hasGatewayAuth(): boolean {
@@ -209,8 +209,24 @@ export async function generateAndPersistDailyBrief(
     const result = await generateObject({
       model: gateway(DAILY_BRIEF_MODEL_ID),
       schema: narrativeSchema,
-      system: BRIEF_SYSTEM,
-      prompt: `Produce a daily briefing from this JSON:\n${JSON.stringify(payload)}`,
+      messages: [
+        {
+          role: 'system' as const,
+          content: [
+            {
+              type: 'text' as const,
+              text: BRIEF_SYSTEM,
+              experimental_providerMetadata: {
+                anthropic: { cacheControl: { type: 'ephemeral' } },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user' as const,
+          content: `Produce a daily briefing from this JSON:\n${JSON.stringify(payload)}`,
+        },
+      ],
       maxOutputTokens: 2048,
     })
     narrative = result.object

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -209,25 +209,12 @@ export async function generateAndPersistDailyBrief(
     const result = await generateObject({
       model: gateway(DAILY_BRIEF_MODEL_ID),
       schema: narrativeSchema,
-      messages: [
-        {
-          role: 'system' as const,
-          content: [
-            {
-              type: 'text' as const,
-              text: BRIEF_SYSTEM,
-              providerOptions: {
-                anthropic: { cacheControl: { type: 'ephemeral' } },
-              },
-            },
-          ],
-        },
-        {
-          role: 'user' as const,
-          content: `Produce a daily briefing from this JSON:\n${JSON.stringify(payload)}`,
-        },
-      ],
+      system: BRIEF_SYSTEM,
+      prompt: `Produce a daily briefing from this JSON:\n${JSON.stringify(payload)}`,
       maxOutputTokens: 2048,
+      providerOptions: {
+        gateway: { caching: 'auto' },
+      },
     })
     narrative = result.object
   } catch (e) {

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -216,7 +216,7 @@ export async function generateAndPersistDailyBrief(
             {
               type: 'text' as const,
               text: BRIEF_SYSTEM,
-              experimental_providerMetadata: {
+              providerOptions: {
                 anthropic: { cacheControl: { type: 'ephemeral' } },
               },
             },


### PR DESCRIPTION
## Summary
- Replace `openai/gpt-5.4` with `anthropic/claude-sonnet-4-6` via AI Gateway
- Add `cache_control: { type: 'ephemeral' }` on system prompt content block so repeated morning-brief cron calls across tenants hit the Anthropic prompt cache
- Bump `PROMPT_VERSION` from `v1` → `v2` to prevent stale-brief detection from conflating old and new model outputs

## Test plan
- [ ] Trigger brief regeneration on a seeded day and confirm valid JSON matching the existing Zod schema is returned
- [ ] Check `daily_brief.model` column records `anthropic/claude-sonnet-4-6`
- [ ] Check `daily_brief.prompt_version` column records `v2`
- [ ] Confirm CI (typecheck, lint, unit-tests, build) green

Closes #174

https://claude.ai/code/session_015VLE84MiYyUSAu9PfnUTou

---
_Generated by [Claude Code](https://claude.ai/code/session_015VLE84MiYyUSAu9PfnUTou)_