### PR TITLE
fix(ical): correct DTSTAMP double-Z and convert shift times to UTC

### DIFF
--- a/app/api/calendar/[token]/shifts.ics/route.ts
+++ b/app/api/calendar/[token]/shifts.ics/route.ts
@@ -21,19 +21,24 @@ export async function GET(_request: Request, { params }: { params: Promise<{ tok
     return new NextResponse('Not Found', { status: 404 })
   }
 
-  // Check staff_schedule feature flag for this tenant
-  const { data: flagRow } = await serviceClient
-    .from('feature_flags')
-    .select('enabled')
-    .eq('tenant_id', membership.tenant_id)
-    .eq('flag_key', 'staff_schedule')
-    .maybeSingle()
+  // Check staff_schedule feature flag + fetch tenant timezone in parallel
+  const [flagResult, tenantResult] = await Promise.all([
+    serviceClient
+      .from('feature_flags')
+      .select('enabled')
+      .eq('tenant_id', membership.tenant_id)
+      .eq('flag_key', 'staff_schedule')
+      .maybeSingle(),
+    serviceClient.from('tenants').select('timezone').eq('id', membership.tenant_id).single(),
+  ])
 
   // Missing row = enabled by default
-  const flagEnabled = flagRow ? flagRow.enabled : true
+  const flagEnabled = flagResult.data ? flagResult.data.enabled : true
   if (!flagEnabled) {
     return new NextResponse('Not Found', { status: 404 })
   }
+
+  const timezone = tenantResult.data?.timezone ?? 'UTC'
 
   // Fetch shifts for next 90 days
   const today = format(new Date(), 'yyyy-MM-dd')
@@ -73,7 +78,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ tok
     }
   }
 
