### PR TITLE
feat(quick-add): multi-item parsing + review checklist (#171)

### DIFF
--- a/app/actions/quick-add.ts
+++ b/app/actions/quick-add.ts
@@ -8,15 +8,22 @@ import { generateQuickAddParse } from '@/lib/quick-add-generate'
 import type { QuickAddParseData } from '@/lib/quick-add-types'
 import type { ActionResponse } from '@/types/actions'
 
+export type QuickAddParseResult = {
+  items: QuickAddParseData[]
+}
+
 /**
- * Classify and extract fields from free text. No DB writes.
+ * Classify and extract fields from free text. Returns one or more parsed items
+ * (the LLM emits an array — single-item input yields a length-1 array).
+ * Rate limiting is per request, not per item.
+ * No DB writes.
  * @param input raw user text
  * @param contextDate Y-M-D of the day view
  */
 export async function parseQuickAdd(
   input: string,
   contextDate: string
-): Promise<ActionResponse<QuickAddParseData>> {
+): Promise<ActionResponse<QuickAddParseResult>> {
   const tenantId = await getTenantId()
   const user = await requireEditor(tenantId)
 
@@ -41,5 +48,5 @@ export async function parseQuickAdd(
     return { success: false, error: gen.error }
   }
 
-  return { success: true, data: gen.data }
+  return { success: true, data: { items: gen.items } }
 }

--- a/components/quick-add-input.tsx
+++ b/components/quick-add-input.tsx
@@ -17,6 +17,10 @@ import { Label } from '@/components/ui/label'
 import { mutateWithOfflineQueue } from '@/lib/day-mutation-client'
 import { useTenant } from '@/lib/tenant-context'
 import { QuickAddReview, type QuickAddReviewPayload } from '@/components/quick-add-review'
+import {
+  QuickAddMultiReview,
+  type QuickAddMultiSaveResult,
+} from '@/components/quick-add-multi-review'
 import type { Activity, BreakfastConfiguration, Reservation } from '@/types/index'
 
 type Props = {
@@ -26,18 +30,92 @@ type Props = {
   disabled?: boolean
 }
 
-type View = { stage: 'input' } | { stage: 'review'; data: QuickAddParseData; raw: string }
+type View =
+  | { stage: 'input' }
+  | { stage: 'review'; data: QuickAddParseData; raw: string }
+  | { stage: 'multi-review'; items: QuickAddParseData[]; raw: string }
 
 function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(false)
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window === 'undefined' ? false : window.matchMedia('(max-width: 639px)').matches
+  )
   useEffect(() => {
     const mq = window.matchMedia('(max-width: 639px)')
-    setIsMobile(mq.matches)
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])
   return isMobile
+}
+
+async function savePayload(
+  payload: QuickAddReviewPayload,
+  tenantSlug: string,
+  fallbackContextDate: string
+): Promise<QuickAddMultiSaveResult> {
+  let dayId = payload.dayId
+  if (payload.contextDate !== fallbackContextDate) {
+    const ensured = await ensureDayExists(payload.contextDate)
+    if (!ensured.success) return { success: false, error: ensured.error }
+    dayId = ensured.data.id
+  }
+
+  if (payload.kind === 'activity') {
+    const result = await mutateWithOfflineQueue<Activity>({
+      entity: 'activities',
+      operation: 'create',
+      tenantSlug,
+      dayId,
+      payload: {
+        dayId,
+        title: payload.title,
+        startTime: payload.startTime || undefined,
+        endTime: payload.endTime || undefined,
+        expectedCovers: payload.expectedCovers,
+        notes: payload.notes || undefined,
+        allergens: payload.allergens.length > 0 ? payload.allergens : undefined,
+      },
+    })
+    if (!result.success) return { success: false, error: result.error }
+    return { success: true }
+  }
+  if (payload.kind === 'reservation') {
+    const result = await mutateWithOfflineQueue<Reservation>({
+      entity: 'reservations',
+      operation: 'create',
+      tenantSlug,
+      dayId,
+      payload: {
+        dayId,
+        guestName: payload.guestName || undefined,
+        guestCount: payload.guestCount,
+        startTime: payload.startTime || undefined,
+        endTime: payload.endTime || undefined,
+        notes: payload.notes || undefined,
+        tableBreakdown: payload.tableBreakdown.length > 0 ? payload.tableBreakdown : undefined,
+        allergens: payload.allergens.length > 0 ? payload.allergens : undefined,
+      },
+    })
+    if (!result.success) return { success: false, error: result.error }
+    return { success: true }
+  }
+  const result = await mutateWithOfflineQueue<BreakfastConfiguration>({
+    entity: 'breakfast',
+    operation: 'create',
+    tenantSlug,
+    dayId,
+    payload: {
+      dayId,
+      groupName: payload.groupName || undefined,
+      guestCount: payload.guestCount,
+      startTime: payload.startTime || undefined,
+      notes: payload.notes || undefined,
+      tableBreakdown: payload.tableBreakdown.length > 0 ? payload.tableBreakdown : undefined,
+      allergens: payload.allergens.length > 0 ? payload.allergens : undefined,
+    },
+  })
+  if (!result.success) return { success: false, error: result.error }
+  return { success: true }
 }
 
 export function QuickAddInput({ open, onOpenChange, contextDate, disabled }: Props) {
@@ -55,6 +133,10 @@ export function QuickAddInput({ open, onOpenChange, contextDate, disabled }: Pro
   const [isSaving, startSave] = useTransition()
   const descId = useId()
   const errId = useId()
+
+  // Reset transient state when the dialog/drawer closes. Cascading renders are
+  // expected here — the alternative (key-based remount) would interrupt the
+  // close animation.
 
   useEffect(() => {
     if (!open) {
@@ -80,7 +162,12 @@ export function QuickAddInput({ open, onOpenChange, contextDate, disabled }: Pro
         setError(r.error)
         return
       }
-      setView({ stage: 'review', data: r.data, raw: v })
+      const items = r.data.items
+      if (items.length > 1) {
+        setView({ stage: 'multi-review', items, raw: v })
+      } else {
+        setView({ stage: 'review', data: items[0]!, raw: v })
+      }
     })
   }
 
@@ -93,86 +180,37 @@ export function QuickAddInput({ open, onOpenChange, contextDate, disabled }: Pro
     if (isSaving) return
     setSaveError(null)
     startSave(async () => {
-      // If user changed the date (via the dateAmbiguous picker), resolve a new dayId.
-      let dayId = payload.dayId
-      if (payload.contextDate !== (view.stage === 'review' ? view.data.contextDate : '')) {
-        const ensured = await ensureDayExists(payload.contextDate)
-        if (!ensured.success) {
-          setSaveError(ensured.error)
-          return
-        }
-        dayId = ensured.data.id
+      const fallback = view.stage === 'review' ? view.data.contextDate : ''
+      const result = await savePayload(payload, tenantSlug, fallback)
+      if (!result.success) {
+        setSaveError(result.error)
+        return
       }
-
-      if (payload.kind === 'activity') {
-        const result = await mutateWithOfflineQueue<Activity>({
-          entity: 'activities',
-          operation: 'create',
-          tenantSlug,
-          dayId,
-          payload: {
-            dayId,
-            title: payload.title,
-            startTime: payload.startTime || undefined,
-            endTime: payload.endTime || undefined,
-            expectedCovers: payload.expectedCovers,
-            notes: payload.notes || undefined,
-            allergens: payload.allergens.length > 0 ? payload.allergens : undefined,
-          },
-        })
-        if (!result.success) {
-          setSaveError(result.error)
-          return
-        }
-      } else if (payload.kind === 'reservation') {
-        const result = await mutateWithOfflineQueue<Reservation>({
-          entity: 'reservations',
-          operation: 'create',
-          tenantSlug,
-          dayId,
-          payload: {
-            dayId,
-            guestName: payload.guestName || undefined,
-            guestCount: payload.guestCount,
-            startTime: payload.startTime || undefined,
-            endTime: payload.endTime || undefined,
-            notes: payload.notes || undefined,
-            tableBreakdown: payload.tableBreakdown.length > 0 ? payload.tableBreakdown : undefined,
-            allergens: payload.allergens.length > 0 ? payload.allergens : undefined,
-          },
-        })
-        if (!result.success) {
-          setSaveError(result.error)
-          return
-        }
-      } else {
-        const result = await mutateWithOfflineQueue<BreakfastConfiguration>({
-          entity: 'breakfast',
-          operation: 'create',
-          tenantSlug,
-          dayId,
-          payload: {
-            dayId,
-            groupName: payload.groupName || undefined,
-            guestCount: payload.guestCount,
-            startTime: payload.startTime || undefined,
-            notes: payload.notes || undefined,
-            tableBreakdown: payload.tableBreakdown.length > 0 ? payload.tableBreakdown : undefined,
-            allergens: payload.allergens.length > 0 ? payload.allergens : undefined,
-          },
-        })
-        if (!result.success) {
-          setSaveError(result.error)
-          return
-        }
-      }
-
       toast.success(t('saved'))
       close()
       const target = `/day/${payload.contextDate}`
       if (!pathname.startsWith(target)) router.push(target)
       else router.refresh()
     })
+  }
+
+  function navigateAfterMulti(target: string) {
+    close()
+    if (!pathname.startsWith(target)) router.push(target)
+    else router.refresh()
+  }
+
+  async function handleMultiSaveOne(
+    payload: QuickAddReviewPayload
+  ): Promise<QuickAddMultiSaveResult> {
+    return savePayload(payload, tenantSlug, payload.contextDate)
+  }
+
+  function handleMultiAllDone() {
+    toast.success(t('saved'))
+    const dest =
+      view.stage === 'multi-review' ? (view.items[0]?.contextDate ?? contextDate) : contextDate
+    navigateAfterMulti(`/day/${dest}`)
   }
 
   const isAiNotConfigured = Boolean(error?.includes('AI is not configured'))
@@ -239,9 +277,21 @@ export function QuickAddInput({ open, onOpenChange, contextDate, disabled }: Pro
         isPending={isSaving}
         error={saveError}
       />
+    ) : view.stage === 'multi-review' ? (
+      <QuickAddMultiReview
+        items={view.items}
+        onSaveOne={handleMultiSaveOne}
+        onAllDone={handleMultiAllDone}
+        onBack={handleBack}
+      />
     ) : null
 
-  const title = view.stage === 'input' ? t('title') : t('reviewTitle')
+  const title =
+    view.stage === 'input'
+      ? t('title')
+      : view.stage === 'multi-review'
+        ? t('multiReviewTitle')
+        : t('reviewTitle')
 
   if (isMobile) {
     return (

--- a/components/quick-add-multi-review.tsx
+++ b/components/quick-add-multi-review.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { Coffee, Flag, Loader2, UtensilsCrossed } from 'lucide-react'
+import { useFeatureFlag } from '@/lib/feature-flags-context'
+import type { QuickAddParseData } from '@/lib/quick-add-types'
+import type { QuickAddReviewPayload } from '@/components/quick-add-review'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+
+export type QuickAddMultiSaveResult = { success: true } | { success: false; error: string }
+
+export type QuickAddMultiReviewProps = {
+  items: QuickAddParseData[]
+  onSaveOne: (payload: QuickAddReviewPayload) => Promise<QuickAddMultiSaveResult>
+  onAllDone: () => void
+  onBack: () => void
+}
+
+type RowStatus =
+  | { state: 'idle' }
+  | { state: 'saving' }
+  | { state: 'saved' }
+  | { state: 'error'; error: string }
+
+function payloadFromItem(item: QuickAddParseData): QuickAddReviewPayload {
+  const base = {
+    dayId: item.dayId,
+    contextDate: item.contextDate,
+    notes: item.defaults.notes ?? '',
+    allergens: item.allergens,
+  }
+  if (item.kind === 'activity') {
+    const cov = item.defaults.expectedCovers.trim()
+    const n = cov ? parseInt(cov, 10) : NaN
+    return {
+      ...base,
+      kind: 'activity',
+      title: item.defaults.title.trim(),
+      startTime: item.defaults.startTime,
+      endTime: item.defaults.endTime,
+      ...(Number.isFinite(n) && n >= 0 ? { expectedCovers: n } : {}),
+    }
+  }
+  if (item.kind === 'reservation') {
+    const c = item.defaults.guestCount.trim()
+    const n = c ? parseInt(c, 10) : NaN
+    return {
+      ...base,
+      kind: 'reservation',
+      guestName: item.defaults.guestName.trim(),
+      startTime: item.defaults.startTime,
+      endTime: item.defaults.endTime,
+      tableBreakdown: item.tableBreakdown,
+      ...(Number.isFinite(n) && n >= 1 ? { guestCount: n } : {}),
+    }
+  }
+  const c = item.defaults.guestCount.trim()
+  const n = c ? parseInt(c, 10) : NaN
+  return {
+    ...base,
+    kind: 'breakfast',
+    groupName: item.defaults.groupName.trim(),
+    startTime: item.defaults.startTime,
+    tableBreakdown: item.tableBreakdown,
+    ...(Number.isFinite(n) && n >= 1 ? { guestCount: n } : {}),
+  }
+}
+
+function itemTitle(item: QuickAddParseData): string {
+  if (item.kind === 'activity') return item.defaults.title || ''
+  if (item.kind === 'reservation') return item.defaults.guestName || ''
+  return item.defaults.groupName || ''
+}
+
+function itemCount(item: QuickAddParseData): string {
+  if (item.kind === 'activity') return item.defaults.expectedCovers
+  return item.defaults.guestCount
+}
+
+function KindIcon({ kind }: { kind: QuickAddParseData['kind'] }) {
+  if (kind === 'activity') return <Flag className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+  if (kind === 'reservation')
+    return <UtensilsCrossed className="h-4 w-4 text-amber-600" aria-hidden="true" />
+  return <Coffee className="h-4 w-4 text-blue-600" aria-hidden="true" />
+}
+
+export function QuickAddMultiReview({
+  items,
+  onSaveOne,
+  onAllDone,
+  onBack,
+}: QuickAddMultiReviewProps) {
+  const t = useTranslations('Tenant.quickAdd')
+  const showReservations = useFeatureFlag('reservations')
+  const showBreakfast = useFeatureFlag('breakfast_config')
+
+  const [accepted, setAccepted] = useState<boolean[]>(() => items.map(() => true))
+  const [statuses, setStatuses] = useState<RowStatus[]>(() => items.map(() => ({ state: 'idle' })))
+  const [isSaving, setIsSaving] = useState(false)
+
+  const allowed = useMemo(
+    () => items.map((it) => isItemAllowed(it, showReservations, showBreakfast)),
+    [items, showReservations, showBreakfast]
+  )
+
+  const acceptedCount = accepted.reduce(
+    (n, on, i) => (on && allowed[i] && statuses[i]!.state !== 'saved' ? n + 1 : n),
+    0
+  )
+
+  function toggleAccept(idx: number) {
+    if (isSaving) return
+    setAccepted((a) => a.map((v, i) => (i === idx ? !v : v)))
+    setStatuses((s) => s.map((v, i) => (i === idx && v.state === 'error' ? { state: 'idle' } : v)))
+  }
+
+  async function handleCreate() {
+    if (isSaving || acceptedCount === 0) return
+    setIsSaving(true)
+
+    const next = [...statuses]
+    let allSaved = true
+    for (let i = 0; i < items.length; i++) {
+      if (!accepted[i] || !allowed[i]) {
+        if (next[i]!.state !== 'saved') allSaved = false
+        continue
+      }
+      if (next[i]!.state === 'saved') continue
+
+      next[i] = { state: 'saving' }
+      setStatuses([...next])
+      const payload = payloadFromItem(items[i]!)
+      const result = await onSaveOne(payload)
+      if (result.success) {
+        next[i] = { state: 'saved' }
+      } else {
+        next[i] = { state: 'error', error: result.error }
+        allSaved = false
+        // Auto-uncheck failed row so user can retry without un-checking manually.
+        setAccepted((a) => a.map((v, j) => (j === i ? false : v)))
+      }
+      setStatuses([...next])
+    }
+
+    setIsSaving(false)
+
+    const allDone = next.every((s, i) => s.state === 'saved' || !accepted[i] || !allowed[i])
+    const anySaved = next.some((s) => s.state === 'saved')
+    if (allDone && anySaved && allSaved) onAllDone()
+  }
+
+  return (
+    <div className="space-y-3" aria-label={t('multiReviewTitle')}>
+      <p className="text-muted-foreground text-sm">
+        {t('multiReviewDescription', { count: items.length })}
+      </p>
+
+      <ul className="divide-border divide-y rounded-md border">
+        {items.map((item, idx) => {
+          const status = statuses[idx]!
+          const isAllowed = allowed[idx]!
+          const on = accepted[idx]! && isAllowed
+          const title = itemTitle(item) || t(`primary${capKind(item.kind)}` as PrimaryKey)
+          const time = item.defaults.startTime || ''
+          const count = itemCount(item)
+          const rowId = `qa-multi-row-${idx}`
+          const checkedId = `qa-multi-accept-${idx}`
+          return (
+            <li
+              key={`${item.kind}-${idx}`}
+              id={rowId}
+              className={cn(
+                'flex items-start gap-3 px-3 py-2.5',
+                status.state === 'saved' && 'bg-emerald-50/60 opacity-70 dark:bg-emerald-950/20',
+                status.state === 'error' && 'bg-destructive/5'
+              )}
+            >
+              <div className="mt-1 shrink-0">
+                <KindIcon kind={item.kind} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium">{title}</span>
+                  <span className="text-muted-foreground shrink-0 text-xs">
+                    {t(`kind${capKind(item.kind)}` as KindKey)}
+                  </span>
+                </div>
+                <div className="text-muted-foreground mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-xs">
+                  {time && (
+                    <span>
+                      {t('startTimeLabel')}: {time}
+                    </span>
+                  )}
+                  {count && (
+                    <span>
+                      {item.kind === 'activity' ? t('expectedCoversLabel') : t('guestCountLabel')}:{' '}
+                      {count}
+                    </span>
+                  )}
+                  {item.dateAmbiguous && <span>{t('dateAmbiguousShort')}</span>}
+                </div>
+                {!isAllowed && (
+                  <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+                    {t('multiKindDisabled')}
+                  </p>
+                )}
+                {status.state === 'error' && (
+                  <p role="alert" className="text-destructive mt-1 text-xs">
+                    {status.error}
+                  </p>
+                )}
+                {status.state === 'saved' && (
+                  <p className="mt-1 text-xs text-emerald-700 dark:text-emerald-400">
+                    {t('multiRowSaved')}
+                  </p>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-2 pt-1">
+                {status.state === 'saving' && (
+                  <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
+                )}
+                <Label htmlFor={checkedId} className="sr-only">
+                  {t('multiAcceptToggle', { title })}
+                </Label>
+                <Switch
+                  id={checkedId}
+                  checked={on}
+                  onCheckedChange={() => toggleAccept(idx)}
+                  disabled={isSaving || !isAllowed || status.state === 'saved'}
+                  aria-label={t('multiAcceptToggle', { title })}
+                />
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onBack} disabled={isSaving}>
+          {t('back')}
+        </Button>
+        <Button type="button" onClick={handleCreate} disabled={isSaving || acceptedCount === 0}>
+          {isSaving ? (
+            <>
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              {t('saving')}
+            </>
+          ) : (
+            t('multiCreateButton', { count: acceptedCount })
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+type KindKey = 'kindActivity' | 'kindReservation' | 'kindBreakfast'
+type PrimaryKey = 'primaryActivity' | 'primaryReservation' | 'primaryBreakfast'
+
+function capKind(k: QuickAddParseData['kind']): 'Activity' | 'Reservation' | 'Breakfast' {
+  if (k === 'activity') return 'Activity'
+  if (k === 'reservation') return 'Reservation'
+  return 'Breakfast'
+}
+
+function isItemAllowed(
+  item: QuickAddParseData,
+  showReservations: boolean,
+  showBreakfast: boolean
+): boolean {
+  if (item.kind === 'activity') return true
+  if (item.kind === 'reservation') return showReservations
+  return showBreakfast
+}

--- a/components/quick-add-multi-review.tsx
+++ b/components/quick-add-multi-review.tsx
@@ -123,14 +123,13 @@ export function QuickAddMultiReview({
     setIsSaving(true)
 
     const next = [...statuses]
-    let allSaved = true
+    let attempted = 0
+    let errors = 0
     for (let i = 0; i < items.length; i++) {
-      if (!accepted[i] || !allowed[i]) {
-        if (next[i]!.state !== 'saved') allSaved = false
-        continue
-      }
+      if (!accepted[i] || !allowed[i]) continue
       if (next[i]!.state === 'saved') continue
 
+      attempted++
       next[i] = { state: 'saving' }
       setStatuses([...next])
       const payload = payloadFromItem(items[i]!)
@@ -139,7 +138,7 @@ export function QuickAddMultiReview({
         next[i] = { state: 'saved' }
       } else {
         next[i] = { state: 'error', error: result.error }
-        allSaved = false
+        errors++
         // Auto-uncheck failed row so user can retry without un-checking manually.
         setAccepted((a) => a.map((v, j) => (j === i ? false : v)))
       }
@@ -148,9 +147,7 @@ export function QuickAddMultiReview({
 
     setIsSaving(false)
 
-    const allDone = next.every((s, i) => s.state === 'saved' || !accepted[i] || !allowed[i])
-    const anySaved = next.some((s) => s.state === 'saved')
-    if (allDone && anySaved && allSaved) onAllDone()
+    if (attempted > 0 && errors === 0) onAllDone()
   }
 
   return (

--- a/lib/quick-add-generate.ts
+++ b/lib/quick-add-generate.ts
@@ -52,10 +52,14 @@ const allFields = z.object({
   allergenHints: z.array(z.string()).nullable(),
 })
 
-const quickAddLlmSchema = z.object({
+const quickAddLlmItemSchema = z.object({
   kind: z.enum(['activity', 'reservation', 'breakfast']),
   dateAmbiguous: z.boolean(),
   fields: allFields,
+})
+
+const quickAddLlmSchema = z.object({
+  items: z.array(quickAddLlmItemSchema).min(1).max(20),
 })
 
 // ---------------------------------------------------------------------------
@@ -391,7 +395,7 @@ function nu<T>(v: T | null | undefined): T | undefined {
 }
 
 function buildDataFromLlm(
-  out: z.infer<typeof quickAddLlmSchema>,
+  out: z.infer<typeof quickAddLlmItemSchema>,
   dayId: string,
   contextDate: string
 ): QuickAddParseData {
@@ -535,7 +539,7 @@ function buildDataFromLlm(
 
 export type GenerateQuickAddError = { success: false; error: string }
 export type GenerateQuickAddResult =
-  | { success: true; data: QuickAddParseData; promptVersion: string }
+  | { success: true; items: QuickAddParseData[]; promptVersion: string }
   | GenerateQuickAddError
 
 type AiUsage = {
@@ -614,6 +618,6 @@ export async function generateQuickAddParse(
     return { success: false, error: `Quick add AI error: ${short}` }
   }
 
-  const data = buildDataFromLlm(out, dayId, contextDate)
-  return { success: true, data, promptVersion: PROMPT_VERSION }
+  const items = out.items.map((item) => buildDataFromLlm(item, dayId, contextDate))
+  return { success: true, items, promptVersion: PROMPT_VERSION }
 }

--- a/lib/quick-add-prompt.ts
+++ b/lib/quick-add-prompt.ts
@@ -5,21 +5,42 @@ export const PROMPT_VERSION = 'v1' as const
 const CODES = ALLERGEN_CODES.join(', ')
 
 export const QUICK_ADD_SYSTEM = `You classify free-form text about venue operations and extract fields for the correct item type.
-Return JSON matching the required schema. Rules:
+Return JSON matching the required schema. The schema wraps an "items" array — emit ONE item per distinct booking/event the user describes (always at least one). If the user pastes a list of bookings (e.g. five reservations in an email), emit one entry per booking. If the text describes a single item, emit an items array of length 1.
+Rules:
 - kind: "activity" = programme item / event / class / tee time block; "reservation" = restaurant or table booking; "breakfast" = hotel breakfast service group.
-- dateAmbiguous: set true if the user refers to a date or weekday in a way that is ambiguous (e.g. "Saturday" could mean the upcoming Saturday in a different week, or a Saturday not matching the given context day) OR you cannot place times/dates for this item relative to the context. When true, OMIT startTime, endTime (or startTime for breakfast) or leave time fields out — the staff will set them on the page for the day they are viewing.
+- Each item is classified independently — a single paste can mix kinds (e.g. a tee time, a dinner reservation, and a breakfast block).
+- dateAmbiguous: set true (per item) if the user refers to a date or weekday in a way that is ambiguous (e.g. "Saturday" could mean the upcoming Saturday in a different week, or a Saturday not matching the given context day) OR you cannot place times/dates for this item relative to the context. When true, OMIT startTime, endTime (or startTime for breakfast) or leave time fields out — the staff will set them on the page for the day they are viewing.
 - The scheduled calendar day the user is viewing (context) is the anchor for "today", "this evening", etc. Use it to resolve "Saturday 8pm" to that Saturday if that Saturday IS the context day; if it clearly refers to a different day you cannot place on the context row, set dateAmbiguous: true and omit time fields.
 - Times: 24h strings as HH:MM (e.g. 20:00) as used in HTML time inputs, no seconds unless the schema accepts them; prefer HH:MM.
 - Allergen hints: in allergenHints, list short tokens from the user text. Use EU-14 codes from this list when possible: ${CODES}. Also include natural phrases (e.g. "no nuts", "dairy free") for post-processing. Our system maps synonyms.
 - For reservations: guestName is the party or contact name. guestCount = party size.
 - For breakfast: groupName = room block or group label (optional).
 - tableBreakdown: optional list of per-table or per-sub-party sizes (numbers) that sum to guest count if the user said e.g. "2 and 4".
-- notes: any other free text not already captured. Do not invent PII.`
+- notes: any other free text not already captured for that item. Do not invent PII.
+
+Examples (illustrative; adapt to actual user text):
+1) Single item, "Member golf 8am, 24 players" → items: [{ kind:"activity", fields:{ title:"Member golf", startTime:"08:00", expectedCovers:24 } }]
+2) Multi-reservation list:
+   "- Smith party of 6 at 7:30pm
+    - Lee, 2 guests, 8pm, no nuts
+    - Patel 4 at 8:15pm"
+   → items: [
+       { kind:"reservation", fields:{ guestName:"Smith", guestCount:6, startTime:"19:30" } },
+       { kind:"reservation", fields:{ guestName:"Lee", guestCount:2, startTime:"20:00", allergenHints:["no nuts"] } },
+       { kind:"reservation", fields:{ guestName:"Patel", guestCount:4, startTime:"20:15" } }
+     ]
+3) Mixed kinds in one paste:
+   "Tee time 9am, 16 players. Breakfast for room block A, 30 guests at 7am. Reservation: Garcia, 4, 8pm."
+   → items: [
+       { kind:"activity", fields:{ title:"Tee time", startTime:"09:00", expectedCovers:16 } },
+       { kind:"breakfast", fields:{ groupName:"Room block A", guestCount:30, startTime:"07:00" } },
+       { kind:"reservation", fields:{ guestName:"Garcia", guestCount:4, startTime:"20:00" } }
+     ]`
 
 export function buildUserPrompt(userText: string, _dayId: string, contextDateYmd: string): string {
   return `Context day (Y-M-D) for this day view: ${contextDateYmd}
 User said:
 ${userText}
 
-Extract classification and fields. If nothing fits a type, still pick the best match and set dateAmbiguous if times are unsafe.`
+Extract classification and fields for every distinct item described — emit one entry per item in the "items" array (always length ≥ 1). If only one item is described, return a single-element array. Different items can have different kinds. If nothing fits a type, still pick the best match and set dateAmbiguous if times are unsafe.`
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -310,7 +310,14 @@
       "back": "Back",
       "save": "Save",
       "saving": "Saving…",
-      "saved": "Added."
+      "saved": "Added.",
+      "multiReviewTitle": "Review items",
+      "multiReviewDescription": "We found {count} items. Toggle which to create, then confirm.",
+      "multiCreateButton": "Create {count} items",
+      "multiAcceptToggle": "Include {title}",
+      "multiKindDisabled": "This item type is not enabled for this club.",
+      "multiRowSaved": "Saved.",
+      "dateAmbiguousShort": "Date unclear"
     },
     "shortcuts": {
       "paletteTitle": "Command palette",

--- a/tests/components/quick-add-multi-review.test.tsx
+++ b/tests/components/quick-add-multi-review.test.tsx
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+
+vi.mock('@/lib/feature-flags-context', () => ({
+  useFeatureFlag: () => true,
+}))
+
+// Radix Switch relies on PointerEvent which jsdom doesn't fully support.
+// Swap for a native checkbox-styled button so tests are reliable.
+vi.mock('@/components/ui/switch', () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+    disabled,
+    'aria-label': ariaLabel,
+    id,
+  }: {
+    checked?: boolean
+    onCheckedChange?: (v: boolean) => void
+    disabled?: boolean
+    'aria-label'?: string
+    id?: string
+  }) => (
+    // eslint-disable-next-line no-restricted-syntax -- bespoke test stub for jsdom
+    <button
+      id={id}
+      type="button"
+      role="switch"
+      aria-checked={checked ? 'true' : 'false'}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={() => onCheckedChange?.(!checked)}
+    />
+  ),
+}))
+
+import { QuickAddMultiReview } from '@/components/quick-add-multi-review'
+import type { QuickAddParseData } from '@/lib/quick-add-types'
+
+const messages = {
+  Tenant: {
+    quickAdd: {
+      multiReviewTitle: 'Review items',
+      multiReviewDescription: 'We found {count} items. Toggle which to create, then confirm.',
+      multiCreateButton: 'Create {count} items',
+      multiAcceptToggle: 'Include {title}',
+      multiKindDisabled: 'This item type is not enabled for this club.',
+      multiRowSaved: 'Saved.',
+      dateAmbiguousShort: 'Date unclear',
+      back: 'Back',
+      saving: 'Saving…',
+      kindActivity: 'Activity',
+      kindReservation: 'Reservation',
+      kindBreakfast: 'Breakfast',
+      primaryActivity: 'Title',
+      primaryReservation: 'Guest name',
+      primaryBreakfast: 'Group name',
+      startTimeLabel: 'Start time',
+      expectedCoversLabel: 'Expected covers',
+      guestCountLabel: 'Guest count',
+    },
+  },
+}
+
+function renderWithIntl(ui: React.ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  )
+}
+
+const DAY = '00000000-0000-0000-0000-000000000001'
+const CTX = '2026-05-10'
+
+function activity(title: string, startTime: string, covers: string): QuickAddParseData {
+  return {
+    kind: 'activity',
+    dayId: DAY,
+    contextDate: CTX,
+    dateAmbiguous: false,
+    defaults: {
+      title,
+      description: '',
+      startTime,
+      endTime: '',
+      expectedCovers: covers,
+      notes: '',
+    },
+    allergens: [],
+    gapFieldKeys: [],
+    modelFilledFieldKeys: ['title', 'startTime'],
+  }
+}
+
+function reservation(name: string, count: string, startTime: string): QuickAddParseData {
+  return {
+    kind: 'reservation',
+    dayId: DAY,
+    contextDate: CTX,
+    dateAmbiguous: false,
+    defaults: { guestName: name, guestCount: count, startTime, endTime: '', notes: '' },
+    tableBreakdown: [],
+    allergens: [],
+    gapFieldKeys: [],
+    modelFilledFieldKeys: ['guestName', 'guestCount'],
+  }
+}
+
+function breakfast(group: string, count: string, startTime: string): QuickAddParseData {
+  return {
+    kind: 'breakfast',
+    dayId: DAY,
+    contextDate: CTX,
+    dateAmbiguous: false,
+    defaults: { groupName: group, guestCount: count, startTime, notes: '' },
+    tableBreakdown: [],
+    allergens: [],
+    gapFieldKeys: [],
+    modelFilledFieldKeys: ['groupName', 'guestCount'],
+  }
+}
+
+describe('QuickAddMultiReview', () => {
+  it('renders one row per item with title, time and count', () => {
+    const items = [
+      activity('Tee time', '09:00', '16'),
+      breakfast('Room block A', '30', '07:00'),
+      reservation('Garcia', '4', '20:00'),
+    ]
+    renderWithIntl(
+      <QuickAddMultiReview items={items} onSaveOne={vi.fn()} onAllDone={vi.fn()} onBack={vi.fn()} />
+    )
+
+    expect(screen.getByText('Tee time')).toBeInTheDocument()
+    expect(screen.getByText('Room block A')).toBeInTheDocument()
+    expect(screen.getByText('Garcia')).toBeInTheDocument()
+    expect(screen.getByText(/Start time: 09:00/)).toBeInTheDocument()
+    expect(screen.getByText(/Expected covers: 16/)).toBeInTheDocument()
+    expect(screen.getByText(/Guest count: 4/)).toBeInTheDocument()
+  })
+
+  it('Create button reflects accepted count and excludes deselected rows', async () => {
+    const items = [
+      reservation('Smith', '6', '19:30'),
+      reservation('Lee', '2', '20:00'),
+      reservation('Patel', '4', '20:15'),
+    ]
+    const onSaveOne = vi.fn().mockResolvedValue({ success: true })
+    const onAllDone = vi.fn()
+    renderWithIntl(
+      <QuickAddMultiReview
+        items={items}
+        onSaveOne={onSaveOne}
+        onAllDone={onAllDone}
+        onBack={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Create 3 items' })).toBeInTheDocument()
+
+    const leeToggle = screen.getByRole('switch', { name: 'Include Lee' })
+    fireEvent.click(leeToggle)
+
+    expect(screen.getByRole('button', { name: 'Create 2 items' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create 2 items' }))
+
+    await waitFor(() => expect(onSaveOne).toHaveBeenCalledTimes(2))
+    expect(onSaveOne.mock.calls.map((c) => c[0].guestName)).toEqual(['Smith', 'Patel'])
+    await waitFor(() => expect(onAllDone).toHaveBeenCalledTimes(1))
+  })
+
+  it('partial failure: errored row stays unchecked for retry, success rows do not retry', async () => {
+    const items = [reservation('Smith', '6', '19:30'), reservation('Lee', '2', '20:00')]
+    const onSaveOne = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, error: 'Network down' })
+    const onAllDone = vi.fn()
+
+    renderWithIntl(
+      <QuickAddMultiReview
+        items={items}
+        onSaveOne={onSaveOne}
+        onAllDone={onAllDone}
+        onBack={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create 2 items' }))
+
+    await waitFor(() => expect(screen.getByText('Network down')).toBeInTheDocument())
+    expect(onAllDone).not.toHaveBeenCalled()
+
+    expect(screen.getByText('Saved.')).toBeInTheDocument()
+
+    // Failed row's toggle is now off; create-button count reflects only that row
+    // when re-toggled.
+    const leeToggle = screen.getByRole('switch', { name: 'Include Lee' })
+    expect(leeToggle).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(leeToggle)
+    expect(screen.getByRole('button', { name: 'Create 1 items' })).toBeInTheDocument()
+
+    onSaveOne.mockResolvedValueOnce({ success: true })
+    fireEvent.click(screen.getByRole('button', { name: 'Create 1 items' }))
+
+    await waitFor(() => expect(onAllDone).toHaveBeenCalledTimes(1))
+    // Smith's row should not be re-saved (already saved). Total calls = 3:
+    // Smith (1st run, ok), Lee (1st run, fail), Lee (retry, ok).
+    expect(onSaveOne).toHaveBeenCalledTimes(3)
+    const names = onSaveOne.mock.calls.map((c) => c[0].guestName)
+    expect(names.filter((n) => n === 'Smith')).toHaveLength(1)
+    expect(names.filter((n) => n === 'Lee')).toHaveLength(2)
+  })
+
+  it('all items use the dayId from input', async () => {
+    const items = [activity('A', '09:00', '4'), reservation('B', '2', '20:00')]
+    const seen: string[] = []
+    const onSaveOne = vi.fn(async (p: { dayId: string }) => {
+      seen.push(p.dayId)
+      return { success: true } as const
+    })
+    renderWithIntl(
+      <QuickAddMultiReview
+        items={items}
+        onSaveOne={onSaveOne}
+        onAllDone={vi.fn()}
+        onBack={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Create 2 items' }))
+    await waitFor(() => expect(onSaveOne).toHaveBeenCalledTimes(2))
+    expect(seen.every((id) => id === DAY)).toBe(true)
+  })
+})

--- a/tests/lib/quick-add-multi.test.ts
+++ b/tests/lib/quick-add-multi.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const generateObjectMock = vi.fn()
+
+vi.mock('ai', () => ({
+  generateObject: (...args: unknown[]) => generateObjectMock(...args),
+}))
+
+vi.mock('@ai-sdk/gateway', () => ({
+  gateway: vi.fn().mockReturnValue('mocked-model'),
+}))
+
+vi.mock('@/lib/ai-call-log', () => ({
+  logAiCall: vi.fn().mockResolvedValue(undefined),
+}))
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { generateQuickAddParse } from '@/lib/quick-add-generate'
+
+const ORIGINAL_ENV = { ...process.env }
+const DAY_ID = '00000000-0000-0000-0000-000000000001'
+const CTX = '2026-05-10'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env = { ...ORIGINAL_ENV, AI_GATEWAY_API_KEY: 'test-key' }
+})
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function llmActivity(over: Record<string, unknown> = {}) {
+  return {
+    kind: 'activity' as const,
+    dateAmbiguous: false,
+    fields: {
+      title: null,
+      description: null,
+      guestName: null,
+      groupName: null,
+      startTime: null,
+      endTime: null,
+      expectedCovers: null,
+      guestCount: null,
+      notes: null,
+      tableBreakdown: null,
+      allergenHints: null,
+      ...over,
+    },
+  }
+}
+
+function llmReservation(over: Record<string, unknown> = {}) {
+  return {
+    kind: 'reservation' as const,
+    dateAmbiguous: false,
+    fields: {
+      title: null,
+      description: null,
+      guestName: null,
+      groupName: null,
+      startTime: null,
+      endTime: null,
+      expectedCovers: null,
+      guestCount: null,
+      notes: null,
+      tableBreakdown: null,
+      allergenHints: null,
+      ...over,
+    },
+  }
+}
+
+function llmBreakfast(over: Record<string, unknown> = {}) {
+  return {
+    kind: 'breakfast' as const,
+    dateAmbiguous: false,
+    fields: {
+      title: null,
+      description: null,
+      guestName: null,
+      groupName: null,
+      startTime: null,
+      endTime: null,
+      expectedCovers: null,
+      guestCount: null,
+      notes: null,
+      tableBreakdown: null,
+      allergenHints: null,
+      ...over,
+    },
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('generateQuickAddParse — multi-item', () => {
+  it('returns a length-1 items array for a single-item paste', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: {
+        items: [
+          llmActivity({
+            title: 'Member golf',
+            startTime: '08:00',
+            expectedCovers: 24,
+          }),
+        ],
+      },
+      usage: { promptTokens: 10, completionTokens: 5 },
+    })
+
+    const r = await generateQuickAddParse('Member golf 8am, 24 players', DAY_ID, CTX)
+    expect(r.success).toBe(true)
+    if (!r.success) return
+    expect(r.items).toHaveLength(1)
+    expect(r.items[0]!.kind).toBe('activity')
+    expect(r.items[0]!.dayId).toBe(DAY_ID)
+    expect(r.items[0]!.contextDate).toBe(CTX)
+    if (r.items[0]!.kind === 'activity') {
+      expect(r.items[0]!.defaults.title).toBe('Member golf')
+      expect(r.items[0]!.defaults.startTime).toBe('08:00')
+      expect(r.items[0]!.defaults.expectedCovers).toBe('24')
+    }
+  })
+
+  it('returns 3 items for a multi-reservation paste', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: {
+        items: [
+          llmReservation({ guestName: 'Smith', guestCount: 6, startTime: '19:30' }),
+          llmReservation({
+            guestName: 'Lee',
+            guestCount: 2,
+            startTime: '20:00',
+            allergenHints: ['no nuts'],
+          }),
+          llmReservation({ guestName: 'Patel', guestCount: 4, startTime: '20:15' }),
+        ],
+      },
+      usage: { promptTokens: 30, completionTokens: 12 },
+    })
+
+    const text = '- Smith party of 6 at 7:30pm\n- Lee, 2 guests, 8pm, no nuts\n- Patel 4 at 8:15pm'
+    const r = await generateQuickAddParse(text, DAY_ID, CTX)
+    expect(r.success).toBe(true)
+    if (!r.success) return
+    expect(r.items).toHaveLength(3)
+    for (const it of r.items) {
+      expect(it.kind).toBe('reservation')
+      expect(it.dayId).toBe(DAY_ID)
+      expect(it.contextDate).toBe(CTX)
+    }
+    if (r.items[0]!.kind === 'reservation') {
+      expect(r.items[0]!.defaults.guestName).toBe('Smith')
+      expect(r.items[0]!.defaults.guestCount).toBe('6')
+      expect(r.items[0]!.defaults.startTime).toBe('19:30')
+    }
+    if (r.items[1]!.kind === 'reservation') {
+      expect(r.items[1]!.allergens).toContain('nuts')
+    }
+    if (r.items[2]!.kind === 'reservation') {
+      expect(r.items[2]!.defaults.guestName).toBe('Patel')
+    }
+  })
+
+  it('handles mixed-kind paste (activity + breakfast + reservation)', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: {
+        items: [
+          llmActivity({ title: 'Tee time', startTime: '09:00', expectedCovers: 16 }),
+          llmBreakfast({ groupName: 'Room block A', guestCount: 30, startTime: '07:00' }),
+          llmReservation({ guestName: 'Garcia', guestCount: 4, startTime: '20:00' }),
+        ],
+      },
+      usage: { promptTokens: 40, completionTokens: 18 },
+    })
+
+    const text =
+      'Tee time 9am, 16 players. Breakfast for room block A, 30 guests at 7am. Reservation: Garcia, 4, 8pm.'
+    const r = await generateQuickAddParse(text, DAY_ID, CTX)
+    expect(r.success).toBe(true)
+    if (!r.success) return
+    expect(r.items).toHaveLength(3)
+    expect(r.items.map((it) => it.kind)).toEqual(['activity', 'breakfast', 'reservation'])
+
+    if (r.items[0]!.kind === 'activity') {
+      expect(r.items[0]!.defaults.title).toBe('Tee time')
+      expect(r.items[0]!.defaults.startTime).toBe('09:00')
+      expect(r.items[0]!.defaults.expectedCovers).toBe('16')
+    }
+    if (r.items[1]!.kind === 'breakfast') {
+      expect(r.items[1]!.defaults.groupName).toBe('Room block A')
+      expect(r.items[1]!.defaults.guestCount).toBe('30')
+      expect(r.items[1]!.defaults.startTime).toBe('07:00')
+    }
+    if (r.items[2]!.kind === 'reservation') {
+      expect(r.items[2]!.defaults.guestName).toBe('Garcia')
+      expect(r.items[2]!.defaults.guestCount).toBe('4')
+      expect(r.items[2]!.defaults.startTime).toBe('20:00')
+    }
+  })
+
+  it('all items inherit the same dayId from input', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: {
+        items: [
+          llmActivity({ title: 'A', startTime: '09:00', expectedCovers: 4 }),
+          llmReservation({ guestName: 'B', guestCount: 2, startTime: '20:00' }),
+        ],
+      },
+      usage: {},
+    })
+    const r = await generateQuickAddParse('two things', DAY_ID, CTX)
+    expect(r.success).toBe(true)
+    if (!r.success) return
+    expect(r.items.every((it) => it.dayId === DAY_ID)).toBe(true)
+    expect(r.items.every((it) => it.contextDate === CTX)).toBe(true)
+  })
+
+  it('returns error when text is too short', async () => {
+    const r = await generateQuickAddParse('a', DAY_ID, CTX)
+    expect(r.success).toBe(false)
+    expect(generateObjectMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #171.

Quick Add now extracts every distinct item from a paste — e.g. an email with five reservations, or a mixed-kind dump like "tee time + breakfast block + dinner reservation". Single-item input still works the same; the new path activates only when the LLM returns more than one item.

### Schema / prompt
- `lib/quick-add-prompt.ts`: system prompt now describes an `items` array (always length ≥ 1) with three explicit examples — single, multi-reservation list, mixed-kind paste.
- `lib/quick-add-generate.ts`: Zod schema wraps the existing per-item shape in `{ items: QuickAddLlmItem[] }` (1–20). `generateQuickAddParse` now returns `{ items: QuickAddParseData[] }`.
- `app/actions/quick-add.ts`: returns `{ items }`. Rate limit is per request (one `quickAddRateLimit(user.id)` call regardless of item count).

### UI
- New `components/quick-add-multi-review.tsx`: list of rows with kind icon (Flag / UtensilsCrossed / Coffee), title/group, time, count, and an accept toggle (default on). "Create N items" button issues N create calls in a loop. Per-row state: idle / saving / saved / error.
- Failures show the error inline and auto-uncheck the row so the user can retry; saved rows stay checked-and-disabled so they don't double-save on retry.
- `components/quick-add-input.tsx`: routes to multi-review when `items.length > 1`, otherwise existing single-review path. Save-payload helper extracted to share between single and multi flows.
- All items use the `dayId` from the input.

### Tests
- `tests/lib/quick-add-multi.test.ts`: covers 1-item, 3-item reservation list, and mixed-kind paste; verifies all items inherit the input `dayId` + `contextDate`.
- `tests/components/quick-add-multi-review.test.tsx`: row rendering, accept-count math, partial-failure retry (failed row unchecks, saved rows do not re-save), `dayId` propagation.

## Test plan
- [ ] Unit tests pass in CI (`vitest run`).
- [ ] Manual: paste a multi-reservation email into Quick Add → verify multi-review screen, toggle one off, confirm "Create N items" reflects count, save creates only the toggled rows.
- [ ] Manual: paste a mixed-kind dump → verify rows show correct kind icons + labels.
- [ ] Manual: simulate a save failure (e.g. offline one entity) → verify row turns red with error and toggle auto-unchecks; retry succeeds without re-saving the already-saved row.
- [ ] Manual: paste a single item → confirm existing single-review flow unchanged.

https://claude.ai/code/session_01TGFniBWhLcFHG5LgjfwrjL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGFniBWhLcFHG5LgjfwrjL)_