### PR TITLE
Replace 4 day-view add buttons with unified Add dropdown menu

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { DayAddMenu } from '@/components/day-add-menu'
 import dynamic from 'next/dynamic'
 import { useSearchParams, usePathname, useRouter } from 'next/navigation'
 import { useDayRealtime } from './useDayRealtime'
 import { useTranslations } from 'next-intl'
-import { Plus } from 'lucide-react'
 import { DayNav } from '@/components/day-nav'
 import { DaySummaryCard } from '@/components/day-summary-card'
 import { ViewerDayDashboard } from '@/components/viewer-day-dashboard'
@@ -25,8 +25,6 @@ const BreakfastForm = dynamic(() =>
 import { DayNotes } from '@/components/day-notes'
 import { DayInfoBanner } from '@/components/day-info-banner'
 import { StaffScheduleSection } from '@/components/staff-schedule-section'
-import { Button } from '@/components/ui/button'
-import { KbdHint } from '@/components/kbd-hint'
 import { useFeatureFlag } from '@/lib/feature-flags-context'
 import { useActiveDay } from '@/lib/active-day-context'
 import { useDayViewHotkeys } from '@/lib/keyboard-shortcuts'
@@ -175,23 +173,29 @@ function DayViewEditor({
   const [editBreakfast, setEditBreakfast] = useState<BreakfastConfiguration | null>(null)
 
   const returnFocusRef = useRef<HTMLElement | null>(null)
-  const activityAddRef = useRef<HTMLButtonElement>(null)
-  const reservationAddRef = useRef<HTMLButtonElement>(null)
-  const breakfastAddRef = useRef<HTMLButtonElement>(null)
+  const addMenuRef = useRef<HTMLButtonElement>(null)
+  const shiftAddTriggerRef = useRef<(() => void) | null>(null)
 
   const openAddActivity = useCallback(() => {
+    returnFocusRef.current = addMenuRef.current
     setEditActivity(null)
     setActivityModalOpen(true)
   }, [])
 
   const openAddReservation = useCallback(() => {
+    returnFocusRef.current = addMenuRef.current
     setEditReservation(null)
     setReservationModalOpen(true)
   }, [])
 
   const openAddBreakfast = useCallback(() => {
+    returnFocusRef.current = addMenuRef.current
     setEditBreakfast(null)
     setBreakfastModalOpen(true)
+  }, [])
+
+  const openAddShift = useCallback(() => {
+    shiftAddTriggerRef.current?.()
   }, [])
 
   function openEditActivity(item: ActivityWithRelations) {
@@ -272,26 +276,9 @@ function DayViewEditor({
     date,
     today,
     impersonationRole: authState.impersonationRole,
-    onOpenActivity: () => {
-      returnFocusRef.current = activityAddRef.current
-      openAddActivity()
-    },
-    ...(showReservations
-      ? {
-          onOpenReservation: () => {
-            returnFocusRef.current = reservationAddRef.current
-            openAddReservation()
-          },
-        }
-      : {}),
-    ...(showBreakfast
-      ? {
-          onOpenBreakfast: () => {
-            returnFocusRef.current = breakfastAddRef.current
-            openAddBreakfast()
-          },
-        }
-      : {}),
+    onOpenActivity: openAddActivity,
+    ...(showReservations ? { onOpenReservation: openAddReservation } : {}),
+    ...(showBreakfast ? { onOpenBreakfast: openAddBreakfast } : {}),
   })
 
   useEffect(() => {
@@ -299,34 +286,40 @@ function DayViewEditor({
     if (!create) return
 
     if (create === 'activity') {
-      returnFocusRef.current = activityAddRef.current
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setEditActivity(null)
-
-      setActivityModalOpen(true)
+      openAddActivity()
     } else if (create === 'reservation' && showReservations) {
-      returnFocusRef.current = reservationAddRef.current
-
-      setEditReservation(null)
-
-      setReservationModalOpen(true)
+      openAddReservation()
     } else if (create === 'breakfast' && showBreakfast) {
-      returnFocusRef.current = breakfastAddRef.current
-
-      setEditBreakfast(null)
-
-      setBreakfastModalOpen(true)
+      openAddBreakfast()
     }
 
     const params = new URLSearchParams(searchParams.toString())
     params.delete('create')
     const q = params.toString()
     router.replace(q ? `${pathname}?${q}` : pathname, { scroll: false })
-  }, [searchParams, showReservations, showBreakfast, router, pathname])
+  }, [
+    searchParams,
+    showReservations,
+    showBreakfast,
+    router,
+    pathname,
+    openAddActivity,
+    openAddReservation,
+    openAddBreakfast,
+  ])
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 px-3 py-4 sm:px-6 sm:py-8">
-      <DayNav date={date} today={today} />
+      <div className="flex items-center justify-between gap-2">
+        <DayNav date={date} today={today} />
+        <DayAddMenu
+          ref={addMenuRef}
+          onAddActivity={openAddActivity}
+          onAddReservation={showReservations ? openAddReservation : undefined}
+          onAddBreakfast={showBreakfast ? openAddBreakfast : undefined}
+          onAddShift={showStaffSchedule && shiftAssignees.length > 0 ? openAddShift : undefined}
+        />
+      </div>
 
       {(showDailyBrief || showWeatherReporting) && (
         <DayInfoBanner
@@ -359,26 +352,13 @@ function DayViewEditor({
           onShiftsChange={setShifts}
           forecastRecommended={forecastRecommended}
           forecastBreakdown={forecastBreakdown}
+          addTriggerRef={shiftAddTriggerRef}
         />
       )}
 
       {showBreakfast && (
         <section className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="font-semibold">{t('breakfast')}</h2>
-            <Button
-              ref={breakfastAddRef}
-              size="sm"
-              onClick={() => {
-                returnFocusRef.current = breakfastAddRef.current
-                openAddBreakfast()
-              }}
-              data-testid="add-breakfast"
-            >
-              <Plus className="mr-1 h-4 w-4" /> {t('addBreakfast')}
-              <KbdHint className="ml-1">B</KbdHint>
-            </Button>
-          </div>
+          <h2 className="font-semibold">{t('breakfast')}</h2>
           {breakfastConfigs.length === 0 ? (
             <p className="text-muted-foreground text-sm">{t('noBreakfasts')}</p>
           ) : (
@@ -401,22 +381,7 @@ function DayViewEditor({
       )}
 
       <section className="space-y-3">
-        <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1.5">
-          <h2 className="min-w-0 font-semibold">{t('activities')}</h2>
-          <Button
-            ref={activityAddRef}
-            size="xs"
-            onClick={() => {
-              returnFocusRef.current = activityAddRef.current
-              openAddActivity()
-            }}
-            className="shrink-0"
-            data-testid="add-activity"
-          >
-            <Plus className="size-3.5" /> {t('addActivity')}
-            <KbdHint className="ml-0.5">A</KbdHint>
-          </Button>
-        </div>
+        <h2 className="font-semibold">{t('activities')}</h2>
         {activities.length === 0 ? (
           <p className="text-muted-foreground text-sm">{t('noEntries')}</p>
         ) : (
@@ -439,21 +404,7 @@ function DayViewEditor({
 
       {showReservations && (
         <section className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="font-semibold">{t('reservations')}</h2>
-            <Button
-              ref={reservationAddRef}
-              size="sm"
-              onClick={() => {
-                returnFocusRef.current = reservationAddRef.current
-                openAddReservation()
-              }}
-              data-testid="add-reservation"
-            >
-              <Plus className="mr-1 h-4 w-4" /> {t('addReservation')}
-              <KbdHint className="ml-1">R</KbdHint>
-            </Button>
-          </div>
+          <h2 className="font-semibold">{t('reservations')}</h2>
           {reservations.length === 0 ? (
             <p className="text-muted-foreground text-sm">{t('noReservations')}</p>
           ) : (

--- a/components/day-add-menu.tsx
+++ b/components/day-add-menu.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Plus, CalendarClock, UtensilsCrossed, Coffee, Users } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
@@ -27,16 +27,20 @@ function useIsMobile() {
 }
 
 type Props = {
+  ref?: React.Ref<HTMLButtonElement>
   onAddActivity: () => void
   onAddReservation?: () => void
   onAddBreakfast?: () => void
   onAddShift?: () => void
 }
 
-export const DayAddMenu = forwardRef<HTMLButtonElement, Props>(function DayAddMenu(
-  { onAddActivity, onAddReservation, onAddBreakfast, onAddShift },
-  ref
-) {
+export function DayAddMenu({
+  ref,
+  onAddActivity,
+  onAddReservation,
+  onAddBreakfast,
+  onAddShift,
+}: Props) {
   const tDay = useTranslations('Tenant.day')
   const tStaff = useTranslations('Tenant.staff.section')
   const tPoc = useTranslations('Tenant.poc')
@@ -107,4 +111,4 @@ export const DayAddMenu = forwardRef<HTMLButtonElement, Props>(function DayAddMe
       </PopoverContent>
     </Popover>
   )
-})
+}

--- a/components/day-add-menu.tsx
+++ b/components/day-add-menu.tsx
@@ -29,9 +29,9 @@ function useIsMobile() {
 type Props = {
   ref?: React.Ref<HTMLButtonElement>
   onAddActivity: () => void
-  onAddReservation?: () => void
-  onAddBreakfast?: () => void
-  onAddShift?: () => void
+  onAddReservation?: (() => void) | undefined
+  onAddBreakfast?: (() => void) | undefined
+  onAddShift?: (() => void) | undefined
 }
 
 export function DayAddMenu({

--- a/components/day-add-menu.tsx
+++ b/components/day-add-menu.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { forwardRef, useEffect, useState } from 'react'
+import { Plus, CalendarClock, UtensilsCrossed, Coffee, Users } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer'
+import { MenuItem } from '@/components/ui/menu-item'
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false)
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 639px)')
+    setIsMobile(mq.matches)
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+  return isMobile
+}
+
+type Props = {
+  onAddActivity: () => void
+  onAddReservation?: () => void
+  onAddBreakfast?: () => void
+  onAddShift?: () => void
+}
+
+export const DayAddMenu = forwardRef<HTMLButtonElement, Props>(function DayAddMenu(
+  { onAddActivity, onAddReservation, onAddBreakfast, onAddShift },
+  ref
+) {
+  const tDay = useTranslations('Tenant.day')
+  const tStaff = useTranslations('Tenant.staff.section')
+  const tPoc = useTranslations('Tenant.poc')
+  const isMobile = useIsMobile()
+  const [open, setOpen] = useState(false)
+
+  function handleSelect(fn: () => void) {
+    setOpen(false)
+    fn()
+  }
+
+  const menuItems = (
+    <div className="flex flex-col gap-0.5">
+      <MenuItem data-testid="add-activity" onClick={() => handleSelect(onAddActivity)}>
+        <CalendarClock />
+        {tDay('addActivity')}
+      </MenuItem>
+      {onAddReservation && (
+        <MenuItem data-testid="add-reservation" onClick={() => handleSelect(onAddReservation)}>
+          <UtensilsCrossed />
+          {tDay('addReservation')}
+        </MenuItem>
+      )}
+      {onAddBreakfast && (
+        <MenuItem data-testid="add-breakfast" onClick={() => handleSelect(onAddBreakfast)}>
+          <Coffee />
+          {tDay('addBreakfast')}
+        </MenuItem>
+      )}
+      {onAddShift && (
+        <MenuItem data-testid="add-shift" onClick={() => handleSelect(onAddShift)}>
+          <Users />
+          {tStaff('addShift')}
+        </MenuItem>
+      )}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerTrigger asChild>
+          <Button ref={ref} size="sm" data-testid="day-add-menu">
+            <Plus className="mr-1 h-4 w-4" />
+            {tPoc('add')}
+          </Button>
+        </DrawerTrigger>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>{tPoc('add')}</DrawerTitle>
+          </DrawerHeader>
+          <div className="px-4 pb-8">{menuItems}</div>
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button ref={ref} size="sm" data-testid="day-add-menu">
+          <Plus className="mr-1 h-4 w-4" />
+          {tPoc('add')}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-48 p-1" align="end">
+        {menuItems}
+      </PopoverContent>
+    </Popover>
+  )
+})

--- a/components/staff-schedule-section.tsx
+++ b/components/staff-schedule-section.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
-import { Plus } from 'lucide-react'
 import { ShiftCard } from '@/components/shift-card'
 import { ShiftForm } from '@/components/shift-form'
-import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { ShiftAssignee, ShiftWithAssignee } from '@/types/index'
@@ -20,6 +18,7 @@ type Props = {
   onShiftsChange: React.Dispatch<React.SetStateAction<ShiftWithAssignee[]>>
   forecastRecommended: number
   forecastBreakdown: ForecastBreakdownItem[]
+  addTriggerRef?: React.MutableRefObject<(() => void) | null>
 }
 
 function parseMinutes(time: string): number {
@@ -55,6 +54,7 @@ export function StaffScheduleSection({
   onShiftsChange,
   forecastRecommended,
   forecastBreakdown,
+  addTriggerRef,
 }: Props) {
   const t = useTranslations('Tenant.staff.section')
   const tForecast = useTranslations('Tenant.staff.forecast')
@@ -65,10 +65,19 @@ export function StaffScheduleSection({
   const totalActual = shifts.reduce((sum, s) => sum + shiftActualMinutes(s), 0)
   const hasActuals = shifts.some((s) => s.actual_start)
 
-  function openAdd() {
+  const openAdd = useCallback(() => {
     setEditShift(null)
     setFormOpen(true)
-  }
+  }, [])
+
+  useEffect(() => {
+    if (addTriggerRef) {
+      addTriggerRef.current = openAdd
+      return () => {
+        addTriggerRef.current = null
+      }
+    }
+  }, [addTriggerRef, openAdd])
 
   function openEdit(item: ShiftWithAssignee) {
     setEditShift(item)
@@ -141,11 +150,6 @@ export function StaffScheduleSection({
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-          )}
-          {isEditor && (
-            <Button size="xs" onClick={openAdd} disabled={assignees.length === 0}>
-              <Plus className="size-3.5" /> {t('addShift')}
-            </Button>
           )}
         </div>
       </div>

--- a/tests/e2e/day.spec.ts
+++ b/tests/e2e/day.spec.ts
@@ -28,6 +28,7 @@ test.describe('Day view', () => {
   }) => {
     await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
+    await signedInPage.getByTestId('day-add-menu').click()
     await signedInPage.getByTestId('add-activity').click()
     await signedInPage.getByTestId('activity-form-title').fill('E2E Test Activity')
     await signedInPage.getByTestId('activity-form-save').click()
@@ -68,6 +69,7 @@ test.describe('Reservation CRUD', () => {
   test('add reservation — appears in list', async ({ signedInPage, tenantUrl }) => {
     await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
+    await signedInPage.getByTestId('day-add-menu').click()
     await signedInPage.getByTestId('add-reservation').click()
     await signedInPage.getByTestId('reservation-form-guest-name').fill('E2E Guest')
     await signedInPage.getByTestId('reservation-form-save').click()
@@ -92,6 +94,7 @@ test.describe('Breakfast CRUD', () => {
   test('add breakfast — appears in list', async ({ signedInPage, tenantUrl }) => {
     await signedInPage.goto(`${tenantUrl}/day/${dayDate}`)
 
+    await signedInPage.getByTestId('day-add-menu').click()
     await signedInPage.getByTestId('add-breakfast').click()
     await signedInPage.getByTestId('breakfast-form-group-name').fill('E2E Breakfast Group')
     await signedInPage.getByTestId('breakfast-form-save').click()


### PR DESCRIPTION
## Summary

- Adds `components/day-add-menu.tsx` — a single "Add" button (Popover on desktop, Drawer on mobile) with `MenuItem` entries for Activity, Reservation, Breakfast, and Shift
- Removes the four individual per-section add buttons from `DayViewClient`; section headings remain
- Exposes `addTriggerRef` prop on `StaffScheduleSection` so the parent can trigger the shift form without lifting all shift state
- Feature-flagged options (reservations, breakfast) and shift option (hidden when no assignees) are absent from the menu automatically
- Keyboard shortcuts A/R/B continue to open forms directly via the same callbacks
- E2E tests updated to open the menu (`day-add-menu`) before clicking entity-level testids (`add-activity`, `add-reservation`, `add-breakfast`)

Closes #235

## Test plan

- [ ] Sign in as editor, visit `/[tenant]/day/[date]` — confirm one "Add" button in the nav row, opens popover with 4 items, each opens correct form
- [ ] Toggle `reservations` flag off in admin — Reservation entry disappears from menu
- [ ] Toggle `breakfast_config` flag off — Breakfast entry disappears
- [ ] With no staff members configured, Shift entry is absent
- [ ] Press A/R/B keyboard shortcuts — correct forms open directly without going through menu
- [ ] Mobile width (~375 px) — button opens a bottom drawer instead of popover
- [ ] Viewer role — no Add button visible (viewer dashboard unchanged)

https://claude.ai/code/session_016bHS2EHY6P8eAxDD6MkcGY

---
_Generated by [Claude Code](https://claude.ai/code/session_016bHS2EHY6P8eAxDD6MkcGY)_