### PR TITLE
feat(auth): branded tenant sign-up page (#168)

### DIFF
--- a/app/[tenant]/auth/sign-up/page.tsx
+++ b/app/[tenant]/auth/sign-up/page.tsx
@@ -1,6 +1,49 @@
-import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { getTranslations } from 'next-intl/server'
+import { Logo } from '@/components/logo'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
 
-/** Self-serve sign-up disabled; owners create venue on root domain. Team joins via invite. */
-export default function SignUpPage() {
-  redirect('/auth/sign-in')
+type Props = {
+  params: Promise<{ tenant: string }>
+}
+
+export default async function TenantSignUpPage({ params }: Props) {
+  const { tenant } = await params
+
+  const supabase = createSupabaseServiceClient()
+  const { data } = await supabase
+    .from('tenants')
+    .select('name, logo_url')
+    .eq('slug', tenant)
+    .maybeSingle()
+
+  const t = await getTranslations('Platform.auth')
+  const tenantName = data?.name ?? null
+  const logoUrl = data?.logo_url ?? null
+  const heading = tenantName ? `Join ${tenantName}` : t('signInTitle')
+
+  return (
+    <div className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="flex justify-center">
+          <Logo logoUrl={logoUrl} tenantName={tenantName} className="text-2xl" />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <h1 className="text-center text-xl font-semibold tracking-tight">{heading}</h1>
+          </CardHeader>
+
+          <CardContent className="space-y-4 pt-2 text-center">
+            <p className="text-muted-foreground text-sm">{t('inviteOnlyHint')}</p>
+            <Button asChild className="w-full">
+              <Link href="/auth/sign-in">{t('backToSignIn')}</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary

Closes the remaining acceptance criterion on issue #168 (sign-up half — sign-in already shipped in #188).

`app/[tenant]/auth/sign-up/page.tsx` previously did `redirect('/auth/sign-in')`, bouncing visitors out of the tenant's branded shell. It now resolves the tenant via `slug`, fetches `name` + `logo_url`, and renders a tenant-themed card containing:

- Tenant logo (or name fallback) above the card
- `Join {tenant.name}` heading
- `Platform.auth.inviteOnlyHint` body copy (already translated in en/fr/de/es)
- "Back to sign in" CTA pointing at `/auth/sign-in`

Self-serve sign-up is intentionally disabled in this product (owners onboard via `/new`, members via invite), so the page surfaces the invite-only constraint inside the whitelabelled environment instead of inventing a new flow. Palette is inherited automatically from the `.tenant-themed` ancestor in `app/[tenant]/layout.tsx`. No server-action changes; `app/actions/auth.ts` is untouched.

## Test plan

- [ ] `pnpm dev` and visit `http://demo.localhost:3000/auth/sign-up` — verify branded card, no redirect, tenant logo + name visible
- [ ] Click "Back to sign in" — lands on `http://demo.localhost:3000/auth/sign-in` with the same theme
- [ ] Visit `http://localhost:3000/auth/sign-in` (root) — unchanged
- [ ] `pnpm test:e2e -- tests/e2e/auth.spec.ts` — auth E2E still passes (no sign-up coverage to update)

https://claude.ai/code/session_01Gx5HMQ7BiYsk7qrCtDmnVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gx5HMQ7BiYsk7qrCtDmnVg)_