### PR TITLE
test(e2e): harden Playwright suite with data-testid + waitFor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,22 @@ Prettier config: `.prettierrc` — no semis, single quotes, 100-char width, Tail
 - Requires: local Supabase running (`supabase start`), dev server running (`pnpm dev`)
 - Uses Supabase service role key to create/teardown test tenants — never run against production
 - E2E is excluded from CI (needs full local stack); run locally before merging auth/routing changes
+- Failure artifacts: `playwright.config.ts` enables `video: 'retain-on-failure'` and `screenshot: 'only-on-failure'` — videos + screenshots land in `test-results/` for failed runs only.
+
+#### `data-testid` convention
+
+E2E selectors prefer `getByTestId` over text/role-based selectors for any element that is content-driven (translated, copy-edited, or user-data). Role-based selectors stay for genuinely accessible-named elements (page headings, persistent landmarks).
+
+Naming — kebab-case, scope-prefixed:
+
+- Cards: `<entity>-card`, `<entity>-card-edit`, `<entity>-card-delete`, `<entity>-card-delete-confirm` (e.g. `activity-card`, `activity-card-edit`).
+- Forms: `<entity>-form`, `<entity>-form-<field>`, `<entity>-form-save` (e.g. `activity-form-title`, `reservation-form-guest-name`).
+- Page-level add buttons: `add-<entity>` (e.g. `add-activity`, `add-reservation`, `add-breakfast`).
+- Auth: `sign-in-form`, `sign-in-email`, `sign-in-password`, `sign-in-use-password`, `sign-in-submit`, `sign-out`.
+
+Post-mutation assertions: always wrap with an explicit timeout — `expect(...).toBeVisible({ timeout: 5000 })` or `expect(...).toHaveCount(0, { timeout: 5000 })` — to absorb server-action latency.
+
+Per-test dates: never share a `TODAY` across tests. Compute `format(addDays(new Date(), N), 'yyyy-MM-dd')` per `describe` block so parallel workers (if `workers` ever increases) don't collide.
 
 ## Database Migrations
 

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -373,6 +373,7 @@ function DayViewEditor({
                 returnFocusRef.current = breakfastAddRef.current
                 openAddBreakfast()
               }}
+              data-testid="add-breakfast"
             >
               <Plus className="mr-1 h-4 w-4" /> {t('addBreakfast')}
               <KbdHint className="ml-1">B</KbdHint>
@@ -410,6 +411,7 @@ function DayViewEditor({
               openAddActivity()
             }}
             className="shrink-0"
+            data-testid="add-activity"
           >
             <Plus className="size-3.5" /> {t('addActivity')}
             <KbdHint className="ml-0.5">A</KbdHint>
@@ -446,6 +448,7 @@ function DayViewEditor({
                 returnFocusRef.current = reservationAddRef.current
                 openAddReservation()
               }}
+              data-testid="add-reservation"
             >
               <Plus className="mr-1 h-4 w-4" /> {t('addReservation')}
               <KbdHint className="ml-1">R</KbdHint>

