### PR TITLE
Fix tenant logo sizing, padding, and dark-mode contrast (#231)

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -122,13 +122,7 @@ export default async function TenantLayout({ children }: { children: React.React
                 style={accentStyle}
               >
                 <header className="flex h-14 items-center justify-between border-b px-6">
-                  <Link
-                    href="/"
-                    className="inline-flex items-center"
-                    aria-label={row?.name ?? 'Home'}
-                  >
-                    <Logo logoUrl={row?.logo_url ?? null} tenantName={row?.name ?? null} />
-                  </Link>
+                  <Logo logoUrl={row?.logo_url ?? null} tenantName={row?.name ?? null} />
                   <div className="flex items-center gap-1">
                     <OfflineStatusPill />
                     {/* Theme toggle — visible to all signed-in users */}

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -44,14 +44,16 @@ export function Logo({ className, logoUrl, tenantName }: LogoProps) {
 
   if (logoUrl) {
     content = (
-      <Image
-        src={logoUrl}
-        alt={tenantName ?? 'Logo'}
-        width={120}
-        height={36}
-        className={cn('max-h-9 object-contain', className)}
-        priority
-      />
+      <span className="inline-flex items-center rounded bg-white/90 px-1.5 py-0.5 dark:bg-white/95">
+        <Image
+          src={logoUrl}
+          alt={tenantName ?? 'Logo'}
+          width={160}
+          height={36}
+          className="h-8 w-auto max-w-[160px] object-contain sm:h-9"
+          priority
+        />
+      </span>
     )
   } else if (tenantName) {
     content = (
@@ -71,7 +73,12 @@ export function Logo({ className, logoUrl, tenantName }: LogoProps) {
   }
 
   return (
-    <Link href="/" prefetch={false} aria-label={tenantName ?? 'Courseday'}>
+    <Link
+      href="/"
+      prefetch={false}
+      aria-label={tenantName ?? 'Courseday'}
+      className="inline-flex items-center"
+    >
       {content}
     </Link>
   )


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Sizing**: logo image now constrained to `h-8` (mobile) / `h-9` (desktop) with `w-auto max-w-[160px] object-contain` — wide logos shrink, tall logos don't overflow
- **Dark-mode contrast**: white background plate (`bg-white/90 dark:bg-white/95 rounded px-1.5 py-0.5`) applied only when `logoUrl` is set, ensuring dark-on-transparent logos are always readable
- **Nested anchor fix**: removed redundant `<Link>` wrapper in `app/[tenant]/layout.tsx` — `Logo` already renders its own `<Link>`, the outer one produced invalid `<a>` inside `<a>` HTML

## Test plan

- [ ] Set `tenants.logo_url` to a wide logo → confirm it shrinks horizontally, stays within 160px
- [ ] Set to a tall logo → confirm it doesn't overflow the navbar vertically
- [ ] Set to a dark-on-transparent PNG → view in dark mode → logo readable against dark navbar via white plate
- [ ] Set to a light-on-transparent PNG → view in light mode → logo readable
- [ ] Clear `logo_url` → confirm tenant-name text fallback unchanged, no plate rendered
- [ ] Check browser devtools: no nested `<a>` elements in the navbar

https://claude.ai/code/session_01M8G9yHHrjKSgyV79GWTREn
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8G9yHHrjKSgyV79GWTREn)_