### PR TITLE
AI: editor override for Daily Brief headline and summary

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -143,6 +143,7 @@ function DayViewEditor({
   shiftAssignees,
   forecastRecommended,
   forecastBreakdown,
+  briefOverrideAuthorName,
   live,
   showStaffSchedule,
 }: DayViewProps & {
@@ -459,6 +460,7 @@ function DayViewEditor({
           dateIso={date}
           dayId={dayId}
           isEditor
+          overrideAuthorName={briefOverrideAuthorName}
         />
       )}
 

--- a/app/[tenant]/day/[date]/page.tsx
+++ b/app/[tenant]/day/[date]/page.tsx
@@ -19,6 +19,7 @@ import {
   getDailyBriefForDay,
   getShiftsForDay,
   getTenantAssigneesList,
+  getTenantAssignees,
 } from './queries'
 import { Suspense } from 'react'
 import { DayViewClient } from './DayViewClient'
@@ -87,6 +88,12 @@ export type DayViewProps = {
   shiftAssignees: ShiftAssignee[]
   forecastRecommended: number
   forecastBreakdown: { source: string; count: number }[]
+  /**
+   * Display name of the editor who last edited the brief's headline /
+   * summary, or null when no override exists or the user is no longer a
+   * tenant member. Drives the "edited by …" tooltip.
+   */
+  briefOverrideAuthorName: string | null
 }
 
 const YMD_REGEX = /^\d{4}-\d{2}-\d{2}$/
@@ -198,6 +205,19 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
       : false
   const briefIsEmpty = dailyBriefOn ? !dayHasContent : false
 
+  // Resolve the override author's display name. `shiftAssignees` is only loaded
+  // when staff_schedule is on, so fall back to a direct lookup otherwise.
+  let briefOverrideAuthorName: string | null = null
+  if (dailyBrief?.overridden_by) {
+    const fromList = shiftAssignees.find((a) => a.user_id === dailyBrief.overridden_by)
+    if (fromList) {
+      briefOverrideAuthorName = fromList.display_name
+    } else {
+      const assignees = await getTenantAssignees(tenant.id)
+      briefOverrideAuthorName = assignees.get(dailyBrief.overridden_by)?.display_name ?? null
+    }
+  }
+
   return (
     <Suspense
       fallback={<div className="text-muted-foreground mx-auto max-w-3xl px-3 py-8 text-sm" />}
@@ -222,6 +242,7 @@ export default async function DayPage({ params }: { params: Promise<{ date: stri
         shiftAssignees={shiftAssignees}
         forecastRecommended={forecast.recommended}
         forecastBreakdown={forecast.breakdown}
+        briefOverrideAuthorName={briefOverrideAuthorName}
       />
     </Suspense>
   )

--- a/app/[tenant]/day/[date]/queries.ts
+++ b/app/[tenant]/day/[date]/queries.ts
@@ -125,17 +125,32 @@ const dailyBriefContentSchema = z.object({
     .optional(),
 })
 
+type DailyBriefRow = {
+  id: string
+  content: unknown
+  generated_at: string
+  model: string
+  prompt_version: string
+  headline_override: string | null
+  summary_override: string | null
+  overridden_by: string | null
+  overridden_at: string | null
+}
+
 export async function getDailyBriefForDayWithClient(
   supabase: AppSupabaseClient,
   tenantId: string,
   dayId: string
 ): Promise<DailyBriefRecord | null> {
-  const { data } = await supabase
-    .from('daily_brief')
-    .select('id, content, generated_at, model, prompt_version')
+  // Override columns added in 00050; cast until `pnpm db:types` regenerates `types/supabase.ts`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = (await (supabase.from('daily_brief') as any)
+    .select(
+      'id, content, generated_at, model, prompt_version, headline_override, summary_override, overridden_by, overridden_at'
+    )
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .maybeSingle()
+    .maybeSingle()) as { data: DailyBriefRow | null }
 
   if (!data) return null
   const parsed = dailyBriefContentSchema.safeParse(data.content)
@@ -147,6 +162,10 @@ export async function getDailyBriefForDayWithClient(
     generated_at: data.generated_at,
     model: data.model,
     prompt_version: data.prompt_version,
+    headline_override: data.headline_override,
+    summary_override: data.summary_override,
+    overridden_by: data.overridden_by,
+    overridden_at: data.overridden_at,
   }
 }
 

--- a/app/actions/daily-brief.ts
+++ b/app/actions/daily-brief.ts
@@ -184,29 +184,8 @@ export async function getDailyBrief(
   if (!role) return { success: false, error: 'Not authorized.' }
 
   const { supabase } = await createTenantClient()
-  const { data, error } = await supabase
-    .from('daily_brief')
-    .select('id, content, generated_at, model, prompt_version')
-    .eq('tenant_id', tenantId)
-    .eq('day_id', dayId)
-    .maybeSingle()
-
-  if (error) return { success: false, error: error.message }
-  if (!data) return { success: true, data: null }
-
-  const parsed = dailyBriefContentSchema.safeParse(data.content)
-  if (!parsed.success) return { success: true, data: null }
-
-  return {
-    success: true,
-    data: {
-      id: data.id,
-      content: parsed.data,
-      generated_at: data.generated_at,
-      model: data.model,
-      prompt_version: data.prompt_version,
-    },
-  }
+  const brief = await getDailyBriefForDayWithClient(supabase, tenantId, dayId)
+  return { success: true, data: brief }
 }
 
 export async function generateDailyBrief(
@@ -362,7 +341,7 @@ export async function regenerateBriefSection(
   const generatedAt = new Date().toISOString()
   const merged = mergeBriefSection(existing.content, section, sectionResult.items, generatedAt)
 
-  const { data, error } = await supabase
+  const { error } = await supabase
     .from('daily_brief')
     .update({
       content: merged as never,
@@ -370,22 +349,91 @@ export async function regenerateBriefSection(
     })
     .eq('tenant_id', tenantId)
     .eq('day_id', dayId)
-    .select('id, content, generated_at, model, prompt_version')
-    .single()
 
   if (error) return { success: false, error: error.message }
 
-  const parsed = dailyBriefContentSchema.safeParse(data.content)
-  if (!parsed.success) return { success: false, error: 'Could not validate saved brief.' }
+  const updated = await getDailyBriefForDayWithClient(supabase, tenantId, dayId)
+  if (!updated) return { success: false, error: 'Could not validate saved brief.' }
 
-  return {
-    success: true,
-    data: {
-      id: data.id,
-      content: parsed.data,
-      generated_at: data.generated_at,
-      model: data.model,
-      prompt_version: data.prompt_version,
-    },
+  return { success: true, data: updated }
+}
+
+/**
+ * Editor inline-edit of the brief's headline / summary.
+ *
+ * Stored as separate `*_override` columns alongside the original AI `content`
+ * so a future Regenerate cleanly drops the human edits (see
+ * `generateAndPersistDailyBrief`). Either field may be omitted to leave
+ * untouched; passing an empty string clears that override.
+ *
+ * RLS already restricts UPDATE on daily_brief to tenant editors, so this is
+ * editor-only at the database level — `requireEditor` here just gives a
+ * cleaner error message.
+ */
+export async function updateBriefOverride(
+  dateIso: string,
+  overrides: { headline?: string; summary?: string }
+): Promise<ActionResponse<DailyBriefRecord>> {
+  const tenantId = await getTenantId()
+  if (!(await isFeatureEnabled(tenantId, 'daily_brief'))) {
+    return { success: false, error: 'Daily brief is disabled for this venue.' }
   }
+  const user = await requireEditor(tenantId)
+
+  const dayResult = await ensureDayExists(dateIso)
+  if (!dayResult.success) return { success: false, error: dayResult.error }
+  const dayId = dayResult.data.id
+
+  const { supabase } = await createTenantClient()
+
+  const existing = await getDailyBriefForDayWithClient(supabase, tenantId, dayId)
+  if (!existing) {
+    return {
+      success: false,
+      error: 'No brief to edit. Generate the full brief first.',
+    }
+  }
+
+  const update: Record<string, unknown> = {
+    overridden_by: user.id,
+    overridden_at: new Date().toISOString(),
+  }
+  if (overrides.headline !== undefined) {
+    const trimmed = overrides.headline.trim()
+    update.headline_override = trimmed === '' ? null : trimmed
+  }
+  if (overrides.summary !== undefined) {
+    const trimmed = overrides.summary.trim()
+    update.summary_override = trimmed === '' ? null : trimmed
+  }
+
+  // If the editor cleared both fields and no prior override existed, the
+  // overridden_by/at stamps would still be set — that's fine: it records the
+  // last edit attempt. If both fields are now null we drop the stamps so the
+  // "edited" badge disappears.
+  const willHaveHeadlineOverride =
+    'headline_override' in update
+      ? update.headline_override !== null
+      : existing.headline_override !== null
+  const willHaveSummaryOverride =
+    'summary_override' in update
+      ? update.summary_override !== null
+      : existing.summary_override !== null
+  if (!willHaveHeadlineOverride && !willHaveSummaryOverride) {
+    update.overridden_by = null
+    update.overridden_at = null
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase.from('daily_brief') as any)
+    .update(update)
+    .eq('tenant_id', tenantId)
+    .eq('day_id', dayId)
+
+  if (error) return { success: false, error: (error as { message: string }).message }
+
+  const updated = await getDailyBriefForDayWithClient(supabase, tenantId, dayId)
+  if (!updated) return { success: false, error: 'Could not load updated brief.' }
+
+  return { success: true, data: updated }
 }

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -21,6 +21,12 @@ type Props = {
   isEditor: boolean
   briefStale?: boolean
   briefIsEmpty?: boolean
+  /**
+   * Display name of the editor who last overrode the headline / summary —
+   * resolved server-side from membership. Used for the "edited by …"
+   * tooltip; when null we still show the badge but with a generic label.
+   */
+  overrideAuthorName?: string | null
 }
 
 export function DailyBriefCard({
@@ -30,6 +36,7 @@ export function DailyBriefCard({
   isEditor,
   briefStale: initialBriefStale = false,
   briefIsEmpty = false,
+  overrideAuthorName = null,
 }: Props) {
   const t = useTranslations('Tenant.dailyBrief')
   const router = useRouter()
@@ -65,6 +72,10 @@ export function DailyBriefCard({
           generated_at: new Date().toISOString(),
           model: '',
           prompt_version: 'v1',
+          headline_override: null,
+          summary_override: null,
+          overridden_by: null,
+          overridden_at: null,
         })
         setStale(false)
         toast.success(t('generated'))
@@ -96,9 +107,11 @@ export function DailyBriefCard({
   }, [dateIso, submit, t])
 
   const copyMarkdown = useCallback(() => {
-    const content = brief?.content
-    if (!content) return
-    const md = formatDailyBriefMarkdown(content)
+    if (!brief) return
+    const md = formatDailyBriefMarkdown(brief.content, {
+      headline_override: brief.headline_override,
+      summary_override: brief.summary_override,
+    })
     void navigator.clipboard.writeText(md).then(
       () => toast.success(t('copied')),
       () => toast.error(t('copyFailed'))
@@ -238,10 +251,19 @@ export function DailyBriefCard({
         {hasBrief && (
           <div className="space-y-3">
             <div>
-              <p className="text-base leading-snug font-semibold">{brief.content.headline}</p>
-              <p className="text-muted-foreground mt-2 text-sm whitespace-pre-wrap">
-                {brief.content.summary}
+              <p className="text-base leading-snug font-semibold">
+                {brief.headline_override?.trim() || brief.content.headline}
               </p>
+              <p className="text-muted-foreground mt-2 text-sm whitespace-pre-wrap">
+                {brief.summary_override?.trim() || brief.content.summary}
+              </p>
+              {(brief.headline_override || brief.summary_override) && (
+                <EditedBadge
+                  authorName={overrideAuthorName}
+                  overriddenAt={brief.overridden_at}
+                  t={t}
+                />
+              )}
             </div>
 
             <div className="grid grid-cols-3 gap-2 text-center text-sm">
@@ -369,6 +391,30 @@ function ListBlock({
         <p className="mt-1 text-xs text-red-600 dark:text-red-400">{errorMessage}</p>
       )}
     </div>
+  )
+}
+
+function EditedBadge({
+  authorName,
+  overriddenAt,
+  t,
+}: {
+  authorName: string | null
+  overriddenAt: string | null
+  t: (key: string, values?: Record<string, string | number>) => string
+}) {
+  const tooltip = authorName
+    ? overriddenAt
+      ? t('editedByAt', { name: authorName, time: new Date(overriddenAt).toLocaleString() })
+      : t('editedBy', { name: authorName })
+    : t('editedBadge')
+  return (
+    <span
+      className="bg-muted text-muted-foreground mt-2 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
+      title={tooltip}
+    >
+      {t('edited')}
+    </span>
   )
 }
 

--- a/components/day-info-banner.tsx
+++ b/components/day-info-banner.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
+import { ClipboardCopy, Loader2, Pencil, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
 import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
+import { updateBriefOverride } from '@/app/actions/daily-brief'
 import type { WeatherData } from '@/app/actions/weather'
 import type { DailyBriefContent, DailyBriefRecord } from '@/types/daily-brief'
 
@@ -32,6 +33,12 @@ type Props = {
   dateIso: string
   dayId: string
   isEditor: boolean
+  /**
+   * Display name of the editor who last overrode the headline / summary
+   * (resolved server-side from membership). Used in the "edited by …"
+   * tooltip on the inline-edit badge.
+   */
+  overrideAuthorName?: string | null
 }
 
 function ListBlock({ title, items }: { title: string; items: string[] }) {
@@ -90,6 +97,7 @@ export function DayInfoBanner({
   dateIso,
   dayId,
   isEditor,
+  overrideAuthorName = null,
 }: Props) {
   const t = useTranslations('Tenant.dailyBrief')
   const router = useRouter()
@@ -124,6 +132,12 @@ export function DayInfoBanner({
           generated_at: new Date().toISOString(),
           model: '',
           prompt_version: 'v1',
+          // A fresh AI generation discards any prior overrides — the user
+          // is prompted to confirm before runGenerate is called.
+          headline_override: null,
+          summary_override: null,
+          overridden_by: null,
+          overridden_at: null,
         })
         setStale(false)
         toast.success(t('generated'))
@@ -147,18 +161,39 @@ export function DayInfoBanner({
       toast.message(t('debounced'))
       return
     }
+    // Editor has manually edited the headline/summary; warn before discarding.
+    const hasOverride = Boolean(brief?.headline_override || brief?.summary_override)
+    if (hasOverride && !window.confirm(t('regenerateDiscardWarning'))) return
     lastGenerateAt.current = now
     submit({ dateIso })
-  }, [dateIso, submit, t])
+  }, [brief, dateIso, submit, t])
 
   const copyMarkdown = useCallback(() => {
     if (!brief) return
-    const md = formatDailyBriefMarkdown(brief.content)
+    const md = formatDailyBriefMarkdown(brief.content, {
+      headline_override: brief.headline_override,
+      summary_override: brief.summary_override,
+    })
     void navigator.clipboard.writeText(md).then(
       () => toast.success(t('copied')),
       () => toast.error(t('copyFailed'))
     )
   }, [brief, t])
+
+  const saveOverride = useCallback(
+    async (overrides: { headline?: string; summary?: string }) => {
+      const result = await updateBriefOverride(dateIso, overrides)
+      if (result.success) {
+        setBrief(result.data)
+        toast.success(t('editSaved'))
+        router.refresh()
+        return true
+      }
+      toast.error(result.error || t('editSaveFailed'))
+      return false
+    },
+    [dateIso, router, t]
+  )
 
   // Auto-generate when the page loads with no brief yet (editor only).
   useEffect(() => {
@@ -213,8 +248,12 @@ export function DayInfoBanner({
             tabIndex={0}
             onKeyDown={(e) => e.key === 'Enter' && setDialogOpen(true)}
           >
-            <p className="truncate text-sm font-medium">{brief.content.headline}</p>
-            <p className="text-muted-foreground line-clamp-1 text-xs">{brief.content.summary}</p>
+            <p className="truncate text-sm font-medium">
+              {brief.headline_override?.trim() || brief.content.headline}
+            </p>
+            <p className="text-muted-foreground line-clamp-1 text-xs">
+              {brief.summary_override?.trim() || brief.content.summary}
+            </p>
           </div>
         )}
 
@@ -318,7 +357,15 @@ export function DayInfoBanner({
               {isLoading && <StreamingBriefContent object={streamedObject} t={t} />}
 
               {/* Settled brief */}
-              {hasBrief && !isLoading && <SettledBriefContent brief={brief} t={t} />}
+              {hasBrief && !isLoading && (
+                <SettledBriefContent
+                  brief={brief}
+                  t={t}
+                  isEditor={isEditor}
+                  overrideAuthorName={overrideAuthorName}
+                  onSaveOverride={saveOverride}
+                />
+              )}
             </div>
           </DialogContent>
         </Dialog>
@@ -387,17 +434,48 @@ function StreamingBriefContent({
 function SettledBriefContent({
   brief,
   t,
+  isEditor,
+  overrideAuthorName,
+  onSaveOverride,
 }: {
   brief: DailyBriefRecord
   t: ReturnType<typeof useTranslations<'Tenant.dailyBrief'>>
+  isEditor: boolean
+  overrideAuthorName: string | null
+  onSaveOverride: (overrides: { headline?: string; summary?: string }) => Promise<boolean>
 }) {
+  const headlineDisplay = brief.headline_override?.trim() || brief.content.headline
+  const summaryDisplay = brief.summary_override?.trim() || brief.content.summary
+  const hasOverride = Boolean(brief.headline_override || brief.summary_override)
+
   return (
     <div className="space-y-3">
       <div>
-        <p className="text-base leading-snug font-semibold">{brief.content.headline}</p>
-        <p className="text-muted-foreground mt-2 text-sm whitespace-pre-wrap">
-          {brief.content.summary}
-        </p>
+        <InlineEditableText
+          value={headlineDisplay}
+          isEditor={isEditor}
+          multiline={false}
+          ariaLabel={t('editHeadlineLabel')}
+          textClassName="text-base leading-snug font-semibold"
+          onSave={(next) => onSaveOverride({ headline: next })}
+        />
+        <div className="mt-2">
+          <InlineEditableText
+            value={summaryDisplay}
+            isEditor={isEditor}
+            multiline
+            ariaLabel={t('editSummaryLabel')}
+            textClassName="text-muted-foreground text-sm whitespace-pre-wrap"
+            onSave={(next) => onSaveOverride({ summary: next })}
+          />
+        </div>
+        {hasOverride && (
+          <BriefEditedBadge
+            authorName={overrideAuthorName}
+            overriddenAt={brief.overridden_at}
+            t={t}
+          />
+        )}
       </div>
 
       <div className="grid grid-cols-3 gap-2 text-center text-sm">
@@ -436,5 +514,151 @@ function SettledBriefContent({
         </div>
       </details>
     </div>
+  )
+}
+
+/**
+ * Read-only display by default; reveals a pencil affordance on hover/focus
+ * for editors. Click the pencil (or the text itself) → textarea + save/cancel
+ * footer with keyboard shortcuts. Esc cancels and reverts; Cmd/Ctrl+Enter
+ * saves. Single-line mode disables Enter line breaks (pressing Enter saves).
+ */
+function InlineEditableText({
+  value,
+  isEditor,
+  multiline,
+  ariaLabel,
+  textClassName,
+  onSave,
+}: {
+  value: string
+  isEditor: boolean
+  multiline: boolean
+  ariaLabel: string
+  textClassName: string
+  onSave: (next: string) => Promise<boolean>
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [saving, setSaving] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    if (editing) {
+      setDraft(value)
+      // Defer focus so the element is in the DOM
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus()
+        textareaRef.current?.select()
+      })
+    }
+  }, [editing, value])
+
+  const cancel = useCallback(() => {
+    setDraft(value)
+    setEditing(false)
+  }, [value])
+
+  const commit = useCallback(async () => {
+    if (saving) return
+    if (draft.trim() === value.trim()) {
+      setEditing(false)
+      return
+    }
+    setSaving(true)
+    const ok = await onSave(draft)
+    setSaving(false)
+    if (ok) setEditing(false)
+  }, [draft, onSave, saving, value])
+
+  if (!isEditor) {
+    return <p className={textClassName}>{value}</p>
+  }
+
+  if (!editing) {
+    return (
+      <div className="group relative flex items-start gap-2">
+        <p className={`${textClassName} flex-1`}>{value}</p>
+        <Button
+          type="button"
+          size="iconXs"
+          variant="ghost"
+          aria-label={ariaLabel}
+          title={ariaLabel}
+          className="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+          onClick={() => setEditing(true)}
+        >
+          <Pencil className="h-3 w-3" />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        rows={multiline ? 4 : 1}
+        aria-label={ariaLabel}
+        disabled={saving}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault()
+            cancel()
+            return
+          }
+          if (e.key === 'Enter') {
+            if (!multiline || e.metaKey || e.ctrlKey) {
+              e.preventDefault()
+              void commit()
+            }
+          }
+        }}
+        className={`${textClassName} bg-background w-full resize-y rounded-md border px-2 py-1 outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50`}
+      />
+      <div className="text-muted-foreground flex items-center justify-end gap-2 text-xs">
+        <span className="mr-auto">
+          {multiline ? 'Esc cancels · ⌘/Ctrl+Enter saves' : 'Esc cancels · Enter saves'}
+        </span>
+        <Button type="button" size="xs" variant="ghost" onClick={cancel} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="xs"
+          variant="default"
+          onClick={() => void commit()}
+          disabled={saving}
+        >
+          {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Save'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function BriefEditedBadge({
+  authorName,
+  overriddenAt,
+  t,
+}: {
+  authorName: string | null
+  overriddenAt: string | null
+  t: ReturnType<typeof useTranslations<'Tenant.dailyBrief'>>
+}) {
+  const tooltip = authorName
+    ? overriddenAt
+      ? t('editedByAt', { name: authorName, time: new Date(overriddenAt).toLocaleString() })
+      : t('editedBy', { name: authorName })
+    : t('editedBadge')
+  return (
+    <span
+      className="bg-muted text-muted-foreground mt-2 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
+      title={tooltip}
+    >
+      {t('edited')}
+    </span>
   )
 }

--- a/components/viewer-day-dashboard.tsx
+++ b/components/viewer-day-dashboard.tsx
@@ -39,6 +39,7 @@ type Props = {
   briefStale?: boolean
   briefIsEmpty?: boolean
   shifts: ShiftWithAssignee[]
+  briefOverrideAuthorName?: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -59,6 +60,7 @@ export function ViewerDayDashboard({
   briefStale,
   briefIsEmpty,
   shifts,
+  briefOverrideAuthorName = null,
 }: Props) {
   const { impersonationRole } = useAuth()
 
@@ -94,6 +96,7 @@ export function ViewerDayDashboard({
           isEditor={false}
           briefStale={briefStale ?? false}
           briefIsEmpty={briefIsEmpty ?? false}
+          overrideAuthorName={briefOverrideAuthorName}
         />
       )}
 

--- a/lib/daily-brief-format.ts
+++ b/lib/daily-brief-format.ts
@@ -1,10 +1,25 @@
 import type { DailyBriefContent } from '@/types/daily-brief'
 
-export function formatDailyBriefMarkdown(brief: DailyBriefContent): string {
+export type DailyBriefOverrides = {
+  headline_override?: string | null
+  summary_override?: string | null
+}
+
+/**
+ * Markdown rendering for clipboard copy + cron emails. Editor overrides
+ * (when present) replace the AI-generated headline / summary so external
+ * recipients always see the human-curated wording.
+ */
+export function formatDailyBriefMarkdown(
+  brief: DailyBriefContent,
+  overrides?: DailyBriefOverrides
+): string {
+  const headline = overrides?.headline_override?.trim() || brief.headline
+  const summary = overrides?.summary_override?.trim() || brief.summary
   const lines: string[] = []
-  lines.push(`# ${brief.headline}`)
+  lines.push(`# ${headline}`)
   lines.push('')
-  lines.push(brief.summary)
+  lines.push(summary)
   lines.push('')
   lines.push('## Covers')
   lines.push(`- Breakfast: ${brief.covers.breakfast}`)

--- a/lib/daily-brief-generate.ts
+++ b/lib/daily-brief-generate.ts
@@ -312,15 +312,24 @@ export async function generateAndPersistDailyBrief(
     generated_at: new Date().toISOString(),
     model: DAILY_BRIEF_MODEL_ID,
     prompt_version: PROMPT_VERSION,
+    // A fresh AI generation always discards any prior editor overrides — the
+    // user has been warned in the UI before getting here.
+    headline_override: null,
+    summary_override: null,
+    overridden_by: null,
+    overridden_at: null,
   }
   if (args.generatedBy) row.generated_by = args.generatedBy
   else row.generated_by = null
 
-  const { data, error } = await supabase
-    .from('daily_brief')
-    .upsert(row as never, { onConflict: 'tenant_id,day_id' })
-    .select('id, content, generated_at, model, prompt_version')
-    .single()
+  // Override columns added in 00050; cast until `pnpm db:types` regenerates `types/supabase.ts`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = (await (supabase.from('daily_brief') as any)
+    .upsert(row, { onConflict: 'tenant_id,day_id' })
+    .select(
+      'id, content, generated_at, model, prompt_version, headline_override, summary_override, overridden_by, overridden_at'
+    )
+    .single()) as { data: DailyBriefPersistedRow; error: { message: string } | null }
 
   if (error) return { success: false, error: error.message }
 
@@ -335,6 +344,22 @@ export async function generateAndPersistDailyBrief(
       generated_at: data.generated_at,
       model: data.model,
       prompt_version: data.prompt_version,
+      headline_override: data.headline_override,
+      summary_override: data.summary_override,
+      overridden_by: data.overridden_by,
+      overridden_at: data.overridden_at,
     },
   }
+}
+
+type DailyBriefPersistedRow = {
+  id: string
+  content: unknown
+  generated_at: string
+  model: string
+  prompt_version: string
+  headline_override: string | null
+  summary_override: string | null
+  overridden_by: string | null
+  overridden_at: string | null
 }

--- a/lib/morning-brief-cron.ts
+++ b/lib/morning-brief-cron.ts
@@ -48,7 +48,10 @@ function briefToHtml(
   dateLabel: string,
   staffLines?: StaffLine[]
 ) {
-  const body = formatDailyBriefMarkdown(brief.content)
+  const body = formatDailyBriefMarkdown(brief.content, {
+    headline_override: brief.headline_override,
+    summary_override: brief.summary_override,
+  })
     .split('\n')
     .map((line) => {
       if (line.startsWith('# ')) {
@@ -299,7 +302,13 @@ export async function runMorningBriefEmailCron(): Promise<MorningBriefCronResult
           staffShiftsForEmail.length > 0
             ? `\n\n## Staff today\n${staffShiftsForEmail.map((s) => `- ${formatStaffLine(s)}`).join('\n')}`
             : ''
-        const text = formatDailyBriefMarkdown(brief.content) + staffSection + `\n\n${dayUrl}\n`
+        const text =
+          formatDailyBriefMarkdown(brief.content, {
+            headline_override: brief.headline_override,
+            summary_override: brief.summary_override,
+          }) +
+          staffSection +
+          `\n\n${dayUrl}\n`
         const html = briefToHtml(
           brief,
           tenant.name,

--- a/messages/de.json
+++ b/messages/de.json
@@ -165,7 +165,16 @@
       "regenerateActions": "Vorgeschlagene Maßnahmen neu erzeugen",
       "sectionRegenerated": "Abschnitt aktualisiert",
       "sectionRegenFailed": "Abschnitt konnte nicht neu erzeugt werden",
-      "sectionRateLimited": "Limit für Abschnittserneuerung erreicht. Bitte morgen erneut versuchen."
+      "sectionRateLimited": "Limit für Abschnittserneuerung erreicht. Bitte morgen erneut versuchen.",
+      "editHeadlineLabel": "Überschrift bearbeiten",
+      "editSummaryLabel": "Zusammenfassung bearbeiten",
+      "editSaved": "Briefing aktualisiert",
+      "editSaveFailed": "Bearbeitung konnte nicht gespeichert werden",
+      "edited": "Bearbeitet",
+      "editedBy": "Bearbeitet von {name}",
+      "editedByAt": "Bearbeitet von {name} · {time}",
+      "editedBadge": "Von einem Editor bearbeitet",
+      "regenerateDiscardWarning": "Bei einer Neugenerierung gehen deine Änderungen an Überschrift und Zusammenfassung verloren. Fortfahren?"
     },
     "quickAdd": {
       "openButton": "Schnell hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -269,7 +269,16 @@
       "regenerateActions": "Regenerate suggested actions",
       "sectionRegenerated": "Section updated",
       "sectionRegenFailed": "Could not regenerate section",
-      "sectionRateLimited": "Section regen limit reached. Try again tomorrow."
+      "sectionRateLimited": "Section regen limit reached. Try again tomorrow.",
+      "editHeadlineLabel": "Edit headline",
+      "editSummaryLabel": "Edit summary",
+      "editSaved": "Brief updated",
+      "editSaveFailed": "Could not save edit",
+      "edited": "Edited",
+      "editedBy": "Edited by {name}",
+      "editedByAt": "Edited by {name} · {time}",
+      "editedBadge": "Edited by an editor",
+      "regenerateDiscardWarning": "Regenerating will discard your edits to the headline and summary. Continue?"
     },
     "quickAdd": {
       "openButton": "Quick add",

--- a/messages/es.json
+++ b/messages/es.json
@@ -165,7 +165,16 @@
       "regenerateActions": "Regenerar acciones sugeridas",
       "sectionRegenerated": "Sección actualizada",
       "sectionRegenFailed": "No se pudo regenerar la sección",
-      "sectionRateLimited": "Límite de regeneración de sección alcanzado. Intente mañana."
+      "sectionRateLimited": "Límite de regeneración de sección alcanzado. Intente mañana.",
+      "editHeadlineLabel": "Editar titular",
+      "editSummaryLabel": "Editar resumen",
+      "editSaved": "Resumen actualizado",
+      "editSaveFailed": "No se pudo guardar la edición",
+      "edited": "Editado",
+      "editedBy": "Editado por {name}",
+      "editedByAt": "Editado por {name} · {time}",
+      "editedBadge": "Editado por un editor",
+      "regenerateDiscardWarning": "Regenerar descartará tus ediciones al titular y al resumen. ¿Continuar?"
     },
     "quickAdd": {
       "openButton": "Añadir rápido",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -269,7 +269,16 @@
       "regenerateActions": "Régénérer les actions suggérées",
       "sectionRegenerated": "Section mise à jour",
       "sectionRegenFailed": "Impossible de régénérer la section",
-      "sectionRateLimited": "Limite de régénération de section atteinte. Réessayez demain."
+      "sectionRateLimited": "Limite de régénération de section atteinte. Réessayez demain.",
+      "editHeadlineLabel": "Modifier le titre",
+      "editSummaryLabel": "Modifier le résumé",
+      "editSaved": "Briefing mis à jour",
+      "editSaveFailed": "Impossible d'enregistrer la modification",
+      "edited": "Modifié",
+      "editedBy": "Modifié par {name}",
+      "editedByAt": "Modifié par {name} · {time}",
+      "editedBadge": "Modifié par un éditeur",
+      "regenerateDiscardWarning": "La régénération supprimera vos modifications du titre et du résumé. Continuer ?"
     },
     "quickAdd": {
       "openButton": "Ajout rapide",

--- a/supabase/migrations/00050_add_daily_brief_overrides.sql
+++ b/supabase/migrations/00050_add_daily_brief_overrides.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- Migration 00050: Editor overrides for daily_brief headline + summary
+-- =============================================================================
+-- Editors can manually edit the brief's headline / summary to fix typos,
+-- clarify phrasing, or soften tone without throwing away the rest of the
+-- LLM-generated content. Overrides are stored alongside the original
+-- `content` jsonb so the AI output is preserved (for diffing / restoring)
+-- and so a future Regenerate cleanly clears the human edits.
+--
+-- Existing RLS policies on daily_brief already restrict UPDATE to tenant
+-- editors, so no new policies are needed.
+-- =============================================================================
+
+BEGIN;
+
+ALTER TABLE daily_brief
+  ADD COLUMN headline_override text,
+  ADD COLUMN summary_override  text,
+  ADD COLUMN overridden_by     uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  ADD COLUMN overridden_at     timestamptz;
+
+COMMIT;

--- a/tests/actions/daily-brief.test.ts
+++ b/tests/actions/daily-brief.test.ts
@@ -67,6 +67,10 @@ function makeBriefRecord(generatedAt = NOW): DailyBriefRecord {
     generated_at: generatedAt,
     model: 'openai/gpt-5.4',
     prompt_version: 'v1',
+    headline_override: null,
+    summary_override: null,
+    overridden_by: null,
+    overridden_at: null,
   }
 }
 

--- a/types/daily-brief.ts
+++ b/types/daily-brief.ts
@@ -37,4 +37,8 @@ export type DailyBriefRecord = {
   generated_at: string
   model: string
   prompt_version: string
+  headline_override: string | null
+  summary_override: string | null
+  overridden_by: string | null
+  overridden_at: string | null
 }


### PR DESCRIPTION
## Summary
- Adds inline edit affordance (pencil icon, Esc cancels, Cmd/Ctrl+Enter saves) on the daily brief's headline and summary inside the editor's day-info-banner dialog.
- Persists overrides in new `daily_brief.{headline,summary}_override` columns plus `overridden_by` / `overridden_at` (migration `00050`); the original AI `content` jsonb is preserved.
- Shows a small "Edited" badge with author tooltip (name resolved from membership) to both editors and viewers; viewers do not see the pencil.
- Markdown copy-to-clipboard and the morning-brief email both prefer the override when present, so external recipients always read the human-curated wording.
- Regenerate (full or via the stale prompt) shows a confirm dialog when overrides exist, then clears them via `generateAndPersistDailyBrief` upserting nulls.
- New `updateBriefOverride(dateIso, { headline?, summary? })` server action; existing RLS on `daily_brief` restricts UPDATE to tenant editors so no policy changes were needed.

## Files changed
- `supabase/migrations/00050_add_daily_brief_overrides.sql` — new columns
- `types/daily-brief.ts` — extends `DailyBriefRecord` with override fields
- `app/[tenant]/day/[date]/queries.ts` — selects overrides; cast to bypass stale `types/supabase.ts`
- `app/actions/daily-brief.ts` — new `updateBriefOverride`, refactors `getDailyBrief` / `regenerateBriefSection` to reuse the central reader
- `lib/daily-brief-generate.ts` — clears overrides on regen
- `lib/daily-brief-format.ts` — accepts optional overrides, prefers them in markdown
- `lib/morning-brief-cron.ts` — passes overrides into formatter + html
- `components/day-info-banner.tsx` — `InlineEditableText` + `BriefEditedBadge`, regen-confirm flow
- `components/daily-brief-card.tsx` — viewer badge + override-preferring display
- `app/[tenant]/day/[date]/page.tsx`, `DayViewClient.tsx`, `viewer-day-dashboard.tsx` — wire `briefOverrideAuthorName` (resolved server-side)
- `messages/{en,fr,de,es}.json` — new strings (`editHeadlineLabel`, `edited`, `regenerateDiscardWarning`, …)
- `tests/actions/daily-brief.test.ts` — fixture updated for new fields

## Notes
- `pnpm db:types` was not run in this environment; the override columns are accessed through narrow casts (`as any` on the table builder, typed result cast) until CI / the next regen picks up the schema change.
- Existing RLS update policy on `daily_brief` already requires `is_tenant_editor(tenant_id)`, so the new override columns are write-protected by the database, not just the action.

## Test plan
- [ ] Editor: hover over headline / summary in the daily-brief dialog → pencil appears; click → textarea; Esc cancels; Cmd/Ctrl+Enter saves; "Edited" badge appears with author tooltip
- [ ] Viewer (`ViewerDayDashboard`): override text is shown, no pencil, badge tooltip resolves to editor name
- [ ] Copy markdown: clipboard contains override headline/summary
- [ ] Trigger regenerate with overrides set → confirm prompt appears; on confirm, overrides clear and the new AI text replaces them
- [ ] Run morning-brief cron locally → email body uses overridden wording
- [ ] Non-editor cannot call `updateBriefOverride` (RLS rejects)
- [ ] Migration applies cleanly on `supabase db reset`

Closes #177

https://claude.ai/code/session_01CvCwjhFCpJ7SDpP1U27btP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvCwjhFCpJ7SDpP1U27btP)_