### PR TITLE
feat(ai): per-call telemetry log + superadmin usage panel

### DIFF
--- a/app/actions/daily-brief.ts
+++ b/app/actions/daily-brief.ts
@@ -354,7 +354,7 @@ export async function regenerateBriefSection(
     ...(staffScheduleOn && staffShifts.length > 0 ? { staffShifts } : {}),
   })
 
-  const sectionResult = await generateBriefSection(payload, section)
+  const sectionResult = await generateBriefSection(payload, section, tenantId)
   if (!sectionResult.success) {
     return { success: false, error: sectionResult.error }
   }

--- a/app/actions/quick-add.ts
+++ b/app/actions/quick-add.ts
@@ -36,7 +36,7 @@ export async function parseQuickAdd(
   }
   const dayId = dayResult.data.id
 
-  const gen = await generateQuickAddParse(input.trim(), dayId, contextDate)
+  const gen = await generateQuickAddParse(input.trim(), dayId, contextDate, tenantId)
   if (!gen.success) {
     return { success: false, error: gen.error }
   }

--- a/app/admin/ai-usage.tsx
+++ b/app/admin/ai-usage.tsx
@@ -1,0 +1,307 @@
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+type AiCallFeature = 'quick_add' | 'daily_brief'
+type AiCallStatus = 'ok' | 'error'
+
+type AiCallRow = {
+  tenant_id: string | null
+  feature: AiCallFeature
+  duration_ms: number | null
+  status: AiCallStatus
+  created_at: string
+}
+
+type FeatureStats = {
+  total: number
+  errors: number
+  errorRate: number
+  p50: number | null
+  p95: number | null
+}
+
+type TenantUsage = {
+  tenantId: string | null
+  total: number
+  errors: number
+  avgLatency: number | null
+}
+
+const FEATURES: AiCallFeature[] = ['quick_add', 'daily_brief']
+
+const FEATURE_LABEL: Record<AiCallFeature, string> = {
+  quick_add: 'Quick Add',
+  daily_brief: 'Daily Brief',
+}
+
+function percentile(sortedAsc: number[], p: number): number | null {
+  if (sortedAsc.length === 0) return null
+  const idx = Math.min(sortedAsc.length - 1, Math.ceil((p / 100) * sortedAsc.length) - 1)
+  return sortedAsc[Math.max(0, idx)] ?? null
+}
+
+function statsForRows(rows: AiCallRow[]): FeatureStats {
+  const total = rows.length
+  const errors = rows.reduce((n, r) => n + (r.status === 'error' ? 1 : 0), 0)
+  const durations = rows
+    .map((r) => r.duration_ms)
+    .filter((v): v is number => typeof v === 'number')
+    .sort((a, b) => a - b)
+  return {
+    total,
+    errors,
+    errorRate: total === 0 ? 0 : errors / total,
+    p50: percentile(durations, 50),
+    p95: percentile(durations, 95),
+  }
+}
+
+function topTenants(rows: AiCallRow[], limit: number): TenantUsage[] {
+  const map = new Map<string, { total: number; errors: number; sum: number; durCount: number }>()
+  for (const r of rows) {
+    const key = r.tenant_id ?? '__unknown__'
+    const cur = map.get(key) ?? { total: 0, errors: 0, sum: 0, durCount: 0 }
+    cur.total += 1
+    if (r.status === 'error') cur.errors += 1
+    if (typeof r.duration_ms === 'number') {
+      cur.sum += r.duration_ms
+      cur.durCount += 1
+    }
+    map.set(key, cur)
+  }
+  return [...map.entries()]
+    .map(([key, v]) => ({
+      tenantId: key === '__unknown__' ? null : key,
+      total: v.total,
+      errors: v.errors,
+      avgLatency: v.durCount === 0 ? null : Math.round(v.sum / v.durCount),
+    }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, limit)
+}
+
+function formatMs(value: number | null): string {
+  if (value == null) return '—'
+  if (value < 1000) return `${value} ms`
+  return `${(value / 1000).toFixed(2)} s`
+}
+
+function formatPct(value: number): string {
+  return `${(value * 100).toFixed(1)}%`
+}
+
+async function loadAiUsage(): Promise<{ rows7d: AiCallRow[]; rows24h: AiCallRow[] }> {
+  const now = Date.now()
+  const since7dIso = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const since24hMs = now - 24 * 60 * 60 * 1000
+
+  const supabase = createSupabaseServiceClient()
+  const { data, error } = await supabase
+    .from('ai_call_log')
+    .select('tenant_id, feature, duration_ms, status, created_at')
+    .gte('created_at', since7dIso)
+
+  if (error) {
+    console.error('[ai-usage] load failed:', error.message)
+    return { rows7d: [], rows24h: [] }
+  }
+  const rows7d = (data ?? []) as AiCallRow[]
+  const rows24h = rows7d.filter((r) => new Date(r.created_at).getTime() >= since24hMs)
+  return { rows7d, rows24h }
+}
+
+export async function AdminAiUsage({
+  tenantNamesById,
+}: {
+  tenantNamesById: Record<string, string>
+}) {
+  const { rows7d, rows24h } = await loadAiUsage()
+
+  const total24h = rows24h.length
+  const total7d = rows7d.length
+  const errors24h = rows24h.reduce((n, r) => n + (r.status === 'error' ? 1 : 0), 0)
+  const errors7d = rows7d.reduce((n, r) => n + (r.status === 'error' ? 1 : 0), 0)
+
+  const perFeature24h: Record<AiCallFeature, FeatureStats> = {
+    quick_add: statsForRows(rows24h.filter((r) => r.feature === 'quick_add')),
+    daily_brief: statsForRows(rows24h.filter((r) => r.feature === 'daily_brief')),
+  }
+  const perFeature7d: Record<AiCallFeature, FeatureStats> = {
+    quick_add: statsForRows(rows7d.filter((r) => r.feature === 'quick_add')),
+    daily_brief: statsForRows(rows7d.filter((r) => r.feature === 'daily_brief')),
+  }
+
+  const topTenants7d = topTenants(rows7d, 10)
+
+  return (
+    <div id="ai-usage" className="space-y-6">
+      <h2 className="text-2xl font-bold">AI Usage</h2>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-sm font-medium">Calls (24h)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold tabular-nums">{total24h}</p>
+            <p className="text-muted-foreground text-xs">
+              {errors24h} error{errors24h === 1 ? '' : 's'}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-sm font-medium">Calls (7d)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold tabular-nums">{total7d}</p>
+            <p className="text-muted-foreground text-xs">
+              {errors7d} error{errors7d === 1 ? '' : 's'}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-sm font-medium">
+              Error rate (24h)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold tabular-nums">
+              {total24h === 0 ? '—' : formatPct(errors24h / total24h)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-sm font-medium">
+              Error rate (7d)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold tabular-nums">
+              {total7d === 0 ? '—' : formatPct(errors7d / total7d)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Per feature (last 7d)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-muted-foreground text-xs uppercase">
+                <tr className="border-b">
+                  <th className="py-2 text-left font-medium">Feature</th>
+                  <th className="py-2 text-right font-medium">Calls</th>
+                  <th className="py-2 text-right font-medium">Errors</th>
+                  <th className="py-2 text-right font-medium">Error rate</th>
+                  <th className="py-2 text-right font-medium">p50</th>
+                  <th className="py-2 text-right font-medium">p95</th>
+                </tr>
+              </thead>
+              <tbody>
+                {FEATURES.map((feature) => {
+                  const s = perFeature7d[feature]
+                  return (
+                    <tr key={feature} className="border-b last:border-0">
+                      <td className="py-2">{FEATURE_LABEL[feature]}</td>
+                      <td className="py-2 text-right tabular-nums">{s.total}</td>
+                      <td className="py-2 text-right tabular-nums">{s.errors}</td>
+                      <td className="py-2 text-right tabular-nums">
+                        {s.total === 0 ? '—' : formatPct(s.errorRate)}
+                      </td>
+                      <td className="py-2 text-right tabular-nums">{formatMs(s.p50)}</td>
+                      <td className="py-2 text-right tabular-nums">{formatMs(s.p95)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Per feature (last 24h)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-muted-foreground text-xs uppercase">
+                <tr className="border-b">
+                  <th className="py-2 text-left font-medium">Feature</th>
+                  <th className="py-2 text-right font-medium">Calls</th>
+                  <th className="py-2 text-right font-medium">Errors</th>
+                  <th className="py-2 text-right font-medium">Error rate</th>
+                  <th className="py-2 text-right font-medium">p50</th>
+                  <th className="py-2 text-right font-medium">p95</th>
+                </tr>
+              </thead>
+              <tbody>
+                {FEATURES.map((feature) => {
+                  const s = perFeature24h[feature]
+                  return (
+                    <tr key={feature} className="border-b last:border-0">
+                      <td className="py-2">{FEATURE_LABEL[feature]}</td>
+                      <td className="py-2 text-right tabular-nums">{s.total}</td>
+                      <td className="py-2 text-right tabular-nums">{s.errors}</td>
+                      <td className="py-2 text-right tabular-nums">
+                        {s.total === 0 ? '—' : formatPct(s.errorRate)}
+                      </td>
+                      <td className="py-2 text-right tabular-nums">{formatMs(s.p50)}</td>
+                      <td className="py-2 text-right tabular-nums">{formatMs(s.p95)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Top tenants by volume (7d)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {topTenants7d.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No AI calls recorded yet.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="text-muted-foreground text-xs uppercase">
+                  <tr className="border-b">
+                    <th className="py-2 text-left font-medium">Tenant</th>
+                    <th className="py-2 text-right font-medium">Calls</th>
+                    <th className="py-2 text-right font-medium">Errors</th>
+                    <th className="py-2 text-right font-medium">Avg latency</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topTenants7d.map((t) => {
+                    const name = t.tenantId
+                      ? (tenantNamesById[t.tenantId] ?? t.tenantId.slice(0, 8))
+                      : '— (deleted)'
+                    return (
+                      <tr key={t.tenantId ?? '__unknown__'} className="border-b last:border-0">
+                        <td className="py-2">{name}</td>
+                        <td className="py-2 text-right tabular-nums">{t.total}</td>
+                        <td className="py-2 text-right tabular-nums">{t.errors}</td>
+                        <td className="py-2 text-right tabular-nums">{formatMs(t.avgLatency)}</td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { createSupabaseServiceClient } from '@/lib/supabase-server'
 import { getFeatureFlagsByTenants } from '@/app/actions/feature-flags'
 import { AdminDashboard } from './dashboard'
+import { AdminAiUsage } from './ai-usage'
 import { AdminFeatureRequests } from '@/components/admin-feature-requests'
 import { rootDomain } from '@/lib/utils'
 
@@ -18,10 +19,13 @@ export default async function AdminPage() {
 
   const tenantList = tenants ?? []
   const flagsByTenant = await getFeatureFlagsByTenants(tenantList.map((t) => t.id))
+  const tenantNamesById = Object.fromEntries(tenantList.map((t) => [t.id, t.name]))
 
   return (
     <div className="space-y-12">
       <AdminDashboard tenants={tenantList} flagsByTenant={flagsByTenant} />
+
+      <AdminAiUsage tenantNamesById={tenantNamesById} />
 
       <div id="feature-requests">
         <h2 className="mb-6 text-2xl font-bold">Feature Requests</h2>

--- a/lib/ai-call-log.ts
+++ b/lib/ai-call-log.ts
@@ -1,0 +1,58 @@
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+
+export type AiCallFeature = 'quick_add' | 'daily_brief'
+export type AiCallStatus = 'ok' | 'error'
+
+export type LogAiCallArgs = {
+  tenantId: string | null
+  feature: AiCallFeature
+  model: string
+  promptTokens: number | null
+  completionTokens: number | null
+  durationMs: number
+  status: AiCallStatus
+  error?: string | null
+}
+
+type AiCallLogInsert = {
+  tenant_id: string | null
+  feature: AiCallFeature
+  model: string
+  prompt_tokens: number | null
+  completion_tokens: number | null
+  duration_ms: number
+  status: AiCallStatus
+  error_message: string | null
+}
+
+const ERROR_MAX = 500
+
+/**
+ * Record one LLM invocation. Never throws — telemetry failures must not break
+ * the user-facing AI call. Token counts come from the AI SDK `usage` field on
+ * generateObject / streamObject responses.
+ *
+ * No PII is stored: caller must NOT pass prompt content, completion content,
+ * or user identifiers in `error`.
+ */
+export async function logAiCall(args: LogAiCallArgs): Promise<void> {
+  try {
+    const supabase = createSupabaseServiceClient()
+    const row: AiCallLogInsert = {
+      tenant_id: args.tenantId,
+      feature: args.feature,
+      model: args.model,
+      prompt_tokens: args.promptTokens,
+      completion_tokens: args.completionTokens,
+      duration_ms: args.durationMs,
+      status: args.status,
+      error_message: args.error ? args.error.slice(0, ERROR_MAX) : null,
+    }
+    const { error } = await supabase.from('ai_call_log').insert(row)
+    if (error) {
+      console.error('[ai-call-log] insert failed:', error.message)
+    }
+  } catch (e) {
+    console.error('[ai-call-log] unexpected error:', e)
+  }
+}

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -4,6 +4,7 @@ import type { z } from 'zod'
 import type { AppSupabaseClient } from '@/app/[tenant]/day/[date]/queries'
 import type { WeatherData } from '@/app/actions/weather'
 import type { ActionResponse } from '@/types/actions'
+import { logAiCall } from '@/lib/ai-call-log'
 import type {
   DailyBriefContent,
   DailyBriefRecord,
@@ -174,9 +175,28 @@ const SECTION_INSTRUCTIONS: Record<RegenerableSection, string> = {
     'Produce ONLY suggested actions for staff for this day, as `items`. Concrete, actionable bullets the team should consider before service. Never include guest personal names. If nothing qualifies, return an empty array.',
 }
 
+type AiUsage = {
+  promptTokens?: number | null
+  completionTokens?: number | null
+  inputTokens?: number | null
+  outputTokens?: number | null
+}
+
+function readUsage(usage: AiUsage | undefined): {
+  promptTokens: number | null
+  completionTokens: number | null
+} {
+  if (!usage) return { promptTokens: null, completionTokens: null }
+  return {
+    promptTokens: usage.promptTokens ?? usage.inputTokens ?? null,
+    completionTokens: usage.completionTokens ?? usage.outputTokens ?? null,
+  }
+}
+
 export async function generateBriefSection(
   payload: ReturnType<typeof llmPayload>,
-  section: RegenerableSection
+  section: RegenerableSection,
+  tenantId: string | null = null
 ): Promise<{ success: true; items: string[] } | { success: false; error: string }> {
   if (!hasGatewayAuth()) {
     return {
@@ -185,6 +205,7 @@ export async function generateBriefSection(
     }
   }
 
+  const startedAt = Date.now()
   try {
     const result = await generateObject({
       model: gateway(DAILY_BRIEF_MODEL_ID),
@@ -196,9 +217,29 @@ export async function generateBriefSection(
         gateway: { caching: 'auto' },
       },
     })
+    const { promptTokens, completionTokens } = readUsage(result.usage as AiUsage | undefined)
+    void logAiCall({
+      tenantId,
+      feature: 'daily_brief',
+      model: DAILY_BRIEF_MODEL_ID,
+      promptTokens,
+      completionTokens,
+      durationMs: Date.now() - startedAt,
+      status: 'ok',
+    })
     return { success: true, items: result.object.items }
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Generation failed.'
+    void logAiCall({
+      tenantId,
+      feature: 'daily_brief',
+      model: DAILY_BRIEF_MODEL_ID,
+      promptTokens: null,
+      completionTokens: null,
+      durationMs: Date.now() - startedAt,
+      status: 'error',
+      error: msg,
+    })
     return {
       success: false,
       error:
@@ -276,6 +317,7 @@ export async function generateAndPersistDailyBrief(
   })
 
   let narrative: z.infer<typeof narrativeSchema>
+  const startedAt = Date.now()
   try {
     const result = await generateObject({
       model: gateway(DAILY_BRIEF_MODEL_ID),
@@ -288,8 +330,28 @@ export async function generateAndPersistDailyBrief(
       },
     })
     narrative = result.object
+    const { promptTokens, completionTokens } = readUsage(result.usage as AiUsage | undefined)
+    void logAiCall({
+      tenantId: args.tenantId,
+      feature: 'daily_brief',
+      model: DAILY_BRIEF_MODEL_ID,
+      promptTokens,
+      completionTokens,
+      durationMs: Date.now() - startedAt,
+      status: 'ok',
+    })
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Generation failed.'
+    void logAiCall({
+      tenantId: args.tenantId,
+      feature: 'daily_brief',
+      model: DAILY_BRIEF_MODEL_ID,
+      promptTokens: null,
+      completionTokens: null,
+      durationMs: Date.now() - startedAt,
+      status: 'error',
+      error: msg,
+    })
     return {
       success: false,
       error:

--- a/lib/quick-add-generate.ts
+++ b/lib/quick-add-generate.ts
@@ -5,6 +5,7 @@ import { createBreakfastSchema, type CreateBreakfastFormData } from '@/lib/break
 import { activitySchema } from '@/lib/program-item-schema'
 import { reservationSchema, type ReservationFormData } from '@/lib/reservation-schema'
 import { type AllergenCode, filterAllergenCodes, isAllergenCode } from '@/lib/allergens'
+import { logAiCall } from '@/lib/ai-call-log'
 
 import { PROMPT_VERSION, QUICK_ADD_SYSTEM, buildUserPrompt } from './quick-add-prompt'
 import type { QuickAddParseData, QuickAddGapId } from '@/lib/quick-add-types'
@@ -537,10 +538,29 @@ export type GenerateQuickAddResult =
   | { success: true; data: QuickAddParseData; promptVersion: string }
   | GenerateQuickAddError
 
+type AiUsage = {
+  promptTokens?: number | null
+  completionTokens?: number | null
+  inputTokens?: number | null
+  outputTokens?: number | null
+}
+
+function readUsage(usage: AiUsage | undefined): {
+  promptTokens: number | null
+  completionTokens: number | null
+} {
+  if (!usage) return { promptTokens: null, completionTokens: null }
+  return {
+    promptTokens: usage.promptTokens ?? usage.inputTokens ?? null,
+    completionTokens: usage.completionTokens ?? usage.outputTokens ?? null,
+  }
+}
+
 export async function generateQuickAddParse(
   userText: string,
   dayId: string,
-  contextDate: string
+  contextDate: string,
+  tenantId: string | null = null
 ): Promise<GenerateQuickAddResult> {
   const t = userText.trim()
   if (t.length < 2) {
@@ -557,6 +577,7 @@ export async function generateQuickAddParse(
   const prompt = buildUserPrompt(t, dayId, contextDate)
 
   let out: z.infer<typeof quickAddLlmSchema>
+  const startedAt = Date.now()
   try {
     const res = await generateObject({
       model: gateway(QUICK_ADD_MODEL_ID),
@@ -566,9 +587,29 @@ export async function generateQuickAddParse(
       maxOutputTokens: 2048,
     })
     out = res.object
+    const { promptTokens, completionTokens } = readUsage(res.usage as AiUsage | undefined)
+    void logAiCall({
+      tenantId,
+      feature: 'quick_add',
+      model: QUICK_ADD_MODEL_ID,
+      promptTokens,
+      completionTokens,
+      durationMs: Date.now() - startedAt,
+      status: 'ok',
+    })
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Generation failed.'
     console.error('[quick-add] generateObject failed:', e)
+    void logAiCall({
+      tenantId,
+      feature: 'quick_add',
+      model: QUICK_ADD_MODEL_ID,
+      promptTokens: null,
+      completionTokens: null,
+      durationMs: Date.now() - startedAt,
+      status: 'error',
+      error: msg,
+    })
     const short = msg.length > 200 ? msg.slice(0, 200) : msg
     return { success: false, error: `Quick add AI error: ${short}` }
   }

--- a/supabase/migrations/00050_create_ai_call_log.sql
+++ b/supabase/migrations/00050_create_ai_call_log.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- Migration 00050: ai_call_log — per-call LLM telemetry
+-- =============================================================================
+-- One row per LLM invocation (success or failure). Used by the superadmin AI
+-- usage panel to surface call volume, error rate, and latency per tenant /
+-- feature. No prompt or completion content is stored — token tallies only.
+--
+-- Access model: service-role only. RLS is enabled with no authenticated /
+-- anon policies, so non-service callers cannot read or write the table.
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE ai_call_log (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id          uuid REFERENCES tenants(id) ON DELETE SET NULL,
+  feature            text NOT NULL CHECK (feature IN ('quick_add', 'daily_brief')),
+  model              text NOT NULL,
+  prompt_tokens      integer,
+  completion_tokens  integer,
+  duration_ms        integer,
+  status             text NOT NULL CHECK (status IN ('ok', 'error')),
+  error_message      text,
+  created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ai_call_log_tenant_created_idx
+  ON ai_call_log (tenant_id, created_at DESC);
+
+CREATE INDEX ai_call_log_feature_created_idx
+  ON ai_call_log (feature, created_at DESC);
+
+ALTER TABLE ai_call_log ENABLE ROW LEVEL SECURITY;
+
+-- No policies for `authenticated` or `anon`: service_role bypasses RLS, so
+-- only the service role key can insert or read rows. Application code that
+-- needs telemetry access must use createSupabaseServiceClient().
+
+COMMIT;


### PR DESCRIPTION
## Summary
- New `ai_call_log` table (service-role only RLS) records per-call tenant, feature, model, token counts, duration, and status — no prompt/completion content, no user IDs.
- `lib/ai-call-log.ts` exposes a non-blocking `logAiCall` helper; quick-add and daily-brief LLM paths now log success and failure (try/catch wraps the insert so telemetry can never break the user-facing call).
- Admin dashboard gains an **AI Usage** section: 24h + 7d totals, error rate, p50 / p95 latency per feature, and top 10 tenants by volume (uses tenant names from the existing list).

## Test plan
- [ ] Apply migration locally (`supabase db reset`) and run `pnpm db:types`; confirm `ai_call_log` appears in generated types.
- [ ] Trigger Quick Add in the day view; check that a row lands in `ai_call_log` with `feature='quick_add'`, `status='ok'`, non-null tokens.
- [ ] Disconnect / break the AI gateway and trigger Quick Add; row appears with `status='error'` and a truncated `error_message`.
- [ ] Trigger Daily Brief generation and a section regen; confirm rows for `daily_brief` with appropriate `model` and tokens.
- [ ] Visit `/admin`; AI Usage cards populate, per-feature tables show p50/p95, top tenants ranks by volume.
- [ ] Confirm RLS — query `ai_call_log` from a non-service-role client returns zero rows.

Closes #179

https://claude.ai/code/session_01YMndDDwb9L6Pes5bMehRSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMndDDwb9L6Pes5bMehRSA)_