### PR TITLE
feat(ai): structured skeletons for Quick Add and Daily Brief

### DIFF
--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -7,6 +7,7 @@ import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 import { experimental_useObject as useObject } from '@ai-sdk/react'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
 import type { DailyBriefContent, DailyBriefRecord, RegenerableSection } from '@/types/daily-brief'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
@@ -209,13 +210,13 @@ export function DailyBriefCard({
 
         {/* Progressive streaming skeleton */}
         {streaming && (
-          <div className="space-y-3">
+          <div className="space-y-3" role="status" aria-live="polite" aria-label={t('generating')}>
             {streamedObject?.headline ? (
               <p className="animate-in fade-in text-base leading-snug font-semibold duration-300">
                 {streamedObject.headline}
               </p>
             ) : (
-              <div className="bg-muted h-5 w-3/4 animate-pulse rounded" />
+              <Skeleton className="h-5 w-3/4" />
             )}
 
             {streamedObject?.summary ? (
@@ -223,13 +224,13 @@ export function DailyBriefCard({
                 {streamedObject.summary}
               </p>
             ) : (
-              <div className="space-y-1">
-                <div className="bg-muted h-4 w-full animate-pulse rounded" />
-                <div className="bg-muted h-4 w-5/6 animate-pulse rounded" />
+              <div className="space-y-1.5">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-5/6" />
               </div>
             )}
 
-            {covers && (
+            {covers ? (
               <div className="animate-in fade-in grid grid-cols-3 gap-2 text-center text-sm duration-300">
                 <div className="bg-muted/50 rounded-md py-2">
                   <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
@@ -244,7 +245,20 @@ export function DailyBriefCard({
                   <div className="font-semibold tabular-nums">{covers.reservations ?? '—'}</div>
                 </div>
               </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-2">
+                <Skeleton className="h-12 rounded-md" />
+                <Skeleton className="h-12 rounded-md" />
+                <Skeleton className="h-12 rounded-md" />
+              </div>
             )}
+
+            <div className="space-y-1.5 pt-1">
+              <Skeleton className="h-3 w-1/3" />
+              <Skeleton className="h-3 w-11/12" />
+              <Skeleton className="h-3 w-10/12" />
+              <Skeleton className="h-3 w-9/12" />
+            </div>
           </div>
         )}
 

--- a/components/quick-add-input.tsx
+++ b/components/quick-add-input.tsx
@@ -264,8 +264,6 @@ export function QuickAddInput({ open, onOpenChange, contextDate, disabled }: Pro
 
   const isAiNotConfigured = Boolean(error?.includes('AI is not configured'))
   const isParsing = view.stage === 'streaming'
-  // Spinner only until the first token arrives.
-  const showSpinner = isParsing && !streamObj
 
   const inputBody = (
     <form
@@ -327,18 +325,7 @@ export function QuickAddInput({ open, onOpenChange, contextDate, disabled }: Pro
   const streamingBody =
     view.stage === 'streaming' ? (
       <div className="space-y-3">
-        {showSpinner ? (
-          <div
-            className="text-muted-foreground flex items-center justify-center gap-2 py-12 text-sm"
-            role="status"
-            aria-live="polite"
-          >
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {t('parsing')}
-          </div>
-        ) : (
-          <QuickAddStreamingPreview partial={streamObj} label={t('parsing')} />
-        )}
+        <QuickAddStreamingPreview partial={streamObj} label={t('parsing')} />
         <div className="flex justify-end gap-2 pt-1">
           <Button
             type="button"

--- a/components/quick-add-streaming-preview.tsx
+++ b/components/quick-add-streaming-preview.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl'
 import { Loader2 } from 'lucide-react'
 import { Label } from '@/components/ui/label'
+import { Skeleton as UiSkeleton } from '@/components/ui/skeleton'
 
 type StreamedItem = {
   kind?: 'activity' | 'reservation' | 'breakfast'
@@ -28,7 +29,7 @@ type Props = {
 }
 
 function Skeleton({ className = '' }: { className?: string }) {
-  return <div aria-hidden="true" className={`bg-muted h-9 animate-pulse rounded-md ${className}`} />
+  return <UiSkeleton aria-hidden="true" className={`bg-muted h-9 ${className}`} />
 }
 
 function ValueBox({ children }: { children: React.ReactNode }) {

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn('bg-accent animate-pulse rounded-md', className)}
+      className={cn('bg-accent rounded-md motion-safe:animate-pulse', className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- Quick Add: pre-token spinner replaced — `QuickAddStreamingPreview` now renders immediately, so users see the parsed-fields shape (kind chip, title line, time line, count) as skeleton bars before tokens arrive.
- Daily Brief: progressive streaming view now also renders a three-column covers skeleton (when covers haven't streamed yet) and a four-row vip-notes placeholder block, matching the expected output shape.
- Shared `Skeleton` primitive switched to `motion-safe:animate-pulse` so the shimmer disappears under `prefers-reduced-motion`. Inline `bg-muted animate-pulse` divs in both surfaces now route through it.

## Test plan
- [ ] Open Quick Add — confirm the centred spinner is gone and structured field skeletons appear immediately on submit, then morph into streamed values.
- [ ] Trigger an initial Daily Brief generation — confirm headline bar, two-line summary, three-column covers tile, and four vip-note bullets appear before any tokens land.
- [ ] Re-run regenerate — confirm flow behaviour unchanged.
- [ ] Toggle OS reduced-motion — confirm no shimmer in the skeletons (the regenerate button's `Loader2` is unaffected and intentional).
- [ ] Verify both light and dark mode contrast on the skeleton bars.

Closes #180

https://claude.ai/code/session_013pCYrc6hyvut7QTkJ4SN9U

---
_Generated by [Claude Code](https://claude.ai/code/session_013pCYrc6hyvut7QTkJ4SN9U)_