--- a/components/activity-card.tsx
+++ b/components/activity-card.tsx
@@ -92,7 +92,7 @@ export function ActivityCard({ item, isEditor, onEdit, onDeleted, onBeforeEdit }
 
   return (
     <>
-      <Card className={isPending ? 'opacity-70' : undefined}>
+      <Card className={isPending ? 'opacity-70' : undefined} data-testid="activity-card">
         <CardContent className="px-4 py-3">
           <div className="flex items-start justify-between gap-3">
             {/* Left: details */}
@@ -208,6 +208,7 @@ export function ActivityCard({ item, isEditor, onEdit, onDeleted, onBeforeEdit }
                     onEdit(item)
                   }}
                   aria-label={`Edit: ${item.title}`}
+                  data-testid="activity-card-edit"
                 >
                   <Pencil className="h-4 w-4" aria-hidden="true" />
                 </Button>
@@ -216,6 +217,7 @@ export function ActivityCard({ item, isEditor, onEdit, onDeleted, onBeforeEdit }
                   size="icon"
                   onClick={() => setDeleteOpen(true)}
                   aria-label={`Delete: ${item.title}`}
+                  data-testid="activity-card-delete"
                 >
                   <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </Button>
@@ -266,6 +268,7 @@ export function ActivityCard({ item, isEditor, onEdit, onDeleted, onBeforeEdit }
                 onClick={() => handleDelete('single')}
                 disabled={isDeleting}
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                data-testid="activity-card-delete-confirm"
               >
                 {isDeleting ? t('deleting') : t('delete')}
               </AlertDialogAction>

--- a/components/activity-form.tsx
+++ b/components/activity-form.tsx
@@ -361,11 +361,11 @@ export function ActivityForm({
   }
 
   const formBody = (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-testid="activity-form">
       {/* Title */}
       <div className={cn('space-y-1', qaRing('title'))}>
         <Label htmlFor="af-title">{t('titleLabel')} *</Label>
-        <Input id="af-title" {...register('title')} />
+        <Input id="af-title" {...register('title')} data-testid="activity-form-title" />
         {errors.title && <p className="text-destructive text-sm">{errors.title.message}</p>}
       </div>
 
@@ -598,7 +598,7 @@ export function ActivityForm({
         <Button type="button" variant="outline" onClick={onClose}>
           {t('cancel')}
         </Button>
-        <Button type="submit" disabled={isPending}>
+        <Button type="submit" disabled={isPending} data-testid="activity-form-save">
           {isPending ? t('saving') : t('save')}
         </Button>
       </div>

--- a/components/auth/sign-in-form.tsx
+++ b/components/auth/sign-in-form.tsx
@@ -98,7 +98,7 @@ export function SignInForm({ defaultSlug, tenantName, logoUrl }: SignInFormProps
             <h1 className="text-center text-xl font-semibold tracking-tight">{heading}</h1>
           </CardHeader>
 
-          <form action={action}>
+          <form action={action} data-testid="sign-in-form">
             <input type="hidden" name="slug" value={slug} />
             <CardContent className="space-y-4">
               {state?.error && <p className="text-destructive text-sm">{state.error}</p>}
@@ -117,6 +117,7 @@ export function SignInForm({ defaultSlug, tenantName, logoUrl }: SignInFormProps
                   value={email}
                   onChange={(event) => setEmail(event.target.value)}
                   required
+                  data-testid="sign-in-email"
                 />
               </div>
 
@@ -129,6 +130,7 @@ export function SignInForm({ defaultSlug, tenantName, logoUrl }: SignInFormProps
                     type="password"
                     autoComplete="current-password"
                     required={showPassword}
+                    data-testid="sign-in-password"
                   />
                 </div>
               )}
@@ -150,11 +152,17 @@ export function SignInForm({ defaultSlug, tenantName, logoUrl }: SignInFormProps
                   className="w-full"
                   variant="secondary"
                   onClick={() => setShowPassword(true)}
+                  data-testid="sign-in-use-password"
                 >
                   {t('usePasswordButton')}
                 </Button>
               ) : (
-                <Button type="submit" className="w-full" disabled={isPending}>
+                <Button
+                  type="submit"
+                  className="w-full"
+                  disabled={isPending}
+                  data-testid="sign-in-submit"
+                >
                   {isPending ? t('signingIn') : t('signInButton')}
                 </Button>
               )}

--- a/components/breakfast-card.tsx
+++ b/components/breakfast-card.tsx
@@ -62,7 +62,7 @@ export function BreakfastCard({ item, isEditor, onEdit, onDeleted, onBeforeEdit 
 
   return (
     <>
-      <Card className={isPending ? 'opacity-70' : undefined}>
+      <Card className={isPending ? 'opacity-70' : undefined} data-testid="breakfast-card">
         <CardContent className="px-4 py-3">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1 space-y-1.5">
@@ -108,6 +108,7 @@ export function BreakfastCard({ item, isEditor, onEdit, onDeleted, onBeforeEdit 
                     onEdit(item)
                   }}
                   aria-label={`Edit: ${item.group_name ?? t('unnamedGroup')}`}
+                  data-testid="breakfast-card-edit"
                 >
                   <Pencil className="h-4 w-4" aria-hidden="true" />
                 </Button>
@@ -116,6 +117,7 @@ export function BreakfastCard({ item, isEditor, onEdit, onDeleted, onBeforeEdit 
                   size="icon"
                   onClick={() => setDeleteOpen(true)}
                   aria-label={`Delete: ${item.group_name ?? t('unnamedGroup')}`}
+                  data-testid="breakfast-card-delete"
                 >
                   <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </Button>
@@ -137,6 +139,7 @@ export function BreakfastCard({ item, isEditor, onEdit, onDeleted, onBeforeEdit 
               onClick={handleDelete}
               disabled={isDeleting}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid="breakfast-card-delete-confirm"
             >
               {isDeleting ? t('deleting') : t('delete')}
             </AlertDialogAction>

--- a/components/breakfast-form.tsx
+++ b/components/breakfast-form.tsx
@@ -208,10 +208,15 @@ export function BreakfastForm({
   const title = isEditing ? t('editTitle') : t('addTitle')
 
   const formBody = (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-testid="breakfast-form">
       <div className={cn('space-y-1', qaRing('groupName'))}>
         <Label htmlFor="bf-group">{t('groupNameLabel')}</Label>
-        <Input id="bf-group" placeholder={t('groupNamePlaceholder')} {...register('groupName')} />
+        <Input
+          id="bf-group"
+          placeholder={t('groupNamePlaceholder')}
+          {...register('groupName')}
+          data-testid="breakfast-form-group-name"
+        />
       </div>
 
       <div className={cn('space-y-1', qaRing('guestCount'))}>
@@ -251,7 +256,7 @@ export function BreakfastForm({
         <Button type="button" variant="outline" onClick={onClose}>
           {t('cancel')}
         </Button>
-        <Button type="submit" disabled={isPending}>
+        <Button type="submit" disabled={isPending} data-testid="breakfast-form-save">
           {isPending ? t('saving') : t('save')}
         </Button>
       </div>

--- a/components/reservation-card.tsx
+++ b/components/reservation-card.tsx
@@ -62,7 +62,7 @@ export function ReservationCard({ item, isEditor, onEdit, onDeleted, onBeforeEdi
 
   return (
     <>
-      <Card className={isPending ? 'opacity-70' : undefined}>
+      <Card className={isPending ? 'opacity-70' : undefined} data-testid="reservation-card">
         <CardContent className="px-4 py-3">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1 space-y-1.5">
@@ -108,6 +108,7 @@ export function ReservationCard({ item, isEditor, onEdit, onDeleted, onBeforeEdi
                     onEdit(item)
                   }}
                   aria-label={`Edit: ${item.guest_name ?? t('fallbackName')}`}
+                  data-testid="reservation-card-edit"
                 >
                   <Pencil className="h-4 w-4" aria-hidden="true" />
                 </Button>
@@ -116,6 +117,7 @@ export function ReservationCard({ item, isEditor, onEdit, onDeleted, onBeforeEdi
                   size="icon"
                   onClick={() => setDeleteOpen(true)}
                   aria-label={`Delete: ${item.guest_name ?? t('fallbackName')}`}
+                  data-testid="reservation-card-delete"
                 >
                   <Trash2 className="h-4 w-4" aria-hidden="true" />
                 </Button>
@@ -137,6 +139,7 @@ export function ReservationCard({ item, isEditor, onEdit, onDeleted, onBeforeEdi
               onClick={handleDelete}
               disabled={isDeleting}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid="reservation-card-delete-confirm"
             >
               {isDeleting ? t('deleting') : t('delete')}
             </AlertDialogAction>

--- a/components/reservation-form.tsx
+++ b/components/reservation-form.tsx
@@ -220,10 +220,10 @@ export function ReservationForm({
   }
 
   const formBody = (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-testid="reservation-form">
       <div className={cn('space-y-1', qaRing('guestName'))}>
         <Label htmlFor="rf-name">{t('guestNameLabel')}</Label>
-        <Input id="rf-name" {...register('guestName')} />
+        <Input id="rf-name" {...register('guestName')} data-testid="reservation-form-guest-name" />
       </div>
 
       <div className={cn('space-y-1', qaRing('guestCount'))}>
@@ -263,7 +263,7 @@ export function ReservationForm({
         <Button type="button" variant="outline" onClick={onClose}>
           {t('cancel')}
         </Button>
-        <Button type="submit" disabled={isPending}>
+        <Button type="submit" disabled={isPending} data-testid="reservation-form-save">
           {isPending ? t('saving') : t('save')}
         </Button>
       </div>

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -18,6 +18,7 @@ export function UserMenu({ user: _user, signOutLabel = 'Sign out' }: UserMenuPro
         className="text-muted-foreground hover:text-foreground"
         aria-label={signOutLabel}
         title={signOutLabel}
+        data-testid="sign-out"
       >
         <LogOut className="h-4 w-4" />
       </Button>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
     // Root domain base URL; tests navigate to subdomain URLs explicitly
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
   },
 
   projects: [

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -12,17 +12,17 @@ test.describe('Authentication', () => {
     await page.goto(`${tenantUrl}/auth/sign-in`)
     // Form renders directly on tenant subdomain — no redirect to root domain
     await expect(page).toHaveURL(`${tenantUrl}/auth/sign-in`)
-    await expect(page.getByRole('heading', { name: /sign in/i })).toBeVisible()
-    await expect(page.getByLabel(/email/i)).toBeVisible()
+    await expect(page.getByTestId('sign-in-form')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByTestId('sign-in-email')).toBeVisible()
   })
 
   test('invalid credentials show error', async ({ page, tenantUrl }) => {
     await page.goto(`${tenantUrl}/auth/sign-in`)
-    await page.getByLabel(/email/i).fill('wrong@example.com')
+    await page.getByTestId('sign-in-email').fill('wrong@example.com')
     // Reveal password field before filling it
-    await page.getByRole('button', { name: /use password/i }).click()
-    await page.getByLabel(/password/i).fill('wrongpassword')
-    await page.getByRole('button', { name: /sign in/i }).click()
+    await page.getByTestId('sign-in-use-password').click()
+    await page.getByTestId('sign-in-password').fill('wrongpassword')
+    await page.getByTestId('sign-in-submit').click()
     // Should stay on sign-in (not redirect away)
     await expect(page).toHaveURL(/\/auth\/sign-in/)
   })
@@ -34,25 +34,17 @@ test.describe('Authentication', () => {
     testPassword,
   }) => {
     await page.goto(`${tenantUrl}/auth/sign-in`)
-    await page.getByLabel(/email/i).fill(testEmail)
+    await page.getByTestId('sign-in-email').fill(testEmail)
     // Reveal password field before filling it
-    await page.getByRole('button', { name: /use password/i }).click()
-    await page.getByLabel(/password/i).fill(testPassword)
-    await page.getByRole('button', { name: /sign in/i }).click()
+    await page.getByTestId('sign-in-use-password').click()
+    await page.getByTestId('sign-in-password').fill(testPassword)
+    await page.getByTestId('sign-in-submit').click()
     await page.waitForURL(`${tenantUrl}/`)
     await expect(page).toHaveURL(`${tenantUrl}/`)
   })
 
   test('authenticated user can sign out', async ({ signedInPage, tenantUrl: _tenantUrl }) => {
-    // Open user menu and sign out
-    await signedInPage
-      .getByRole('button', { name: /sign out|user menu/i })
-      .first()
-      .click()
-    const signOutBtn = signedInPage.getByRole('menuitem', { name: /sign out/i })
-    if (await signOutBtn.isVisible()) {
-      await signOutBtn.click()
-    }
+    await signedInPage.getByTestId('sign-out').first().click()
     await signedInPage.waitForURL(/\/auth\/sign-in/)
     await expect(signedInPage).toHaveURL(/\/auth\/sign-in/)
   })

--- a/tests/e2e/day.spec.ts
+++ b/tests/e2e/day.spec.ts
@@ -2,114 +2,112 @@
  * Day view and activity CRUD tests.
  */
 import { test, expect } from './fixtures'
-import { format } from 'date-fns'
+import { addDays, format } from 'date-fns'
 
-const TODAY = format(new Date(), 'yyyy-MM-dd')
+// Per-suite future date so parallel workers (if ever enabled) can't collide on
+// today's date and so test order isn't sensitive to wall-clock midnight.
+function uniqueFutureDate(offset: number): string {
+  return format(addDays(new Date(), offset), 'yyyy-MM-dd')
+}
 
 test.describe('Day view', () => {
-  test('navigating to today shows day view', async ({ signedInPage, tenantUrl }) => {
-    await signedInPage.goto(`${tenantUrl}/day/${TODAY}`)
-    await expect(signedInPage).toHaveURL(`${tenantUrl}/day/${TODAY}`)
+  const dayDate = uniqueFutureDate(7)
+
+  test('navigating to day shows day view', async ({ signedInPage, tenantUrl }) => {
+    await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
+    await expect(signedInPage).toHaveURL(`${tenantUrl}/day/${dayDate}`)
     // Activities section should be visible
-    await expect(signedInPage.getByRole('heading', { name: /activities/i })).toBeVisible()
+    await expect(signedInPage.getByRole('heading', { name: /activities/i })).toBeVisible({
+      timeout: 5000,
+    })
   })
 
   test('add activity — form opens, saves, and appears in list', async ({
     signedInPage,
     tenantUrl,
   }) => {
-    await signedInPage.goto(`${tenantUrl}/day/${TODAY}`)
+    await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
-    // Click "Activity" add button
-    await signedInPage.getByRole('button', { name: /^activity$/i }).click()
+    await signedInPage.getByTestId('add-activity').click()
+    await signedInPage.getByTestId('activity-form-title').fill('E2E Test Activity')
+    await signedInPage.getByTestId('activity-form-save').click()
 
-    // Fill title
-    const titleInput = signedInPage.getByLabel(/title/i)
-    await titleInput.fill('E2E Test Activity')
-
-    // Submit
-    await signedInPage.getByRole('button', { name: /^save$/i }).click()
-
-    // Activity should appear
-    await expect(signedInPage.getByText('E2E Test Activity')).toBeVisible()
+    await expect(signedInPage.getByText('E2E Test Activity')).toBeVisible({ timeout: 5000 })
   })
 
   test('edit activity — updates title in list', async ({ signedInPage, tenantUrl }) => {
-    await signedInPage.goto(`${tenantUrl}/day/${TODAY}`)
+    await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
-    // Find the activity added in the previous test and click its edit button
-    const editBtn = signedInPage.getByRole('button', { name: /edit: E2E Test Activity/i })
-    await editBtn.click()
+    const card = signedInPage.getByTestId('activity-card').filter({ hasText: 'E2E Test Activity' })
+    await card.getByTestId('activity-card-edit').click()
 
-    const titleInput = signedInPage.getByLabel(/title/i)
+    const titleInput = signedInPage.getByTestId('activity-form-title')
     await titleInput.clear()
     await titleInput.fill('E2E Updated Activity')
+    await signedInPage.getByTestId('activity-form-save').click()
 
-    await signedInPage.getByRole('button', { name: /^save$/i }).click()
-
-    await expect(signedInPage.getByText('E2E Updated Activity')).toBeVisible()
+    await expect(signedInPage.getByText('E2E Updated Activity')).toBeVisible({ timeout: 5000 })
   })
 
   test('delete activity — removes from list', async ({ signedInPage, tenantUrl }) => {
-    await signedInPage.goto(`${tenantUrl}/day/${TODAY}`)
+    await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
-    // Delete the activity
-    const deleteBtn = signedInPage.getByRole('button', { name: /delete: E2E Updated Activity/i })
-    await deleteBtn.click()
+    const card = signedInPage
+      .getByTestId('activity-card')
+      .filter({ hasText: 'E2E Updated Activity' })
+    await card.getByTestId('activity-card-delete').click()
+    await signedInPage.getByTestId('activity-card-delete-confirm').click()
 
-    // Confirm deletion in dialog
-    await signedInPage.getByRole('button', { name: /^delete$/i }).click()
-
-    await expect(signedInPage.getByText('E2E Updated Activity')).not.toBeVisible()
+    await expect(signedInPage.getByText('E2E Updated Activity')).toHaveCount(0, { timeout: 5000 })
   })
 })
 
 test.describe('Reservation CRUD', () => {
+  const dayDate = uniqueFutureDate(8)
+
   test('add reservation — appears in list', async ({ signedInPage, tenantUrl }) => {
-    await signedInPage.goto(`${tenantUrl}/day/${TODAY}`)
+    await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
-    await signedInPage.getByRole('button', { name: /add reservation/i }).click()
+    await signedInPage.getByTestId('add-reservation').click()
+    await signedInPage.getByTestId('reservation-form-guest-name').fill('E2E Guest')
+    await signedInPage.getByTestId('reservation-form-save').click()
 
-    await signedInPage.getByLabel(/guest name/i).fill('E2E Guest')
-
-    await signedInPage.getByRole('button', { name: /^save$/i }).click()
-
-    await expect(signedInPage.getByText('E2E Guest')).toBeVisible()
+    await expect(signedInPage.getByText('E2E Guest')).toBeVisible({ timeout: 5000 })
   })
 
   test('delete reservation — removes from list', async ({ signedInPage, tenantUrl }) => {
-    await signedInPage.goto(`${tenantUrl}/day/${TODAY}`)
+    await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
-    const deleteBtn = signedInPage.getByRole('button', { name: /delete: E2E Guest/i })
-    await deleteBtn.click()
+    const card = signedInPage.getByTestId('reservation-card').filter({ hasText: 'E2E Guest' })
+    await card.getByTestId('reservation-card-delete').click()
+    await signedInPage.getByTestId('reservation-card-delete-confirm').click()
 
-    await signedInPage.getByRole('button', { name: /^delete$/i }).click()
-
-    await expect(signedInPage.getByText('E2E Guest')).not.toBeVisible()
+    await expect(signedInPage.getByText('E2E Guest')).toHaveCount(0, { timeout: 5000 })
   })
 })
 
 test.describe('Breakfast CRUD', () => {
+  const dayDate = uniqueFutureDate(9)
+
   test('add breakfast — appears in list', async ({ signedInPage, tenantUrl }) => {
-    await signedInPage.goto(`${tenantUrl}/day/${TODAY}`)
+    await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
-    await signedInPage.getByRole('button', { name: /add breakfast/i }).click()
+    await signedInPage.getByTestId('add-breakfast').click()
+    await signedInPage.getByTestId('breakfast-form-group-name').fill('E2E Breakfast Group')
+    await signedInPage.getByTestId('breakfast-form-save').click()
 
-    await signedInPage.getByLabel(/group name/i).fill('E2E Breakfast Group')
-
-    await signedInPage.getByRole('button', { name: /^save$/i }).click()
-
-    await expect(signedInPage.getByText('E2E Breakfast Group')).toBeVisible()
+    await expect(signedInPage.getByText('E2E Breakfast Group')).toBeVisible({ timeout: 5000 })
   })
 
   test('delete breakfast — removes from list', async ({ signedInPage, tenantUrl }) => {
-    await signedInPage.goto(`${tenantUrl}/day/${TODAY}`)
+    await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
-    const deleteBtn = signedInPage.getByRole('button', { name: /delete: E2E Breakfast Group/i })
-    await deleteBtn.click()
+    const card = signedInPage
+      .getByTestId('breakfast-card')
+      .filter({ hasText: 'E2E Breakfast Group' })
+    await card.getByTestId('breakfast-card-delete').click()
+    await signedInPage.getByTestId('breakfast-card-delete-confirm').click()
 
-    await signedInPage.getByRole('button', { name: /^delete$/i }).click()
-
-    await expect(signedInPage.getByText('E2E Breakfast Group')).not.toBeVisible()
+    await expect(signedInPage.getByText('E2E Breakfast Group')).toHaveCount(0, { timeout: 5000 })
   })
 })

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -116,9 +116,11 @@ export const test = base.extend<TestFixtures>({
     await setupTenant()
     // Navigate to sign-in page
     await page.goto(`${tenantUrl}/auth/sign-in`)
-    await page.getByLabel(/email/i).fill(TEST_EMAIL)
-    await page.getByLabel(/password/i).fill(TEST_PASSWORD)
-    await page.getByRole('button', { name: /sign in/i }).click()
+    await page.getByTestId('sign-in-email').fill(TEST_EMAIL)
+    // Reveal password field before filling
+    await page.getByTestId('sign-in-use-password').click()
+    await page.getByTestId('sign-in-password').fill(TEST_PASSWORD)
+    await page.getByTestId('sign-in-submit').click()
     // Wait for redirect to home
     await page.waitForURL(`${tenantUrl}/`)
     await use(page)


### PR DESCRIPTION
## Summary

Closes #106. Hardens the E2E suite against UI refactors and translation churn (we have 4 locales) and adds cheap failure debugging.

- Adds `data-testid` to ~20 stable targets: cards (`activity-card`, `reservation-card`, `breakfast-card` + `-edit` / `-delete` / `-delete-confirm`), forms (`*-form`, `*-form-<field>`, `*-form-save`), page-level add buttons (`add-activity`, `add-reservation`, `add-breakfast`), sign-in (`sign-in-form`, `sign-in-email`, `sign-in-password`, `sign-in-use-password`, `sign-in-submit`), and `sign-out`.
- Migrates `tests/e2e/day.spec.ts`, `tests/e2e/auth.spec.ts`, and the `signedInPage` fixture from text/role-based selectors to `getByTestId`. Role-based selectors stay only for genuinely accessible-named elements (page headings).
- Wraps every post-mutation assertion in an explicit `{ timeout: 5000 }` and replaces `not.toBeVisible()` with `toHaveCount(0, { timeout })` for delete-flow stability.
- Replaces the shared `TODAY = format(new Date(), 'yyyy-MM-dd')` with a per-describe future date (`addDays(today, 7|8|9)`) so parallel workers can't collide and order isn't sensitive to wall-clock midnight.
- `playwright.config.ts`: `video: 'retain-on-failure'`, `screenshot: 'only-on-failure'`.
- Documents the `data-testid` convention + waitFor + per-test-date rules in the CLAUDE.md E2E section.

## Test plan

- [ ] `pnpm test:e2e` locally with Supabase + dev server up — all suites pass
- [ ] Force a failure (e.g. break a selector) and confirm a video + screenshot land in `test-results/`
- [ ] Sanity-check the four locales still render correctly (no regression from the new testids — they're additive)

https://claude.ai/code/session_01JHSCZsjgSmM8h55822osuf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHSCZsjgSmM8h55822osuf)_