-  const ical = buildIcal(shifts, '-//Courseday//Shift Feed//EN')
+  const ical = buildIcal(shifts, '-//Courseday//Shift Feed//EN', timezone)
 
   return new NextResponse(ical, {
     status: 200,

--- a/lib/ical.ts
+++ b/lib/ical.ts
@@ -1,4 +1,5 @@
-// RFC 5545 minimal iCal generator — no external deps
+// RFC 5545 minimal iCal generator
+import { fromZonedTime } from 'date-fns-tz'
 
 function escapeIcal(value: string): string {
   return value
@@ -32,13 +33,17 @@ function prop(name: string, value: string): string {
   return foldLine(`${name}:${value}`)
 }
 
-// Format Date to iCal DATE-TIME in UTC: 20230101T120000Z
-function toIcalDate(dateStr: string, timeStr: string): string {
+// Convert a local date+time in the given IANA timezone to a UTC iCal DATE-TIME: 20230101T120000Z
+function toIcalUtc(dateStr: string, timeStr: string, timezone: string): string {
   const [h, m] = timeStr.split(':')
-  const d = dateStr.replace(/-/g, '')
   const hh = (h ?? '00').padStart(2, '0')
   const mm = (m ?? '00').padStart(2, '0')
-  return `${d}T${hh}${mm}00`
+  const utc = fromZonedTime(`${dateStr}T${hh}:${mm}:00`, timezone)
+  return utc
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}/, '')
+  // e.g. "20230101T120000Z"
 }
 
 export interface IcalShift {
@@ -50,7 +55,8 @@ export interface IcalShift {
   notes: string | null
 }
 
-export function buildIcal(shifts: IcalShift[], prodId: string): string {
+export function buildIcal(shifts: IcalShift[], prodId: string, timezone: string): string {
+  // now already ends with "Z", e.g. "20230101T120000Z"
   const now = new Date()
     .toISOString()
     .replace(/[-:]/g, '')
@@ -67,14 +73,14 @@ export function buildIcal(shifts: IcalShift[], prodId: string): string {
   for (const shift of shifts) {
     if (!shift.start_time || !shift.end_time) continue
 
-    const dtstart = toIcalDate(shift.date_iso, shift.start_time)
-    const dtend = toIcalDate(shift.date_iso, shift.end_time)
+    const dtstart = toIcalUtc(shift.date_iso, shift.start_time, timezone)
+    const dtend = toIcalUtc(shift.date_iso, shift.end_time, timezone)
     const summary = escapeIcal(shift.role_label ?? 'Shift')
     const uid = `${shift.id}@courseday`
 
     lines.push('BEGIN:VEVENT\r\n')
     lines.push(prop('UID', uid))
-    lines.push(prop('DTSTAMP', now + 'Z'))
+    lines.push(prop('DTSTAMP', now))
     lines.push(prop('DTSTART', dtstart))
     lines.push(prop('DTEND', dtend))
     lines.push(prop('SUMMARY', summary))

--- a/tests/api/calendar-shifts-ics.test.ts
+++ b/tests/api/calendar-shifts-ics.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn()
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServiceClient: vi.fn(() => ({ from: mockFrom })),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(data: unknown, error: unknown = null) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data, error }),
+    single: vi.fn().mockResolvedValue({ data, error }),
+  }
+  return chain
+}
+
+function importRoute() {
+  return import('@/app/api/calendar/[token]/shifts.ics/route')
+}
+
+function makeRequest(token: string) {
+  return new Request(`http://localhost:3000/api/calendar/${token}/shifts.ics`)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/calendar/[token]/shifts.ics', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockFrom.mockReset()
+  })
+
+  it('returns 404 for unknown token', async () => {
+    mockFrom.mockReturnValue(makeChain(null))
+
+    const { GET } = await importRoute()
+    const res = await GET(makeRequest('bad-token'), {
+      params: Promise.resolve({ token: 'bad-token' }),
+    })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when staff_schedule flag is disabled', async () => {
+    const membership = { id: 'mem-1', user_id: 'user-1', tenant_id: 'tenant-1' }
+    const flagDisabled = { enabled: false }
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'memberships') return makeChain(membership)
+      if (table === 'feature_flags') return makeChain(flagDisabled)
+      if (table === 'tenants') return makeChain({ timezone: 'UTC' })
+      return makeChain([])
+    })
+
+    const { GET } = await importRoute()
+    const res = await GET(makeRequest('valid-token'), {
+      params: Promise.resolve({ token: 'valid-token' }),
+    })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 200 with text/calendar content type for valid token', async () => {
+    const membership = { id: 'mem-1', user_id: 'user-1', tenant_id: 'tenant-1' }
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'memberships') return makeChain(membership)
+      if (table === 'feature_flags') return makeChain(null) // missing = enabled
+      if (table === 'tenants') return makeChain({ timezone: 'UTC' })
+      if (table === 'day') return makeChain([])
+      if (table === 'shift') return makeChain([])
+      return makeChain(null)
+    })
+
+    const { GET } = await importRoute()
+    const res = await GET(makeRequest('valid-token'), {
+      params: Promise.resolve({ token: 'valid-token' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/calendar; charset=utf-8')
+    const body = await res.text()
+    expect(body).toContain('BEGIN:VCALENDAR')
+    expect(body).toContain('END:VCALENDAR')
+  })
+
+  it('includes VEVENT blocks for shifts with start and end times', async () => {
+    const membership = { id: 'mem-1', user_id: 'user-1', tenant_id: 'tenant-1' }
+    const days = [{ id: 'day-1', date_iso: '2026-06-01' }]
+    const shiftRows = [
+      {
+        id: 'shift-1',
+        day_id: 'day-1',
+        start_time: '09:00',
+        end_time: '17:00',
+        role: 'Starter',
+        notes: null,
+      },
+    ]
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'memberships') return makeChain(membership)
+      if (table === 'feature_flags') return makeChain(null)
+      if (table === 'tenants') return makeChain({ timezone: 'UTC' })
+      if (table === 'day') return makeChain(days)
+      if (table === 'shift') return makeChain(shiftRows)
+      return makeChain(null)
+    })
+
+    const { GET } = await importRoute()
+    const res = await GET(makeRequest('valid-token'), {
+      params: Promise.resolve({ token: 'valid-token' }),
+    })
+
+    const body = await res.text()
+    expect(body).toContain('BEGIN:VEVENT')
+    expect(body).toContain('END:VEVENT')
+    expect(body).toContain('SUMMARY:Starter')
+    // UTC times (timezone=UTC so local == UTC)
+    expect(body).toContain('DTSTART:20260601T090000Z')
+    expect(body).toContain('DTEND:20260601T170000Z')
+    // DTSTAMP must not have double Z
+    const dtstampMatch = body.match(/DTSTAMP:(\S+)/)
+    expect(dtstampMatch).not.toBeNull()
+    expect(dtstampMatch![1]).toMatch(/^\d{8}T\d{6}Z$/)
+  })
+
+  it('converts shift times from tenant timezone to UTC', async () => {
+    const membership = { id: 'mem-1', user_id: 'user-1', tenant_id: 'tenant-1' }
+    const days = [{ id: 'day-1', date_iso: '2026-06-01' }]
+    // 09:00 America/New_York = 13:00 UTC (EDT, UTC-4)
+    const shiftRows = [
+      {
+        id: 'shift-1',
+        day_id: 'day-1',
+        start_time: '09:00',
+        end_time: '17:00',
+        role: 'Server',
+        notes: null,
+      },
+    ]
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'memberships') return makeChain(membership)
+      if (table === 'feature_flags') return makeChain(null)
+      if (table === 'tenants') return makeChain({ timezone: 'America/New_York' })
+      if (table === 'day') return makeChain(days)
+      if (table === 'shift') return makeChain(shiftRows)
+      return makeChain(null)
+    })
+
+    const { GET } = await importRoute()
+    const res = await GET(makeRequest('valid-token'), {
+      params: Promise.resolve({ token: 'valid-token' }),
+    })
+
+    const body = await res.text()
+    // 09:00 EDT = 13:00 UTC; 17:00 EDT = 21:00 UTC
+    expect(body).toContain('DTSTART:20260601T130000Z')
+    expect(body).toContain('DTEND:20260601T210000Z')
+  })
+
+  it('skips shifts missing start or end time', async () => {
+    const membership = { id: 'mem-1', user_id: 'user-1', tenant_id: 'tenant-1' }
+    const days = [{ id: 'day-1', date_iso: '2026-06-01' }]
+    const shiftRows = [
+      {
+        id: 'shift-1',
+        day_id: 'day-1',
+        start_time: null,
+        end_time: null,
+        role: 'Ranger',
+        notes: null,
+      },
+    ]
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'memberships') return makeChain(membership)
+      if (table === 'feature_flags') return makeChain(null)
+      if (table === 'tenants') return makeChain({ timezone: 'UTC' })
+      if (table === 'day') return makeChain(days)
+      if (table === 'shift') return makeChain(shiftRows)
+      return makeChain(null)
+    })
+
+    const { GET } = await importRoute()
+    const res = await GET(makeRequest('valid-token'), {
+      params: Promise.resolve({ token: 'valid-token' }),
+    })
+
+    const body = await res.text()
+    expect(body).not.toContain('BEGIN:VEVENT')
+  })
+})

