### PR TITLE
Link My Schedule rows to day view

### DIFF
--- a/app/[tenant]/my-schedule/page.tsx
+++ b/app/[tenant]/my-schedule/page.tsx
@@ -53,7 +53,7 @@ export default async function MySchedulePage() {
   return (
     <div className="mx-auto max-w-2xl px-4 py-6">
       <h1 className="mb-6 text-xl font-bold">{t('title')}</h1>
-      <MyScheduleList initialShifts={shifts} today={today} />
+      <MyScheduleList initialShifts={shifts} today={today} tenantSlug={tenant.slug} />
       <IcalFeedSection initialUrl={initialUrl} />
     </div>
   )

--- a/components/my-schedule-list.tsx
+++ b/components/my-schedule-list.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
+import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import {
   getISOWeek,
@@ -80,9 +81,10 @@ function formatTimeRange(start: string | null, end: string | null): string {
 type Props = {
   initialShifts: MyShiftWithDate[]
   today: string
+  tenantSlug: string
 }
 
-export function MyScheduleList({ initialShifts, today }: Props) {
+export function MyScheduleList({ initialShifts, today, tenantSlug }: Props) {
   const t = useTranslations('Tenant.staff.mySchedule')
   const [pastShifts, setPastShifts] = useState<MyShiftWithDate[]>([])
   const [showPast, setShowPast] = useState(false)
@@ -129,7 +131,11 @@ export function MyScheduleList({ initialShifts, today }: Props) {
               const timeLabel = formatTimeRange(shift.start_time, shift.end_time)
               const roleLabel = shift.role?.trim()
               return (
-                <div key={shift.id} className="bg-card space-y-1 rounded-lg border p-4">
+                <Link
+                  key={shift.id}
+                  href={`/${tenantSlug}/day/${day.dateIso}`}
+                  className="bg-card hover:bg-accent block space-y-1 rounded-lg border p-4 transition-colors"
+                >
                   <p className="text-muted-foreground text-xs font-medium">
                     {formatShiftDate(day.dateIso)}
                   </p>
@@ -142,7 +148,7 @@ export function MyScheduleList({ initialShifts, today }: Props) {
                   {shift.notes && (
                     <p className="text-muted-foreground text-sm italic">{shift.notes}</p>
                   )}
-                </div>
+                </Link>
               )
             })
           )}


### PR DESCRIPTION
## Summary
- Wraps each shift card in a Next.js `Link` routing to `/[tenant]/day/[date]`
- Adds `hover:bg-accent` + `transition-colors` for clickable row affordance
- Threads `tenantSlug` prop from `MySchedulePage` → `MyScheduleList`

## Test plan
- [ ] Sign in as staff, visit `/[tenant]/my-schedule`
- [ ] Click a shift card → lands on `/[tenant]/day/[date]`
- [ ] Hover shows subtle background change
- [ ] Tab to card, Enter navigates (keyboard accessible)

Closes #225

https://claude.ai/code/session_01AvkqYot2zHtKyAVsk5Tov2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvkqYot2zHtKyAVsk5Tov2)_