### PR TITLE
Hide My Profile from mobile nav for staff/viewer users

### DIFF
--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Home, CalendarDays, Settings, Sparkles, CalendarCheck, UserCircle } from 'lucide-react'
+import { Home, CalendarDays, Settings, Sparkles, CalendarCheck } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import {
@@ -50,16 +50,6 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
             label: navT('mySchedule'),
             icon: CalendarCheck,
             active: pathname.startsWith('/my-schedule'),
-          },
-        ]
-      : []),
-    ...(!isEditor
-      ? [
-          {
-            href: '/profile',
-            label: navT('profile'),
-            icon: UserCircle,
-            active: pathname.startsWith('/profile'),
           },
         ]
       : []),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the "My Profile" entry from the bottom tab bar for staff/viewer (non-editor) users
- Editors already have profile accessible via the Settings drawer — no change needed there
- Cleans up the now-unused `UserCircle` import

Closes #226

https://claude.ai/code/session_01FDH5zxv1VsPq3nkNQnARQb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDH5zxv1VsPq3nkNQnARQb)_