### PR TITLE
whitelabel: replace Courseday CTA in morning brief email

### DIFF
--- a/lib/morning-brief-cron.ts
+++ b/lib/morning-brief-cron.ts
@@ -17,71 +17,9 @@ import {
 import { getWeatherForTenantId } from '@/app/actions/weather'
 import { dayHasPlannedContent, generateAndPersistDailyBrief } from '@/lib/daily-brief-generate'
 import type { DailyBriefRecord } from '@/types/daily-brief'
+import { briefToHtml, formatStaffLine } from '@/lib/morning-brief-html'
 
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
-
-type StaffLine = {
-  name: string
-  role: string | null
-  start_time: string | null
-  end_time: string | null
-}
-
-function formatStaffLine(s: StaffLine): string {
-  const time =
-    s.start_time && s.end_time ? `${s.start_time.slice(0, 5)}–${s.end_time.slice(0, 5)}` : null
-  const detail = [s.role, time].filter(Boolean).join(' ')
-  return detail ? `${s.name} (${detail})` : s.name
-}
-
-export function briefToHtml(
-  brief: DailyBriefRecord,
-  tenantName: string,
-  dayUrl: string,
-  dateLabel: string,
-  staffLines?: StaffLine[]
-) {
-  const body = formatDailyBriefMarkdown(brief.content, {
-    headline_override: brief.headline_override,
-    summary_override: brief.summary_override,
-  })
-    .split('\n')
-    .map((line) => {
-      if (line.startsWith('# ')) {
-        return `<h1 style="font-size:20px;margin:0 0 12px;">${escapeHtml(line.slice(2))}</h1>`
-      }
-      if (line.startsWith('## ')) {
-        return `<h2 style="font-size:15px;margin:20px 0 8px;">${escapeHtml(line.slice(3))}</h2>`
-      }
-      if (line.trim() === '') return '<br/>'
-      if (line.startsWith('- ')) {
-        return `<p style="margin:4px 0 4px 12px;">• ${escapeHtml(line.slice(2))}</p>`
-      }
-      return `<p style="margin:8px 0;">${escapeHtml(line)}</p>`
-    })
-    .join('')
-
-  const staffSection =
-    staffLines && staffLines.length > 0
-      ? `<h2 style="font-size:15px;margin:20px 0 8px;">Staff today</h2>${staffLines.map((s) => `<p style="margin:4px 0 4px 12px;">• ${escapeHtml(formatStaffLine(s))}</p>`).join('')}`
-      : ''
-
-  return `
-    <div style="font-family: system-ui, -apple-system, Segoe UI, sans-serif; font-size: 14px; color: #111; max-width: 560px;">
-      <p style="color:#555; font-size:13px; margin:0 0 16px;">${escapeHtml(tenantName)} · ${escapeHtml(dateLabel)}</p>
-      ${body}
-      ${staffSection}
-      <p style="margin-top: 24px;"><a href="${escapeHtml(dayUrl)}" style="color: #2563eb;">Open day in ${escapeHtml(tenantName)}</a></p>
-    </div>
-  `
-}
+export { briefToHtml }
 
 export type MorningBriefCronResult = {
   ok: true

--- a/lib/morning-brief-cron.ts
+++ b/lib/morning-brief-cron.ts
@@ -41,7 +41,7 @@ function formatStaffLine(s: StaffLine): string {
   return detail ? `${s.name} (${detail})` : s.name
 }
 
-function briefToHtml(
+export function briefToHtml(
   brief: DailyBriefRecord,
   tenantName: string,
   dayUrl: string,
@@ -78,7 +78,7 @@ function briefToHtml(
       <p style="color:#555; font-size:13px; margin:0 0 16px;">${escapeHtml(tenantName)} · ${escapeHtml(dateLabel)}</p>
       ${body}
       ${staffSection}
-      <p style="margin-top: 24px;"><a href="${escapeHtml(dayUrl)}" style="color: #2563eb;">Open day in Courseday</a></p>
+      <p style="margin-top: 24px;"><a href="${escapeHtml(dayUrl)}" style="color: #2563eb;">Open day in ${escapeHtml(tenantName)}</a></p>
     </div>
   `
 }

--- a/lib/morning-brief-html.ts
+++ b/lib/morning-brief-html.ts
@@ -1,0 +1,67 @@
+import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
+import type { DailyBriefRecord } from '@/types/daily-brief'
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export type StaffLine = {
+  name: string
+  role: string | null
+  start_time: string | null
+  end_time: string | null
+}
+
+export function formatStaffLine(s: StaffLine): string {
+  const time =
+    s.start_time && s.end_time ? `${s.start_time.slice(0, 5)}–${s.end_time.slice(0, 5)}` : null
+  const detail = [s.role, time].filter(Boolean).join(' ')
+  return detail ? `${s.name} (${detail})` : s.name
+}
+
+export function briefToHtml(
+  brief: DailyBriefRecord,
+  tenantName: string,
+  dayUrl: string,
+  dateLabel: string,
+  staffLines?: StaffLine[]
+) {
+  const body = formatDailyBriefMarkdown(brief.content, {
+    headline_override: brief.headline_override,
+    summary_override: brief.summary_override,
+  })
+    .split('\n')
+    .map((line) => {
+      if (line.startsWith('# ')) {
+        return `<h1 style="font-size:20px;margin:0 0 12px;">${escapeHtml(line.slice(2))}</h1>`
+      }
+      if (line.startsWith('## ')) {
+        return `<h2 style="font-size:15px;margin:20px 0 8px;">${escapeHtml(line.slice(3))}</h2>`
+      }
+      if (line.trim() === '') return '<br/>'
+      if (line.startsWith('- ')) {
+        return `<p style="margin:4px 0 4px 12px;">• ${escapeHtml(line.slice(2))}</p>`
+      }
+      return `<p style="margin:8px 0;">${escapeHtml(line)}</p>`
+    })
+    .join('')
+
+  const staffSection =
+    staffLines && staffLines.length > 0
+      ? `<h2 style="font-size:15px;margin:20px 0 8px;">Staff today</h2>${staffLines.map((s) => `<p style="margin:4px 0 4px 12px;">• ${escapeHtml(formatStaffLine(s))}</p>`).join('')}`
+      : ''
+
+  return `
+    <div style="font-family: system-ui, -apple-system, Segoe UI, sans-serif; font-size: 14px; color: #111; max-width: 560px;">
+      <p style="color:#555; font-size:13px; margin:0 0 16px;">${escapeHtml(tenantName)} · ${escapeHtml(dateLabel)}</p>
+      ${body}
+      ${staffSection}
+      <p style="margin-top: 24px;"><a href="${escapeHtml(dayUrl)}" style="color: #2563eb;">Open day in ${escapeHtml(tenantName)}</a></p>
+    </div>
+  `
+}

--- a/tests/lib/morning-brief-cron.test.ts
+++ b/tests/lib/morning-brief-cron.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { briefToHtml } from '@/lib/morning-brief-cron'
+import type { DailyBriefRecord } from '@/types/daily-brief'
+
+const sampleBrief: DailyBriefRecord = {
+  id: 'brief-1',
+  content: {
+    headline: 'Smooth service expected',
+    summary: 'Two activities and a busy lunch service.',
+    covers: { breakfast: 12, activities: 24, reservations: 36 },
+    vipNotes: [],
+    allergenRollup: [],
+    risks: [],
+    suggestedActions: [],
+  },
+  generated_at: '2026-05-10T07:00:00.000Z',
+  model: 'test-model',
+  prompt_version: '1',
+  headline_override: null,
+  summary_override: null,
+  overridden_by: null,
+  overridden_at: null,
+}
+
+describe('briefToHtml whitelabelling', () => {
+  it('renders the tenant name in the CTA and contains no "Courseday" string', () => {
+    const tenantName = 'Pebble Beach Golf Links'
+    const html = briefToHtml(
+      sampleBrief,
+      tenantName,
+      'https://pebble.example.com/day/2026-05-10',
+      '2026-05-10'
+    )
+
+    expect(html).toContain(tenantName)
+    expect(html).toContain(`Open day in ${tenantName}`)
+    expect(html).not.toContain('Courseday')
+  })
+
+  it('escapes tenant names containing HTML-sensitive characters', () => {
+    const tenantName = 'Smith & Sons <Golf>'
+    const html = briefToHtml(
+      sampleBrief,
+      tenantName,
+      'https://example.com/day/2026-05-10',
+      '2026-05-10'
+    )
+
+    expect(html).not.toContain('Courseday')
+    expect(html).not.toContain('<Golf>')
+    expect(html).toContain('Smith &amp; Sons &lt;Golf&gt;')
+  })
+})

--- a/tests/lib/morning-brief-html.test.ts
+++ b/tests/lib/morning-brief-html.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { briefToHtml } from '@/lib/morning-brief-cron'
+import { briefToHtml } from '@/lib/morning-brief-html'
 import type { DailyBriefRecord } from '@/types/daily-brief'
 
 const sampleBrief: DailyBriefRecord = {


### PR DESCRIPTION
## Summary
- Replace hardcoded "Open day in Courseday" CTA in the morning brief email with `Open day in ${tenantName}` (HTML-escaped).
- Export `briefToHtml` so it can be unit-tested.
- Add `tests/lib/morning-brief-cron.test.ts` asserting the rendered HTML contains the tenant name and contains zero literal "Courseday" strings, plus an HTML-escape sanity case.

The remaining "Courseday" string in the file is the `RESEND_FROM_EMAIL` env fallback (`'Courseday <onboarding@resend.dev>'`), which is never customer-visible — `extractEmailAddress` strips it down to the `@resend.dev` address, and the displayed From-name comes from `tenantFromName` (`email_from_name ?? tenant.name`). Per the ticket, From-name handling is a separate ticket.

Closes #161

## Test plan
- [ ] CI: `unit-tests` job passes (new `morning-brief-cron.test.ts` runs).
- [ ] CI: `typecheck` + `lint` + `build` jobs pass.
- [ ] (Optional) Trigger morning brief from editor day-view button locally and visually confirm CTA reads "Open day in &lt;Tenant&gt;".


---
_Generated by [Claude Code](https://claude.ai/code/session_01GNC1ECj2sYmBhhxZzE7zQu)_