### PR TITLE
De-duplicate settings page titles (issue #232)

### DIFF
--- a/components/activity-tag-management.tsx
+++ b/components/activity-tag-management.tsx
@@ -155,8 +155,7 @@ export function ActivityTagManagement() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Activity Tags</h2>
+      <div className="flex justify-end">
         <Button
           size="sm"
           onClick={() => {

--- a/components/checklist-management.tsx
+++ b/components/checklist-management.tsx
@@ -306,10 +306,7 @@ export function ChecklistManagement() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">{t('title')}</h2>
-          <p className="text-muted-foreground text-sm">{t('description')}</p>
-        </div>
+        <p className="text-muted-foreground text-sm">{t('description')}</p>
         <Button
           size="sm"
           onClick={() => {

--- a/components/poc-management.tsx
+++ b/components/poc-management.tsx
@@ -176,8 +176,7 @@ export function PocManagement() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Points of Contact</h2>
+      <div className="flex justify-end">
         <Button
           size="sm"
           onClick={() => {

--- a/components/shift-template-management.tsx
+++ b/components/shift-template-management.tsx
@@ -230,8 +230,7 @@ export function ShiftTemplateManagement({ assignees = [] }: { assignees?: ShiftA
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">{t('title')}</h2>
+      <div className="flex justify-end">
         <Button
           size="sm"
           onClick={() => {

--- a/components/venue-type-management.tsx
+++ b/components/venue-type-management.tsx
@@ -153,8 +153,7 @@ export function VenueTypeManagement() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Venue Types</h2>
+      <div className="flex justify-end">
         <Button
           size="sm"
           onClick={() => {


### PR DESCRIPTION
## Summary

- Removes hardcoded English `<h2>` titles from `poc-management`, `activity-tag-management`, and `venue-type-management` — these duplicated the translated `<h1>` rendered by the parent settings page
- Removes redundant translated `<h2>` titles from `checklist-management` and `shift-template-management` for the same reason
- "Add" buttons repositioned flush-right (`flex justify-end`) now that there's no sibling heading to justify against

## Test plan

- [ ] Visit `/[tenant]/admin/settings/poc` — one translated heading, add button top-right
- [ ] Visit `/[tenant]/admin/settings/activity-tags` — one translated heading, add button top-right
- [ ] Visit `/[tenant]/admin/settings/venue-types` — one translated heading, add button top-right
- [ ] Visit `/[tenant]/admin/settings/checklists` — one translated heading, description + add button remain
- [ ] Visit `/[tenant]/admin/settings/shift-templates` — one translated heading, add button top-right
- [ ] Switch tenant language to French/German — all headings translate, no English duplicates

https://claude.ai/code/session_0139LfwYMbBBAbP6emR4tjYG

---
_Generated by [Claude Code](https://claude.ai/code/session_0139LfwYMbBBAbP6emR4tjYG)_