--- a/tests/api/calendar-shifts-ics.test.ts
+++ b/tests/api/calendar-shifts-ics.test.ts
@@ -10,7 +10,11 @@ vi.mock('@/lib/supabase-server', () => ({
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeChain(data: unknown, error: unknown = null) {
-  const chain = {
+  // Make the chain thenable so `await query` (list queries with no terminal
+  // .maybeSingle()/.single()) resolves to { data, error } just like the real
+  // Supabase query builder does.
+  const resolved = Promise.resolve({ data, error })
+  const chain: Record<string, unknown> = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     gte: vi.fn().mockReturnThis(),
@@ -19,6 +23,15 @@ function makeChain(data: unknown, error: unknown = null) {
     order: vi.fn().mockReturnThis(),
     maybeSingle: vi.fn().mockResolvedValue({ data, error }),
     single: vi.fn().mockResolvedValue({ data, error }),
+    // thenable interface
+    then: resolved.then.bind(resolved),
+    catch: resolved.catch.bind(resolved),
+    finally: resolved.finally.bind(resolved),
+  }
+  // mockReturnThis() won't work once we cast to Record — rewire each method so
+  // chaining still works after the cast.
+  for (const key of ['select', 'eq', 'gte', 'lte', 'in', 'order']) {
+    ;(chain[key] as ReturnType<typeof vi.fn>).mockReturnValue(chain)
   }
   return chain
 }


### PR DESCRIPTION
## Summary

Fixes #229 — iCal feed URL was producing an invalid ICS file, breaking calendar subscriptions.

Two bugs found in `lib/ical.ts`:

- **Double-Z in DTSTAMP**: `now` (from `toISOString()`) already ends with `Z`, but `+ 'Z'` was appended, producing `20260510T195728ZZ` — invalid per RFC 5545.
- **Floating datetimes**: `DTSTART`/`DTEND` were emitted without any timezone qualifier (no `Z`, no `TZID`). Calendar apps interpreted shifts in the viewer's local time instead of the tenant's timezone.

## Changes

- `lib/ical.ts`: import `fromZonedTime` from `date-fns-tz`; new `toIcalUtc()` converts local shift time in the tenant's IANA timezone to UTC; `buildIcal()` now accepts `timezone` param; DTSTAMP no longer appends extra `Z`.
- `app/api/calendar/[token]/shifts.ics/route.ts`: fetch `tenants.timezone` in parallel with the feature flag check; pass it to `buildIcal`; falls back to `'UTC'`.
- `tests/api/calendar-shifts-ics.test.ts`: Vitest suite — invalid token → 404, disabled flag → 404, valid token → 200 + `text/calendar`, UTC conversion from `America/New_York`, shifts with null times are skipped.

## Test plan

- [ ] Valid iCal token → 200, `Content-Type: text/calendar; charset=utf-8`, valid ICS body
- [ ] `DTSTAMP` matches `^\d{8}T\d{6}Z$` (single Z)
- [ ] Shifts in `America/New_York` tenant show UTC-converted times (09:00 EDT → 13:00 UTC)
- [ ] Invalid/expired token → 404
- [ ] CI unit-tests pass

https://claude.ai/code/session_01DLKnYNHBspUfoSEqPxAcz6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLKnYNHBspUfoSEqPxAcz6)_