### PR TITLE
feat: surface generated_at timestamp in daily brief footer

### DIFF
--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { formatDistanceToNow } from 'date-fns'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { ClipboardCopy, Loader2, RefreshCw, Sparkles } from 'lucide-react'
@@ -343,6 +344,13 @@ export function DailyBriefCard({
                 )}
               </div>
             </details>
+            {brief.generated_at && (
+              <p className="text-muted-foreground text-xs">
+                {t('updatedAt', {
+                  time: formatDistanceToNow(new Date(brief.generated_at), { addSuffix: true }),
+                })}
+              </p>
+            )}
           </div>
         )}
       </div>

--- a/components/day-info-banner.tsx
+++ b/components/day-info-banner.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { formatDistanceToNow } from 'date-fns'
 import { ClipboardCopy, Loader2, Pencil, RefreshCw, Sparkles } from 'lucide-react'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
@@ -513,6 +514,13 @@ function SettledBriefContent({
           )}
         </div>
       </details>
+      {brief.generated_at && (
+        <p className="text-muted-foreground text-xs">
+          {t('updatedAt', {
+            time: formatDistanceToNow(new Date(brief.generated_at), { addSuffix: true }),
+          })}
+        </p>
+      )}
     </div>
   )
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -174,7 +174,8 @@
       "editedBy": "Bearbeitet von {name}",
       "editedByAt": "Bearbeitet von {name} · {time}",
       "editedBadge": "Von einem Editor bearbeitet",
-      "regenerateDiscardWarning": "Bei einer Neugenerierung gehen deine Änderungen an Überschrift und Zusammenfassung verloren. Fortfahren?"
+      "regenerateDiscardWarning": "Bei einer Neugenerierung gehen deine Änderungen an Überschrift und Zusammenfassung verloren. Fortfahren?",
+      "updatedAt": "Aktualisiert {time}"
     },
     "quickAdd": {
       "openButton": "Schnell hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -264,6 +264,7 @@
       "risks": "Risks",
       "actions": "Suggested actions",
       "meta": "Generated {time} · {model}",
+      "updatedAt": "Updated {time}",
       "regenerateVip": "Regenerate VIP notes",
       "regenerateRisks": "Regenerate risks",
       "regenerateActions": "Regenerate suggested actions",

--- a/messages/es.json
+++ b/messages/es.json
@@ -174,7 +174,8 @@
       "editedBy": "Editado por {name}",
       "editedByAt": "Editado por {name} · {time}",
       "editedBadge": "Editado por un editor",
-      "regenerateDiscardWarning": "Regenerar descartará tus ediciones al titular y al resumen. ¿Continuar?"
+      "regenerateDiscardWarning": "Regenerar descartará tus ediciones al titular y al resumen. ¿Continuar?",
+      "updatedAt": "Actualizado {time}"
     },
     "quickAdd": {
       "openButton": "Añadir rápido",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -278,7 +278,8 @@
       "editedBy": "Modifié par {name}",
       "editedByAt": "Modifié par {name} · {time}",
       "editedBadge": "Modifié par un éditeur",
-      "regenerateDiscardWarning": "La régénération supprimera vos modifications du titre et du résumé. Continuer ?"
+      "regenerateDiscardWarning": "La régénération supprimera vos modifications du titre et du résumé. Continuer ?",
+      "updatedAt": "Mis à jour {time}"
     },
     "quickAdd": {
       "openButton": "Ajout rapide",


### PR DESCRIPTION
## Summary

- Adds a visible "Updated {relative time}" footer to `DailyBriefCard` and the `DayInfoBanner` dialog — previously `generated_at` was buried inside the collapsible Details section
- Uses `formatDistanceToNow` from `date-fns` (already in the project) for human-readable relative timestamps
- Adds `updatedAt` i18n key to en/fr/de/es translation files

## Test plan

- [ ] Navigate to a day with activities and an existing brief — confirm "Updated X ago" appears below the brief body
- [ ] Open the banner dialog — confirm same timestamp is visible below the Details section
- [ ] Day with no activities — confirm no timestamp shown (no brief)
- [ ] After manual regeneration — confirm timestamp updates to reflect new `generated_at`

Closes #221

https://claude.ai/code/session_01R9kiAaxWmpNqqzygP2ce98

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9kiAaxWmpNqqzygP2ce98)_