### PR TITLE
Remove date string from Quick Add placeholder copy

### DIFF
--- a/components/quick-add-input.tsx
+++ b/components/quick-add-input.tsx
@@ -273,8 +273,14 @@ export function QuickAddInput({ open, onOpenChange, contextDate, disabled }: Pro
       className="space-y-3"
     >
       <p id={descId} className="text-muted-foreground text-sm">
-        {t('description', { contextDate })}
+        {t('description')}
       </p>
+      <div className="flex items-center gap-1.5">
+        <span className="text-muted-foreground text-xs">{t('addingTo')}:</span>
+        <span className="bg-muted text-foreground rounded px-2 py-0.5 text-xs font-medium">
+          {contextDate}
+        </span>
+      </div>
       <div className="space-y-1.5">
         <Label htmlFor="quick-add-textarea">{t('inputLabel')}</Label>
         <Textarea

--- a/messages/de.json
+++ b/messages/de.json
@@ -180,7 +180,8 @@
     "quickAdd": {
       "openButton": "Schnell hinzufügen",
       "title": "Schnell hinzufügen",
-      "description": "Beschreiben Sie den Eintrag. Wir füllen ein Formular für {contextDate} vor — nichts wird gespeichert, bis Sie bestätigen.",
+      "description": "Beschreiben Sie den Eintrag. Wir füllen ein Formular für Sie vor — nichts wird gespeichert, bis Sie bestätigen.",
+      "addingTo": "Hinzufügen zu",
       "inputLabel": "Was hinzufügen",
       "placeholder": "z. B. Tisch für 6 um 20 Uhr, Smith, ohne Nüsse",
       "cancel": "Abbrechen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -284,7 +284,8 @@
     "quickAdd": {
       "openButton": "Quick add",
       "title": "Quick add",
-      "description": "Describe what to add. We will pre-fill a form for {contextDate}. Nothing is saved until you confirm.",
+      "description": "Describe what to add. We will pre-fill a form for you. Nothing is saved until you confirm.",
+      "addingTo": "Adding to",
       "inputLabel": "What to add",
       "placeholder": "E.g. Party of 6 at 8pm, Smith, no nuts",
       "cancel": "Cancel",

--- a/messages/es.json
+++ b/messages/es.json
@@ -180,7 +180,8 @@
     "quickAdd": {
       "openButton": "Añadir rápido",
       "title": "Añadir rápido",
-      "description": "Describa la entrada. Rellenaremos un formulario para {contextDate}. Nada se guarda hasta que confirme.",
+      "description": "Describa la entrada. Rellenaremos un formulario para usted. Nada se guarda hasta que confirme.",
+      "addingTo": "Añadiendo a",
       "inputLabel": "Qué añadir",
       "placeholder": "p. ej. Mesa de 6 a las 20h, Sánchez, sin frutos secos",
       "cancel": "Cancelar",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -284,7 +284,8 @@
     "quickAdd": {
       "openButton": "Ajout rapide",
       "title": "Ajout rapide",
-      "description": "Décrivez l'ajout. Nous préremplirons un formulaire pour le {contextDate}. Rien n'est enregistré tant que vous ne validez pas.",
+      "description": "Décrivez l'ajout. Nous préremplirons un formulaire pour vous. Rien n'est enregistré tant que vous ne validez pas.",
+      "addingTo": "Ajout pour",
       "inputLabel": "Quoi ajouter",
       "placeholder": "Ex. table de 6 à 20h, Martin, sans noix",
       "cancel": "Annuler",


### PR DESCRIPTION
## Summary
- Remove `{contextDate}` interpolation from `quickAdd.description` in all four language files (en, fr, de, es)
- Update component to call `t('description')` without passing the date
- Add a clearly-labelled "Adding to: `<date>`" chip below the description so the target day is still discoverable

Closes #228

https://claude.ai/code/session_01LdzmUoDfAsAVazQpuTHeqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdzmUoDfAsAVazQpuTHeqz)_