### PR TITLE
feat: preserve raw text and show inline error on Quick Add parse failure

### DIFF
--- a/app/actions/quick-add.ts
+++ b/app/actions/quick-add.ts
@@ -22,9 +22,11 @@ export async function parseQuickAdd(
 
   const { success: allowed } = await quickAddRateLimit(user.id)
   if (!allowed) {
+    const nowMs = Date.now()
+    const secsRemaining = Math.ceil(((Math.floor(nowMs / 60000) + 1) * 60000 - nowMs) / 1000)
     return {
       success: false,
-      error: 'Too many quick add attempts. Wait a minute and try again.',
+      error: `Too many quick add attempts. Try again in ${secsRemaining}s.`,
     }
   }
 

--- a/components/global-quick-add.tsx
+++ b/components/global-quick-add.tsx
@@ -19,8 +19,7 @@ export function GlobalQuickAdd() {
   const t = useTranslations('Tenant.quickAdd')
   const router = useRouter()
   const pathname = usePathname()
-  const { activeDayYmd } = useActiveDay()
-  const { setPendingQuickAddResult } = useActiveDay()
+  const { activeDayYmd, setPendingQuickAddResult } = useActiveDay()
   const { quickAddOpen, setQuickAddOpen } = useKeyboardShortcuts()
 
   const handleSuccess = useCallback(
@@ -32,17 +31,6 @@ export function GlobalQuickAdd() {
       }
     },
     [pathname, router, setPendingQuickAddResult]
-  )
-
-  const handleParseFailed = useCallback(
-    (raw: string, error: string) => {
-      setPendingQuickAddResult({ type: 'failed', raw, error })
-      const targetPath = `/day/${activeDayYmd}`
-      if (!pathname.startsWith(targetPath)) {
-        router.push(targetPath)
-      }
-    },
-    [activeDayYmd, pathname, router, setPendingQuickAddResult]
   )
 
   return (
@@ -60,7 +48,6 @@ export function GlobalQuickAdd() {
         onOpenChange={setQuickAddOpen}
         contextDate={activeDayYmd}
         onSuccess={handleSuccess}
-        onParseFailed={handleParseFailed}
       />
     </>
   )

--- a/components/quick-add-input.tsx
+++ b/components/quick-add-input.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition, type FormEvent, useId } from 'react'
 import { useTranslations } from 'next-intl'
 import { Loader2, Sparkles } from 'lucide-react'
+import Link from 'next/link'
 import { parseQuickAdd } from '@/app/actions/quick-add'
 import type { QuickAddParseData } from '@/lib/quick-add-types'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
@@ -15,44 +16,42 @@ type Props = {
   onOpenChange: (open: boolean) => void
   contextDate: string
   onSuccess: (data: QuickAddParseData, raw: string) => void
-  /** Any server failure: parent decides (toast only vs open form with raw in notes). */
-  onParseFailed: (raw: string, errorMessage: string) => void
+  /** Kept for API compatibility; no longer invoked — errors are shown inline. */
+  onParseFailed?: (raw: string, errorMessage: string) => void
   disabled?: boolean
 }
 
-export function QuickAddInput({
-  open,
-  onOpenChange,
-  contextDate,
-  onSuccess,
-  onParseFailed,
-  disabled,
-}: Props) {
+export function QuickAddInput({ open, onOpenChange, contextDate, onSuccess, disabled }: Props) {
   const t = useTranslations('Tenant.quickAdd')
   const [text, setText] = useState('')
+  const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+  const descId = useId()
   const errId = useId()
 
   function close() {
     onOpenChange(false)
     setText('')
+    setError(null)
   }
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
     const v = text.trim()
     if (!v || isPending) return
+    setError(null)
     startTransition(async () => {
       const r = await parseQuickAdd(v, contextDate)
       if (!r.success) {
-        onParseFailed(v, r.error)
-        close()
+        setError(r.error)
         return
       }
       onSuccess(r.data, v)
       close()
     })
   }
+
+  const isAiNotConfigured = Boolean(error?.includes('AI is not configured'))
 
   return (
     <Dialog
@@ -61,17 +60,18 @@ export function QuickAddInput({
         if (!o) {
           onOpenChange(false)
           setText('')
+          setError(null)
         } else onOpenChange(true)
       }}
     >
-      <DialogContent className="sm:max-w-md" aria-describedby={errId}>
+      <DialogContent className="sm:max-w-md" aria-describedby={descId}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Sparkles className="h-4 w-4" />
             {t('title')}
           </DialogTitle>
         </DialogHeader>
-        <p id={errId} className="text-muted-foreground text-sm">
+        <p id={descId} className="text-muted-foreground text-sm">
           {t('description', { contextDate })}
         </p>
         <form onSubmit={handleSubmit} className="space-y-3">
@@ -81,11 +81,29 @@ export function QuickAddInput({
               id="quick-add-textarea"
               className="min-h-[100px] resize-y"
               value={text}
-              onChange={(e) => setText(e.target.value)}
+              onChange={(e) => {
+                setText(e.target.value)
+                setError(null)
+              }}
               placeholder={t('placeholder')}
               autoFocus
               disabled={isPending || disabled}
+              aria-invalid={error ? true : undefined}
+              aria-errormessage={error ? errId : undefined}
             />
+            {error && (
+              <p id={errId} role="alert" className="text-destructive text-sm">
+                {error}
+                {isAiNotConfigured && (
+                  <>
+                    {' '}
+                    <Link href="/admin/settings" className="underline" onClick={close}>
+                      Go to settings
+                    </Link>
+                  </>
+                )}
+              </p>
+            )}
           </div>
           <div className="flex justify-end gap-2 pt-1">
             <Button type="button" variant="outline" onClick={close} disabled={isPending}>


### PR DESCRIPTION
## Summary

- Dialog stays open with text intact on parse failure (no more lost input)
- Error shown inline below the textarea via `role="alert"` — no toast
- Rate-limit error includes seconds remaining: `"Try again in Xs."`
- "AI not configured" error renders a "Go to settings" link to `/admin/settings`
- `onParseFailed` prop kept for API compatibility but no longer invoked (errors are inline now)
- Success path unchanged — dialog closes as before

## Test plan

- [ ] Trigger rate-limit error: verify dialog stays open, text intact, seconds shown
- [ ] Trigger AI-not-configured error (no `AI_GATEWAY_API_KEY`): verify "Go to settings" link appears
- [ ] Trigger generic LLM error: verify inline message, submit re-enabled for retry
- [ ] Successful parse: verify dialog closes and form opens as before
- [ ] Cancel while error shown: verify dialog closes cleanly
- [ ] Existing unit tests pass (no changes to tested logic)

Closes #166

https://claude.ai/code/session_01EARqU5WNfBaUYjP76xNgnH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EARqU5WNfBaUYjP76xNgnH)_