### PR TITLE
fix(#224): staff profile save + editor-edits-staff feature

### DIFF
--- a/app/[tenant]/profile/profile-form.tsx
+++ b/app/[tenant]/profile/profile-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { useTranslations } from 'next-intl'
-import { updateMemberProfile } from '@/app/actions/memberships'
+import { updateMemberProfile, updateStaffProfile } from '@/app/actions/memberships'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -13,12 +13,17 @@ interface ProfileFormProps {
   initialFirstName: string
   initialLastName: string
   initialJobTitle: string
+  /** When set, the form edits another user's profile (editor-edits-staff mode). */
+  membershipId?: string
+  onSaved?: () => void
 }
 
 export function ProfileForm({
   initialFirstName,
   initialLastName,
   initialJobTitle,
+  membershipId,
+  onSaved,
 }: ProfileFormProps) {
   const t = useTranslations('Tenant.profile')
   const [firstName, setFirstName] = useState(initialFirstName)
@@ -29,16 +34,23 @@ export function ProfileForm({
   async function handleSave() {
     setSaving(true)
     try {
-      const result = await updateMemberProfile({
-        first_name: firstName,
-        last_name: lastName,
-        job_title: jobTitle,
-      })
+      const result = membershipId
+        ? await updateStaffProfile(membershipId, {
+            first_name: firstName,
+            last_name: lastName,
+            job_title: jobTitle,
+          })
+        : await updateMemberProfile({
+            first_name: firstName,
+            last_name: lastName,
+            job_title: jobTitle,
+          })
       if (!result.success) {
         toast.error(result.error)
         return
       }
       toast.success(t('saved'))
+      onSaved?.()
     } finally {
       setSaving(false)
     }

--- a/app/actions/memberships.ts
+++ b/app/actions/memberships.ts
@@ -17,6 +17,9 @@ export interface Member {
   created_at: string
   hourly_rate: number | null
   currency: string | null
+  first_name: string | null
+  last_name: string | null
+  job_title: string | null
 }
 
 export interface PendingInvitation {
@@ -89,7 +92,9 @@ export async function getMembers(): Promise<ActionResponse<Member[]>> {
   const { supabase } = await createTenantClient()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: memberships, error } = await (supabase.from('memberships') as any)
-    .select('id, user_id, role, created_at, hourly_rate, currency')
+    .select(
+      'id, user_id, role, created_at, hourly_rate, currency, first_name, last_name, job_title'
+    )
     .eq('tenant_id', tenantId)
     .order('created_at')
 
@@ -103,6 +108,9 @@ export async function getMembers(): Promise<ActionResponse<Member[]>> {
     created_at: string
     hourly_rate: number | null
     currency: string | null
+    first_name: string | null
+    last_name: string | null
+    job_title: string | null
   }>
 
   const serviceClient = createSupabaseServiceClient()
@@ -125,6 +133,9 @@ export async function getMembers(): Promise<ActionResponse<Member[]>> {
         created_at: m.created_at,
         hourly_rate: m.hourly_rate,
         currency: m.currency,
+        first_name: m.first_name,
+        last_name: m.last_name,
+        job_title: m.job_title,
       }
     }),
   }
@@ -406,9 +417,11 @@ export async function updateMemberProfile(data: {
   const role = await getUserRole(tenantId)
   if (!role) return { success: false, error: 'Not authorized.' }
 
-  const { supabase } = await createTenantClient()
+  // Use service client: RLS UPDATE policy is editors-only, but any member
+  // should be able to update their own profile fields.
+  const serviceClient = createSupabaseServiceClient()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase.from('memberships') as any)
+  const { error } = await (serviceClient.from('memberships') as any)
     .update({
       first_name: data.first_name.trim() || null,
       last_name: data.last_name.trim() || null,
@@ -416,6 +429,43 @@ export async function updateMemberProfile(data: {
     })
     .eq('tenant_id', tenantId)
     .eq('user_id', user.id)
+
+  if (error) return { success: false, error: error.message }
+  return { success: true, data: undefined }
+}
+
+export async function updateStaffProfile(
+  membershipId: string,
+  data: { first_name: string; last_name: string; job_title: string }
+): Promise<ActionResponse> {
+  const tenantId = await getTenantId()
+  const currentRole = await getUserRole(tenantId)
+  if (currentRole !== 'editor') return { success: false, error: 'Not authorized.' }
+
+  const serviceClient = createSupabaseServiceClient()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: target, error: fetchError } = await (serviceClient.from('memberships') as any)
+    .select('role')
+    .eq('id', membershipId)
+    .eq('tenant_id', tenantId)
+    .maybeSingle()
+
+  if (fetchError) return { success: false, error: fetchError.message }
+  if (!target) return { success: false, error: 'Member not found.' }
+  if ((target as { role: string }).role !== 'staff') {
+    return { success: false, error: 'Can only edit staff profiles.' }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (serviceClient.from('memberships') as any)
+    .update({
+      first_name: data.first_name.trim() || null,
+      last_name: data.last_name.trim() || null,
+      job_title: data.job_title.trim() || null,
+    })
+    .eq('id', membershipId)
+    .eq('tenant_id', tenantId)
 
   if (error) return { success: false, error: error.message }
   return { success: true, data: undefined }

--- a/components/member-management.tsx
+++ b/components/member-management.tsx
@@ -13,6 +13,7 @@ import {
   cancelInvitation,
 } from '@/app/actions/memberships'
 import type { Member, PendingInvitation, MemberRole } from '@/app/actions/memberships'
+import { ProfileForm } from '@/app/[tenant]/profile/profile-form'
 import { updateMemberPayRate } from '@/app/actions/pay-rates'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -35,6 +36,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import {
   Table,
   TableBody,
@@ -255,6 +257,7 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [removeTarget, setRemoveTarget] = useState<Member | null>(null)
+  const [editProfileTarget, setEditProfileTarget] = useState<Member | null>(null)
   const [isRemoving, startRemoveTransition] = useTransition()
   const [isCancelling, startCancelTransition] = useTransition()
 
@@ -392,15 +395,27 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
                         </TableCell>
                         <TableCell className="py-3 pr-6 text-right">
                           {!isSelf && (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="text-muted-foreground hover:text-destructive size-9"
-                              onClick={() => setRemoveTarget(member)}
-                              aria-label={t('removeTitle')}
-                            >
-                              <Trash2 className="size-4" />
-                            </Button>
+                            <div className="flex items-center justify-end gap-1">
+                              {member.role === 'staff' && (
+                                <Button
+                                  variant="ghost"
+                                  size="iconSm"
+                                  onClick={() => setEditProfileTarget(member)}
+                                  aria-label={t('editProfile')}
+                                >
+                                  <Pencil className="size-4" />
+                                </Button>
+                              )}
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="text-muted-foreground hover:text-destructive size-9"
+                                onClick={() => setRemoveTarget(member)}
+                                aria-label={t('removeTitle')}
+                              >
+                                <Trash2 className="size-4" />
+                              </Button>
+                            </div>
                           )}
                         </TableCell>
                       </TableRow>
@@ -461,6 +476,28 @@ export function MemberManagement({ currentUserId }: { currentUserId: string }) {
           </CardContent>
         </Card>
       )}
+
+      <Dialog
+        open={!!editProfileTarget}
+        onOpenChange={(v) => {
+          if (!v) setEditProfileTarget(null)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('editProfileTitle')}</DialogTitle>
+          </DialogHeader>
+          {editProfileTarget && (
+            <ProfileForm
+              membershipId={editProfileTarget.id}
+              initialFirstName={editProfileTarget.first_name ?? ''}
+              initialLastName={editProfileTarget.last_name ?? ''}
+              initialJobTitle={editProfileTarget.job_title ?? ''}
+              onSaved={() => setEditProfileTarget(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
 
       <AlertDialog
         open={!!removeTarget}

--- a/messages/de.json
+++ b/messages/de.json
@@ -474,7 +474,9 @@
       "removing": "Wird entfernt…",
       "removed": "Mitglied entfernt.",
       "roleUpdated": "Rolle aktualisiert.",
-      "loading": "Laden…"
+      "loading": "Laden…",
+      "editProfile": "Edit profile",
+      "editProfileTitle": "Edit profile"
     },
     "featureRequests": {
       "title": "Ihre Anfragen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -630,6 +630,8 @@
       "removed": "Member removed.",
       "roleUpdated": "Role updated.",
       "loading": "Loading…",
+      "editProfile": "Edit profile",
+      "editProfileTitle": "Edit profile",
       "payRate": {
         "header": "Pay rate",
         "notSet": "—",

--- a/messages/es.json
+++ b/messages/es.json
@@ -474,7 +474,9 @@
       "removing": "Eliminando…",
       "removed": "Miembro eliminado.",
       "roleUpdated": "Rol actualizado.",
-      "loading": "Cargando…"
+      "loading": "Cargando…",
+      "editProfile": "Edit profile",
+      "editProfileTitle": "Edit profile"
     },
     "featureRequests": {
       "title": "Tus solicitudes",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -602,7 +602,9 @@
       "removing": "Suppression…",
       "removed": "Membre retiré.",
       "roleUpdated": "Rôle mis à jour.",
-      "loading": "Chargement…"
+      "loading": "Chargement…",
+      "editProfile": "Edit profile",
+      "editProfileTitle": "Edit profile"
     },
     "featureRequests": {
       "title": "Vos demandes",

--- a/tests/actions/memberships.test.ts
+++ b/tests/actions/memberships.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/tenant', () => ({ getTenantId: vi.fn().mockResolvedValue('tenant-1') }))
+vi.mock('@/lib/membership', () => ({
+  getUserRole: vi.fn().mockResolvedValue('editor'),
+}))
+vi.mock('@/lib/supabase-server', () => ({
+  createTenantClient: vi.fn(),
+  createSupabaseServerClient: vi.fn(),
+  createSupabaseServiceClient: vi.fn(),
+}))
+vi.mock('@/app/actions/auth', () => ({
+  getUser: vi.fn().mockResolvedValue({ id: 'actor-user-id' }),
+}))
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { getUserRole } from '@/lib/membership'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { updateStaffProfile } from '@/app/actions/memberships'
+import { assertSuccess, assertFailure } from '@/tests/helpers/action-response'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type QueryResult = { data: unknown; error: { message: string } | null }
+
+function makeChain(result: QueryResult = { data: null, error: null }) {
+  const chain: Record<string, unknown> = {}
+  ;['select', 'update', 'eq', 'order', 'limit'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain)
+  })
+  chain.single = vi.fn().mockResolvedValue(result)
+  chain.maybeSingle = vi.fn().mockResolvedValue(result)
+  ;(chain as { then?: unknown }).then = (fn: (v: QueryResult) => void) =>
+    Promise.resolve(result).then(fn)
+  return chain
+}
+
+function mockServiceClient(fromFn: ReturnType<typeof vi.fn>) {
+  vi.mocked(createSupabaseServiceClient).mockReturnValue({ from: fromFn } as never)
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const MEMBERSHIP_ID = 'membership-1'
+const PROFILE_DATA = { first_name: 'Jane', last_name: 'Smith', job_title: 'Barman' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getUserRole).mockResolvedValue('editor')
+})
+
+// ── updateStaffProfile ────────────────────────────────────────────────────────
+
+describe('updateStaffProfile', () => {
+  it('editor can update a staff member profile', async () => {
+    const fetchChain = makeChain({ data: { role: 'staff' }, error: null })
+    const updateChain = makeChain({ data: null, error: null })
+    const fromFn = vi.fn().mockReturnValueOnce(fetchChain).mockReturnValueOnce(updateChain)
+    mockServiceClient(fromFn)
+
+    const result = await updateStaffProfile(MEMBERSHIP_ID, PROFILE_DATA)
+
+    assertSuccess(result)
+    expect(updateChain.update).toHaveBeenCalledWith({
+      first_name: 'Jane',
+      last_name: 'Smith',
+      job_title: 'Barman',
+    })
+  })
+
+  it('rejects when caller is not editor', async () => {
+    vi.mocked(getUserRole).mockResolvedValue('staff')
+
+    const result = await updateStaffProfile(MEMBERSHIP_ID, PROFILE_DATA)
+
+    assertFailure(result)
+    expect(result.error).toBe('Not authorized.')
+  })
+
+  it('rejects when target membership not found', async () => {
+    const fetchChain = makeChain({ data: null, error: null })
+    const fromFn = vi.fn().mockReturnValue(fetchChain)
+    mockServiceClient(fromFn)
+
+    const result = await updateStaffProfile(MEMBERSHIP_ID, PROFILE_DATA)
+
+    assertFailure(result)
+    expect(result.error).toBe('Member not found.')
+  })
+
+  it('rejects when target is an editor (not staff)', async () => {
+    const fetchChain = makeChain({ data: { role: 'editor' }, error: null })
+    const fromFn = vi.fn().mockReturnValue(fetchChain)
+    mockServiceClient(fromFn)
+
+    const result = await updateStaffProfile(MEMBERSHIP_ID, PROFILE_DATA)
+
+    assertFailure(result)
+    expect(result.error).toBe('Can only edit staff profiles.')
+  })
+
+  it('propagates DB error on update', async () => {
+    const fetchChain = makeChain({ data: { role: 'staff' }, error: null })
+    const updateChain = makeChain({ data: null, error: { message: 'DB error' } })
+    const fromFn = vi.fn().mockReturnValueOnce(fetchChain).mockReturnValueOnce(updateChain)
+    mockServiceClient(fromFn)
+
+    const result = await updateStaffProfile(MEMBERSHIP_ID, PROFILE_DATA)
+
+    assertFailure(result)
+    expect(result.error).toBe('DB error')
+  })
+})


### PR DESCRIPTION
## Summary

- **Bug fix**: `updateMemberProfile` used `createTenantClient()` (session-scoped, subject to RLS). The existing UPDATE policy is editors-only, so staff/viewer saves were silently swallowed. Switched to `createSupabaseServiceClient()` — the server action already validates the caller is an authenticated tenant member before updating only their own row.
- **Feature**: Added `updateStaffProfile(membershipId, data)` server action — editor-only, validates target is `staff` role (not editor). Extended `Member` type and `getMembers()` with profile fields. Added pencil button + Dialog in `MemberManagement` for staff rows (not self, not editors). Wired `ProfileForm` with optional `membershipId` + `onSaved` props for edit-other-user mode.
- **Test**: New `tests/actions/memberships.test.ts` covers editor-edits-staff success, non-editor rejection, target-not-found, editor-target rejection, and DB error propagation.

## Test plan

- [ ] Sign in as staff, edit name/job title on `/[tenant]/profile`, save → reload → persisted
- [ ] Sign in as editor, members settings → pencil on a staff row → dialog opens pre-filled → save → toast success
- [ ] Editor pencil button absent on editor rows and self row
- [ ] `pnpm test:run` — new memberships tests pass

Closes #224

https://claude.ai/code/session_01KcNGJrDwu3A1xQ7WXh6kXM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcNGJrDwu3A1xQ7WXh6kXM)_