### PR TITLE
feat(daily-brief): per-section regenerate buttons

### DIFF
--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -116,6 +116,13 @@ const dailyBriefContentSchema = z.object({
   ),
   risks: z.array(z.string()),
   suggestedActions: z.array(z.string()),
+  sectionTimestamps: z
+    .object({
+      vipNotes: z.string().optional(),
+      risks: z.string().optional(),
+      suggestedActions: z.string().optional(),
+    })
+    .optional(),
 })
 
 export async function getDailyBriefForDayWithClient(

--- a/app/actions/daily-brief.ts
+++ b/app/actions/daily-brief.ts
@@ -23,7 +23,7 @@ import { createTenantClient } from '@/lib/supabase-server'
 import { getTenantId } from '@/lib/tenant'
 import { getUserRole, requireEditor } from '@/lib/membership'
 import { isFeatureEnabled } from '@/app/actions/feature-flags'
-import { dailyBriefRateLimit } from '@/lib/rate-limit'
+import { dailyBriefRateLimit, dailyBriefSectionRateLimit } from '@/lib/rate-limit'
 import { ensureDayExists } from '@/app/actions/days'
 import {
   getProgramItemsForDay,
@@ -37,11 +37,20 @@ import { getWeatherForDay } from '@/app/actions/weather'
 import {
   dailyBriefContentSchema,
   generateAndPersistDailyBrief,
+  generateBriefSection,
+  mergeBriefSection,
   dayHasPlannedContent,
+  buildCovers,
+  buildAllergenRollup,
+  llmPayload,
 } from '@/lib/daily-brief-generate'
 import { redis } from '@/lib/redis'
 import type { ActionResponse } from '@/types/actions'
-import type { DailyBriefRecord } from '@/types/daily-brief'
+import {
+  REGENERATABLE_SECTIONS,
+  type DailyBriefRecord,
+  type RegenerableSection,
+} from '@/types/daily-brief'
 import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
 import type { WeatherData } from '@/app/actions/weather'
@@ -259,4 +268,124 @@ export async function generateDailyBrief(
     weather,
     ...(staffScheduleOn && staffShifts.length > 0 ? { staffShifts } : {}),
   })
+}
+
+function isRegenerableSection(value: string): value is RegenerableSection {
+  return (REGENERATABLE_SECTIONS as readonly string[]).includes(value)
+}
+
+/**
+ * Regenerate a single brief section (vipNotes / risks / suggestedActions).
+ * Editor-only. Has its own per-section rate limit so a small change doesn't
+ * burn the whole-brief quota.
+ */
+export async function regenerateBriefSection(
+  dateIso: string,
+  section: RegenerableSection
+): Promise<ActionResponse<DailyBriefRecord>> {
+  if (!isRegenerableSection(section)) {
+    return { success: false, error: 'Invalid section.' }
+  }
+
+  const tenantId = await getTenantId()
+  if (!(await isFeatureEnabled(tenantId, 'daily_brief'))) {
+    return { success: false, error: 'Daily brief is disabled for this venue.' }
+  }
+  await requireEditor(tenantId)
+
+  if (!process.env.AI_GATEWAY_API_KEY) {
+    return {
+      success: false,
+      error: 'AI brief is not configured (missing AI_GATEWAY_API_KEY).',
+    }
+  }
+
+  const rl = await dailyBriefSectionRateLimit(tenantId, dateIso, section)
+  if (!rl.success) {
+    return {
+      success: false,
+      error: 'Section regen limit reached. Try again tomorrow.',
+    }
+  }
+
+  const dayResult = await ensureDayExists(dateIso)
+  if (!dayResult.success) return { success: false, error: dayResult.error }
+  const dayId = dayResult.data.id
+
+  const { supabase } = await createTenantClient()
+
+  const existing = await getDailyBriefForDayWithClient(supabase, tenantId, dayId)
+  if (!existing) {
+    return {
+      success: false,
+      error: 'No existing brief to regenerate. Generate the full brief first.',
+    }
+  }
+
+  const staffScheduleOn = await isFeatureEnabled(tenantId, 'staff_schedule')
+
+  const [activities, reservations, breakfasts, dayNotes, weather, rawShifts] = await Promise.all([
+    getProgramItemsForDay(tenantId, dayId),
+    getReservationsForDay(tenantId, dayId),
+    getBreakfastConfigsForDay(tenantId, dayId),
+    getDayNotesForDay(tenantId, dayId),
+    getWeatherForDay(dateIso),
+    staffScheduleOn ? getShiftsForDay(tenantId, dayId) : Promise.resolve([]),
+  ])
+
+  const staffShifts: StaffShiftContext[] = rawShifts.map((s) => ({
+    name: s.assignee.display_name,
+    role: s.role ?? null,
+    start_time: s.start_time ?? null,
+    end_time: s.end_time ?? null,
+  }))
+
+  const covers = buildCovers(activities, reservations, breakfasts)
+  const allergenRollup = buildAllergenRollup(activities, reservations, breakfasts)
+  const payload = llmPayload({
+    dateIso,
+    weather,
+    activities,
+    reservations,
+    breakfasts,
+    dayNotes,
+    covers,
+    allergenRollup,
+    ...(staffScheduleOn && staffShifts.length > 0 ? { staffShifts } : {}),
+  })
+
+  const sectionResult = await generateBriefSection(payload, section)
+  if (!sectionResult.success) {
+    return { success: false, error: sectionResult.error }
+  }
+
+  const generatedAt = new Date().toISOString()
+  const merged = mergeBriefSection(existing.content, section, sectionResult.items, generatedAt)
+
+  const { data, error } = await supabase
+    .from('daily_brief')
+    .update({
+      content: merged as never,
+      generated_at: generatedAt,
+    })
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+    .select('id, content, generated_at, model, prompt_version')
+    .single()
+
+  if (error) return { success: false, error: error.message }
+
+  const parsed = dailyBriefContentSchema.safeParse(data.content)
+  if (!parsed.success) return { success: false, error: 'Could not validate saved brief.' }
+
+  return {
+    success: true,
+    data: {
+      id: data.id,
+      content: parsed.data,
+      generated_at: data.generated_at,
+      model: data.model,
+      prompt_version: data.prompt_version,
+    },
+  }
 }

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -270,12 +270,8 @@ export function DailyBriefCard({
                 <ListBlock
                   title={t('vip')}
                   items={brief.content.vipNotes}
-                  {...(isEditor
-                    ? {
-                        onRegenerate: () => runSectionRegenerate('vipNotes'),
-                        regenerateLabel: t('regenerateVip'),
-                      }
-                    : {})}
+                  onRegenerate={isEditor ? () => runSectionRegenerate('vipNotes') : undefined}
+                  regenerateLabel={isEditor ? t('regenerateVip') : undefined}
                   isRegenerating={regeneratingSection === 'vipNotes'}
                   regenerateDisabled={!isEditor || regeneratingSection !== null}
                   errorMessage={sectionErrors.vipNotes}
@@ -284,12 +280,8 @@ export function DailyBriefCard({
                 <ListBlock
                   title={t('risks')}
                   items={brief.content.risks}
-                  {...(isEditor
-                    ? {
-                        onRegenerate: () => runSectionRegenerate('risks'),
-                        regenerateLabel: t('regenerateRisks'),
-                      }
-                    : {})}
+                  onRegenerate={isEditor ? () => runSectionRegenerate('risks') : undefined}
+                  regenerateLabel={isEditor ? t('regenerateRisks') : undefined}
                   isRegenerating={regeneratingSection === 'risks'}
                   regenerateDisabled={!isEditor || regeneratingSection !== null}
                   errorMessage={sectionErrors.risks}
@@ -297,12 +289,10 @@ export function DailyBriefCard({
                 <ListBlock
                   title={t('actions')}
                   items={brief.content.suggestedActions}
-                  {...(isEditor
-                    ? {
-                        onRegenerate: () => runSectionRegenerate('suggestedActions'),
-                        regenerateLabel: t('regenerateActions'),
-                      }
-                    : {})}
+                  onRegenerate={
+                    isEditor ? () => runSectionRegenerate('suggestedActions') : undefined
+                  }
+                  regenerateLabel={isEditor ? t('regenerateActions') : undefined}
                   isRegenerating={regeneratingSection === 'suggestedActions'}
                   regenerateDisabled={!isEditor || regeneratingSection !== null}
                   errorMessage={sectionErrors.suggestedActions}
@@ -335,11 +325,11 @@ function ListBlock({
 }: {
   title: string
   items: string[]
-  onRegenerate?: () => void
-  regenerateLabel?: string
+  onRegenerate?: (() => void) | undefined
+  regenerateLabel?: string | undefined
   regenerateDisabled?: boolean
   isRegenerating?: boolean
-  errorMessage?: string
+  errorMessage?: string | undefined
 }) {
   if (items.length === 0 && !onRegenerate) return null
   return (

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -8,8 +8,9 @@ import { toast } from 'sonner'
 import { experimental_useObject as useObject } from '@ai-sdk/react'
 import { Button } from '@/components/ui/button'
 import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
-import type { DailyBriefContent, DailyBriefRecord } from '@/types/daily-brief'
+import type { DailyBriefContent, DailyBriefRecord, RegenerableSection } from '@/types/daily-brief'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
+import { regenerateBriefSection } from '@/app/actions/daily-brief'
 
 const REGENERATE_DEBOUNCE_MS = 2000
 
@@ -35,6 +36,10 @@ export function DailyBriefCard({
   const [brief, setBrief] = useState<DailyBriefRecord | null>(initialBrief)
   const [stale, setStale] = useState(initialBriefStale)
   const lastRegenerateAt = useRef(0)
+  const [regeneratingSection, setRegeneratingSection] = useState<RegenerableSection | null>(null)
+  const [sectionErrors, setSectionErrors] = useState<Partial<Record<RegenerableSection, string>>>(
+    {}
+  )
 
   const {
     object: streamedObject,
@@ -99,6 +104,31 @@ export function DailyBriefCard({
       () => toast.error(t('copyFailed'))
     )
   }, [brief, t])
+
+  const runSectionRegenerate = useCallback(
+    (section: RegenerableSection) => {
+      if (regeneratingSection) return
+      setRegeneratingSection(section)
+      setSectionErrors((prev) => {
+        const next = { ...prev }
+        delete next[section]
+        return next
+      })
+      void regenerateBriefSection(dateIso, section).then((result) => {
+        if (result.success) {
+          setBrief(result.data)
+          setStale(false)
+          toast.success(t('sectionRegenerated'))
+          router.refresh()
+        } else {
+          setSectionErrors((prev) => ({ ...prev, [section]: result.error }))
+          toast.error(result.error || t('sectionRegenFailed'))
+        }
+        setRegeneratingSection(null)
+      })
+    },
+    [dateIso, regeneratingSection, router, t]
+  )
 
   const hasBrief = brief !== null
   const streaming = isLoading && !hasBrief
@@ -237,10 +267,46 @@ export function DailyBriefCard({
                 <span className="hidden group-open:inline">{t('less')}</span>
               </summary>
               <div className="space-y-3 pt-2">
-                <ListBlock title={t('vip')} items={brief.content.vipNotes} />
+                <ListBlock
+                  title={t('vip')}
+                  items={brief.content.vipNotes}
+                  {...(isEditor
+                    ? {
+                        onRegenerate: () => runSectionRegenerate('vipNotes'),
+                        regenerateLabel: t('regenerateVip'),
+                      }
+                    : {})}
+                  isRegenerating={regeneratingSection === 'vipNotes'}
+                  regenerateDisabled={!isEditor || regeneratingSection !== null}
+                  errorMessage={sectionErrors.vipNotes}
+                />
                 <AllergenBlock rollup={brief.content.allergenRollup} t={t} />
-                <ListBlock title={t('risks')} items={brief.content.risks} />
-                <ListBlock title={t('actions')} items={brief.content.suggestedActions} />
+                <ListBlock
+                  title={t('risks')}
+                  items={brief.content.risks}
+                  {...(isEditor
+                    ? {
+                        onRegenerate: () => runSectionRegenerate('risks'),
+                        regenerateLabel: t('regenerateRisks'),
+                      }
+                    : {})}
+                  isRegenerating={regeneratingSection === 'risks'}
+                  regenerateDisabled={!isEditor || regeneratingSection !== null}
+                  errorMessage={sectionErrors.risks}
+                />
+                <ListBlock
+                  title={t('actions')}
+                  items={brief.content.suggestedActions}
+                  {...(isEditor
+                    ? {
+                        onRegenerate: () => runSectionRegenerate('suggestedActions'),
+                        regenerateLabel: t('regenerateActions'),
+                      }
+                    : {})}
+                  isRegenerating={regeneratingSection === 'suggestedActions'}
+                  regenerateDisabled={!isEditor || regeneratingSection !== null}
+                  errorMessage={sectionErrors.suggestedActions}
+                />
                 {brief.generated_at && brief.model && (
                   <p className="text-muted-foreground pt-1 text-xs">
                     {t('meta', {
@@ -258,16 +324,60 @@ export function DailyBriefCard({
   )
 }
 
-function ListBlock({ title, items }: { title: string; items: string[] }) {
-  if (items.length === 0) return null
+function ListBlock({
+  title,
+  items,
+  onRegenerate,
+  regenerateLabel,
+  regenerateDisabled = false,
+  isRegenerating = false,
+  errorMessage,
+}: {
+  title: string
+  items: string[]
+  onRegenerate?: () => void
+  regenerateLabel?: string
+  regenerateDisabled?: boolean
+  isRegenerating?: boolean
+  errorMessage?: string
+}) {
+  if (items.length === 0 && !onRegenerate) return null
   return (
     <div>
-      <div className="text-foreground mb-1 font-medium">{title}</div>
-      <ul className="text-muted-foreground list-disc space-y-0.5 pl-5">
-        {items.map((x, i) => (
-          <li key={i}>{x}</li>
-        ))}
-      </ul>
+      <div className="text-foreground mb-1 flex items-center gap-1 font-medium">
+        <span>{title}</span>
+        {onRegenerate && (
+          <Button
+            type="button"
+            size="iconXxs"
+            variant="ghost"
+            onClick={onRegenerate}
+            disabled={regenerateDisabled || isRegenerating}
+            aria-label={regenerateLabel ?? title}
+            title={regenerateLabel ?? title}
+          >
+            {isRegenerating ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+          </Button>
+        )}
+      </div>
+      {items.length > 0 && (
+        <ul
+          className={`text-muted-foreground list-disc space-y-0.5 pl-5 transition-opacity ${
+            isRegenerating ? 'opacity-50' : ''
+          }`}
+        >
+          {items.map((x, i) => (
+            <li key={i}>{x}</li>
+          ))}
+        </ul>
+      )}
+      {errorMessage && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400">{errorMessage}</p>
+      )}
     </div>
   )
 }

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -9,6 +9,7 @@ import type {
   DailyBriefRecord,
   DailyBriefAllergenRollupEntry,
   DailyBriefCovers,
+  DailyBriefSectionTimestamps,
   RegenerableSection,
 } from '@/types/daily-brief'
 import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
@@ -215,13 +216,17 @@ export function mergeBriefSection(
   items: string[],
   timestamp: string = new Date().toISOString()
 ): DailyBriefContent {
-  return {
-    ...content,
-    [section]: items,
-    sectionTimestamps: {
-      ...(content.sectionTimestamps ?? {}),
-      [section]: timestamp,
-    },
+  const sectionTimestamps: DailyBriefSectionTimestamps = {
+    ...(content.sectionTimestamps ?? {}),
+  }
+  sectionTimestamps[section] = timestamp
+  switch (section) {
+    case 'vipNotes':
+      return { ...content, vipNotes: items, sectionTimestamps }
+    case 'risks':
+      return { ...content, risks: items, sectionTimestamps }
+    case 'suggestedActions':
+      return { ...content, suggestedActions: items, sectionTimestamps }
   }
 }
 

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -9,12 +9,17 @@ import type {
   DailyBriefRecord,
   DailyBriefAllergenRollupEntry,
   DailyBriefCovers,
+  RegenerableSection,
 } from '@/types/daily-brief'
 import type { Activity, Reservation, BreakfastConfiguration } from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
-import { narrativeSchema, dailyBriefContentSchema } from '@/lib/daily-brief-schema'
+import {
+  narrativeSchema,
+  dailyBriefContentSchema,
+  sectionItemsSchema,
+} from '@/lib/daily-brief-schema'
 
-export { narrativeSchema, dailyBriefContentSchema }
+export { narrativeSchema, dailyBriefContentSchema, sectionItemsSchema }
 
 export const PROMPT_VERSION = 'v2'
 export const DAILY_BRIEF_MODEL_ID = 'anthropic/claude-sonnet-4-6' as const
@@ -158,6 +163,67 @@ Rules:
 - Never include guest personal names. If notes contain names, generalise (e.g. "a dietary note on one reservation").
 - vipNotes: short bullets for large parties, tight turnarounds, or anything that reads as priority from the data (not names).
 - If data is sparse, say so briefly; still give a useful headline and summary.`
+
+const SECTION_INSTRUCTIONS: Record<RegenerableSection, string> = {
+  vipNotes:
+    'Produce ONLY the VIP / priority notes for this day, as `items`. Short bullets for large parties, tight turnarounds, or items that read as priority from the data. Never include guest personal names. If nothing qualifies, return an empty array.',
+  risks:
+    'Produce ONLY the operational risks for this day, as `items`. Short bullets covering allergen pressure, weather impact, capacity strain, or note-driven concerns. Never include guest personal names. If nothing qualifies, return an empty array.',
+  suggestedActions:
+    'Produce ONLY suggested actions for staff for this day, as `items`. Concrete, actionable bullets the team should consider before service. Never include guest personal names. If nothing qualifies, return an empty array.',
+}
+
+export async function generateBriefSection(
+  payload: ReturnType<typeof llmPayload>,
+  section: RegenerableSection
+): Promise<{ success: true; items: string[] } | { success: false; error: string }> {
+  if (!hasGatewayAuth()) {
+    return {
+      success: false,
+      error: 'AI brief is not configured (set AI_GATEWAY_API_KEY or run `vercel env pull`).',
+    }
+  }
+
+  try {
+    const result = await generateObject({
+      model: gateway(DAILY_BRIEF_MODEL_ID),
+      schema: sectionItemsSchema,
+      system: BRIEF_SYSTEM,
+      prompt: `${SECTION_INSTRUCTIONS[section]}\n\nFrom this JSON:\n${JSON.stringify(payload)}`,
+      maxOutputTokens: 1024,
+      providerOptions: {
+        gateway: { caching: 'auto' },
+      },
+    })
+    return { success: true, items: result.object.items }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Generation failed.'
+    return {
+      success: false,
+      error:
+        msg.length > 200
+          ? 'Section generation failed. Check AI Gateway configuration and try again.'
+          : msg,
+    }
+  }
+}
+
+/** Replace one section's items in a brief, recording a per-section timestamp. */
+export function mergeBriefSection(
+  content: DailyBriefContent,
+  section: RegenerableSection,
+  items: string[],
+  timestamp: string = new Date().toISOString()
+): DailyBriefContent {
+  return {
+    ...content,
+    [section]: items,
+    sectionTimestamps: {
+      ...(content.sectionTimestamps ?? {}),
+      [section]: timestamp,
+    },
+  }
+}
 
 export function dayHasPlannedContent(
   activities: Activity[],

--- a/lib/daily-brief-schema.ts
+++ b/lib/daily-brief-schema.ts
@@ -8,6 +8,18 @@ export const narrativeSchema = z.object({
   suggestedActions: z.array(z.string()),
 })
 
+export const sectionItemsSchema = z.object({
+  items: z.array(z.string()),
+})
+
+export const sectionTimestampsSchema = z
+  .object({
+    vipNotes: z.string().optional(),
+    risks: z.string().optional(),
+    suggestedActions: z.string().optional(),
+  })
+  .optional()
+
 export const dailyBriefContentSchema = z.object({
   headline: z.string(),
   summary: z.string(),
@@ -27,4 +39,5 @@ export const dailyBriefContentSchema = z.object({
   ),
   risks: z.array(z.string()),
   suggestedActions: z.array(z.string()),
+  sectionTimestamps: sectionTimestampsSchema,
 })

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -64,6 +64,22 @@ export async function dailyBriefRateLimit(
   return checkLimit(`daily-brief:${tenantId}:${dateIso}`, DAILY_BRIEF_LIMIT, DAILY_BRIEF_WINDOW_SEC)
 }
 
+/** Per-section daily brief regen: 5 per day per tenant per date per section. */
+const DAILY_BRIEF_SECTION_LIMIT = 5
+const DAILY_BRIEF_SECTION_WINDOW_SEC = 86400
+
+export async function dailyBriefSectionRateLimit(
+  tenantId: string,
+  dateIso: string,
+  section: string
+): Promise<{ success: boolean }> {
+  return checkLimit(
+    `daily-brief-section:${tenantId}:${dateIso}:${section}`,
+    DAILY_BRIEF_SECTION_LIMIT,
+    DAILY_BRIEF_SECTION_WINDOW_SEC
+  )
+}
+
 /** LLM quick-add parse: 30 per minute per user (separate from mutation cap). */
 const QUICK_ADD_LIMIT = 30
 const QUICK_ADD_WINDOW_SEC = 60

--- a/messages/de.json
+++ b/messages/de.json
@@ -159,7 +159,13 @@
       "srcBreakfast": "{n} Frühstück(e)",
       "risks": "Risiken",
       "actions": "Vorgeschlagene Maßnahmen",
-      "meta": "Erzeugt {time} · {model}"
+      "meta": "Erzeugt {time} · {model}",
+      "regenerateVip": "VIP-Notizen neu erzeugen",
+      "regenerateRisks": "Risiken neu erzeugen",
+      "regenerateActions": "Vorgeschlagene Maßnahmen neu erzeugen",
+      "sectionRegenerated": "Abschnitt aktualisiert",
+      "sectionRegenFailed": "Abschnitt konnte nicht neu erzeugt werden",
+      "sectionRateLimited": "Limit für Abschnittserneuerung erreicht. Bitte morgen erneut versuchen."
     },
     "quickAdd": {
       "openButton": "Schnell hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -263,7 +263,13 @@
       "srcBreakfast": "{n} breakfast(s)",
       "risks": "Risks",
       "actions": "Suggested actions",
-      "meta": "Generated {time} · {model}"
+      "meta": "Generated {time} · {model}",
+      "regenerateVip": "Regenerate VIP notes",
+      "regenerateRisks": "Regenerate risks",
+      "regenerateActions": "Regenerate suggested actions",
+      "sectionRegenerated": "Section updated",
+      "sectionRegenFailed": "Could not regenerate section",
+      "sectionRateLimited": "Section regen limit reached. Try again tomorrow."
     },
     "quickAdd": {
       "openButton": "Quick add",

--- a/messages/es.json
+++ b/messages/es.json
@@ -159,7 +159,13 @@
       "srcBreakfast": "{n} desayuno(s)",
       "risks": "Riesgos",
       "actions": "Acciones sugeridas",
-      "meta": "Generado {time} · {model}"
+      "meta": "Generado {time} · {model}",
+      "regenerateVip": "Regenerar notas VIP",
+      "regenerateRisks": "Regenerar riesgos",
+      "regenerateActions": "Regenerar acciones sugeridas",
+      "sectionRegenerated": "Sección actualizada",
+      "sectionRegenFailed": "No se pudo regenerar la sección",
+      "sectionRateLimited": "Límite de regeneración de sección alcanzado. Intente mañana."
     },
     "quickAdd": {
       "openButton": "Añadir rápido",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -263,7 +263,13 @@
       "srcBreakfast": "{n} petit(s)-déjeuner",
       "risks": "Risques",
       "actions": "Actions suggérées",
-      "meta": "Généré {time} · {model}"
+      "meta": "Généré {time} · {model}",
+      "regenerateVip": "Régénérer les notes VIP",
+      "regenerateRisks": "Régénérer les risques",
+      "regenerateActions": "Régénérer les actions suggérées",
+      "sectionRegenerated": "Section mise à jour",
+      "sectionRegenFailed": "Impossible de régénérer la section",
+      "sectionRateLimited": "Limite de régénération de section atteinte. Réessayez demain."
     },
     "quickAdd": {
       "openButton": "Ajout rapide",

--- a/tests/lib/daily-brief-merge.test.ts
+++ b/tests/lib/daily-brief-merge.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { mergeBriefSection } from '@/lib/daily-brief-generate'
+import type { DailyBriefContent } from '@/types/daily-brief'
+
+const baseContent: DailyBriefContent = {
+  headline: 'Smooth service expected',
+  summary: 'Two activities and a busy lunch service.',
+  covers: { breakfast: 12, activities: 24, reservations: 36 },
+  vipNotes: ['old vip 1', 'old vip 2'],
+  allergenRollup: [{ code: 'NUT', inActivities: 1, inReservations: 0, inBreakfast: 0 }],
+  risks: ['old risk 1'],
+  suggestedActions: ['old action 1'],
+}
+
+describe('mergeBriefSection', () => {
+  it('replaces only the requested section and leaves others untouched', () => {
+    const merged = mergeBriefSection(baseContent, 'vipNotes', ['new vip A', 'new vip B'], 'TS-1')
+
+    expect(merged.vipNotes).toEqual(['new vip A', 'new vip B'])
+    expect(merged.risks).toEqual(['old risk 1'])
+    expect(merged.suggestedActions).toEqual(['old action 1'])
+    expect(merged.headline).toBe(baseContent.headline)
+    expect(merged.summary).toBe(baseContent.summary)
+    expect(merged.covers).toEqual(baseContent.covers)
+    expect(merged.allergenRollup).toEqual(baseContent.allergenRollup)
+  })
+
+  it('records a per-section timestamp for the regenerated section', () => {
+    const merged = mergeBriefSection(baseContent, 'risks', ['new risk'], '2026-05-10T10:00:00.000Z')
+    expect(merged.sectionTimestamps?.risks).toBe('2026-05-10T10:00:00.000Z')
+    expect(merged.sectionTimestamps?.vipNotes).toBeUndefined()
+    expect(merged.sectionTimestamps?.suggestedActions).toBeUndefined()
+  })
+
+  it('preserves prior section timestamps when updating a different section', () => {
+    const withTs: DailyBriefContent = {
+      ...baseContent,
+      sectionTimestamps: { vipNotes: '2026-01-01T00:00:00.000Z' },
+    }
+    const merged = mergeBriefSection(withTs, 'risks', ['new risk'], '2026-05-10T10:00:00.000Z')
+    expect(merged.sectionTimestamps?.vipNotes).toBe('2026-01-01T00:00:00.000Z')
+    expect(merged.sectionTimestamps?.risks).toBe('2026-05-10T10:00:00.000Z')
+  })
+
+  it('replaces the section timestamp when the same section is regenerated again', () => {
+    const withTs: DailyBriefContent = {
+      ...baseContent,
+      sectionTimestamps: { suggestedActions: '2026-01-01T00:00:00.000Z' },
+    }
+    const merged = mergeBriefSection(
+      withTs,
+      'suggestedActions',
+      ['fresh action'],
+      '2026-05-10T11:00:00.000Z'
+    )
+    expect(merged.suggestedActions).toEqual(['fresh action'])
+    expect(merged.sectionTimestamps?.suggestedActions).toBe('2026-05-10T11:00:00.000Z')
+  })
+
+  it('does not mutate the input content', () => {
+    const snapshot = JSON.parse(JSON.stringify(baseContent)) as DailyBriefContent
+    mergeBriefSection(baseContent, 'vipNotes', ['x'], 'TS')
+    expect(baseContent).toEqual(snapshot)
+  })
+
+  it('accepts an empty replacement array', () => {
+    const merged = mergeBriefSection(baseContent, 'risks', [], 'TS')
+    expect(merged.risks).toEqual([])
+    expect(merged.vipNotes).toEqual(baseContent.vipNotes)
+  })
+})

--- a/types/daily-brief.ts
+++ b/types/daily-brief.ts
@@ -11,6 +11,11 @@ export type DailyBriefAllergenRollupEntry = {
   inBreakfast: number
 }
 
+export const REGENERATABLE_SECTIONS = ['vipNotes', 'risks', 'suggestedActions'] as const
+export type RegenerableSection = (typeof REGENERATABLE_SECTIONS)[number]
+
+export type DailyBriefSectionTimestamps = Partial<Record<RegenerableSection, string>>
+
 export type DailyBriefContent = {
   headline: string
   summary: string
@@ -19,6 +24,7 @@ export type DailyBriefContent = {
   allergenRollup: DailyBriefAllergenRollupEntry[]
   risks: string[]
   suggestedActions: string[]
+  sectionTimestamps?: DailyBriefSectionTimestamps
 }
 
 export type DailyBriefRecord = {

--- a/types/daily-brief.ts
+++ b/types/daily-brief.ts
@@ -14,7 +14,11 @@ export type DailyBriefAllergenRollupEntry = {
 export const REGENERATABLE_SECTIONS = ['vipNotes', 'risks', 'suggestedActions'] as const
 export type RegenerableSection = (typeof REGENERATABLE_SECTIONS)[number]
 
-export type DailyBriefSectionTimestamps = Partial<Record<RegenerableSection, string>>
+export type DailyBriefSectionTimestamps = {
+  vipNotes?: string | undefined
+  risks?: string | undefined
+  suggestedActions?: string | undefined
+}
 
 export type DailyBriefContent = {
   headline: string
@@ -24,7 +28,7 @@ export type DailyBriefContent = {
   allergenRollup: DailyBriefAllergenRollupEntry[]
   risks: string[]
   suggestedActions: string[]
-  sectionTimestamps?: DailyBriefSectionTimestamps
+  sectionTimestamps?: DailyBriefSectionTimestamps | undefined
 }
 
 export type DailyBriefRecord = {


### PR DESCRIPTION
Closes #176

## Summary
- Editor-only refresh icons next to `vipNotes`, `risks`, and `suggestedActions` so small changes don't burn the whole-brief rate limit.
- New `regenerateBriefSection` server action with its own per-tenant/per-date/per-section rate limit (5/day).
- `generateBriefSection` helper uses `generateObject` with a focused per-section prompt; `mergeBriefSection` replaces only the requested section and records a per-section timestamp inside `content.sectionTimestamps` for traceability.
- Optimistic UI: section dims + spinner while regenerating; on failure the old content is retained and an inline error is shown.

## Acceptance criteria coverage
- [x] Sections supported: `vipNotes`, `risks`, `suggestedActions`
- [x] Per-section rate-limit (5 regens per day per tenant per date per section)
- [x] Persisted brief shows partial regen — `generated_at` updated, per-section timestamps inside content JSON
- [x] Optimistic UI: section greys out + small spinner while regen running
- [x] Failure shows inline error and retains the old content for that section
- [x] Viewer cannot see regen buttons (props gated by `isEditor`)
- [x] Unit test covers section merge logic (`tests/lib/daily-brief-merge.test.ts`)

## Out of scope (per ticket)
- Streaming for per-section regen — uses plain `generateObject`
- Editable overrides
- Regenerating headline / summary / covers — whole-brief regen still handles those

## Test plan
- [ ] Open a day view as editor with an existing brief; expand "Details"
- [ ] Click the refresh icon next to "VIP / priority" — section dims, spinner shows, content updates with new bullets, toast confirms
- [ ] Click the refresh icon next to "Risks" — only that section changes; vipNotes & suggestedActions remain identical
- [ ] Click the refresh icon next to "Suggested actions" — same isolation
- [ ] Hit the per-section limit (6th call same day) — toast shows rate-limit message, content unchanged
- [ ] As viewer, confirm refresh icons are not rendered
- [ ] Force a generation error (e.g. invalid `AI_GATEWAY_API_KEY`) — inline error renders below the section, old content preserved


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgx5zD4cqRCykk36cp6Nxw)_