### PR TITLE
Convert My Profile and My Schedule desktop nav links to icon + tooltip

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -147,7 +147,12 @@ export default async function TenantLayout({ children }: { children: React.React
                         <TooltipProvider>
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <Button variant="ghost" size="iconSm" aria-label={t('mySchedule')} asChild>
+                              <Button
+                                variant="ghost"
+                                size="iconSm"
+                                aria-label={t('mySchedule')}
+                                asChild
+                              >
                                 <Link href="/my-schedule">
                                   <CalendarDays />
                                 </Link>
@@ -164,7 +169,12 @@ export default async function TenantLayout({ children }: { children: React.React
                         <TooltipProvider>
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <Button variant="ghost" size="iconSm" aria-label={t('profile')} asChild>
+                              <Button
+                                variant="ghost"
+                                size="iconSm"
+                                aria-label={t('profile')}
+                                asChild
+                              >
                                 <Link href="/profile">
                                   <User />
                                 </Link>

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -28,6 +28,9 @@ import { getSuperadminImpersonationRole } from '@/lib/superadmin'
 import { getTenantPalette, getTenantThemeCssVariables } from '@/lib/theme/palettes'
 import { TenantKeyboardShell } from '@/components/tenant-keyboard-shell'
 import { GlobalQuickAdd } from '@/components/global-quick-add'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { CalendarDays, User } from 'lucide-react'
 
 const getTenantRow = cache(async (tenantId: string) => {
   const supabase = await createSupabaseServerClient()
@@ -141,23 +144,35 @@ export default async function TenantLayout({ children }: { children: React.React
                     {/* My schedule link — non-editors on desktop when staff_schedule on */}
                     {!editor && featureFlags.staff_schedule && user && (
                       <span className="hidden sm:inline-flex">
-                        <Link
-                          href="/my-schedule"
-                          className="text-muted-foreground hover:text-foreground px-2 text-sm font-medium transition-colors"
-                        >
-                          {t('mySchedule')}
-                        </Link>
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button variant="ghost" size="iconSm" aria-label={t('mySchedule')} asChild>
+                                <Link href="/my-schedule">
+                                  <CalendarDays />
+                                </Link>
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>{t('mySchedule')}</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       </span>
                     )}
                     {/* Profile link — all signed-in members, desktop */}
                     {user && (
                       <span className="hidden sm:inline-flex">
-                        <Link
-                          href="/profile"
-                          className="text-muted-foreground hover:text-foreground px-2 text-sm font-medium transition-colors"
-                        >
-                          {t('profile')}
-                        </Link>
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button variant="ghost" size="iconSm" aria-label={t('profile')} asChild>
+                                <Link href="/profile">
+                                  <User />
+                                </Link>
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>{t('profile')}</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       </span>
                     )}
                     <NotificationBell initialCount={unreadCount} />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaced "My Schedule" text link with `CalendarDays` icon button + tooltip
- Replaced "My Profile" text link with `User` icon button + tooltip
- Both use `Button` `ghost`/`iconSm` variant with `aria-label` matching tooltip text
- Wrapped each in `TooltipProvider` per existing pattern in codebase
- Mobile nav unchanged

Closes #223

## Test plan

- [ ] Sign in as non-editor with `staff_schedule` on — desktop nav shows calendar icon, hover shows "My Schedule" tooltip
- [ ] Sign in as any user — desktop nav shows user icon, hover shows profile tooltip
- [ ] Tab through — focus ring visible, `aria-label` correct
- [ ] Mobile nav unchanged

https://claude.ai/code/session_01A34CG1VYtAQJJPDeRTLRHz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A34CG1VYtAQJJPDeRTLRHz)_