### PR TITLE
feat: weather inside brief, expandable stat blocks, drop shift section (#230)

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -1,5 +1,5 @@
 'use client'
-
+// fmt
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { DayAddMenu } from '@/components/day-add-menu'
 import dynamic from 'next/dynamic'

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -1,5 +1,5 @@
 'use client'
-// fmt
+
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { DayAddMenu } from '@/components/day-add-menu'
 import dynamic from 'next/dynamic'

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -356,7 +356,7 @@ function DayViewEditor({
           {showBreakfast && (
             // eslint-disable-next-line no-restricted-syntax
             <button
-              className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+              className="bg-card hover:bg-muted/30 cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors"
               onClick={() => toggleBlock('breakfast')}
               aria-expanded={openBlocks.has('breakfast')}
             >
@@ -370,7 +370,7 @@ function DayViewEditor({
           )}
           {/* eslint-disable-next-line no-restricted-syntax */}
           <button
-            className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+            className="bg-card hover:bg-muted/30 cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors"
             onClick={() => toggleBlock('activities')}
             aria-expanded={openBlocks.has('activities')}
           >
@@ -384,7 +384,7 @@ function DayViewEditor({
           {showReservations && (
             // eslint-disable-next-line no-restricted-syntax
             <button
-              className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+              className="bg-card hover:bg-muted/30 cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors"
               onClick={() => toggleBlock('reservations')}
               aria-expanded={openBlocks.has('reservations')}
             >

--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -7,7 +7,6 @@ import { useSearchParams, usePathname, useRouter } from 'next/navigation'
 import { useDayRealtime } from './useDayRealtime'
 import { useTranslations } from 'next-intl'
 import { DayNav } from '@/components/day-nav'
-import { DaySummaryCard } from '@/components/day-summary-card'
 import { ViewerDayDashboard } from '@/components/viewer-day-dashboard'
 import { ActivityCard } from '@/components/activity-card'
 import { ReservationCard } from '@/components/reservation-card'
@@ -110,7 +109,6 @@ export function DayViewClient(props: DayViewProps) {
         activities={live.activities}
         reservations={live.reservations}
         breakfastConfigs={live.breakfastConfigs}
-        shifts={live.shifts}
         dayNotes={live.dayNotes}
         setDayNotes={live.setDayNotes}
       />
@@ -144,6 +142,7 @@ function DayViewEditor({
   showStaffSchedule: boolean
 }) {
   const t = useTranslations('Tenant.day')
+  const tsummary = useTranslations('Tenant.summary')
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -151,6 +150,18 @@ function DayViewEditor({
   const showBreakfast = useFeatureFlag('breakfast_config')
   const showWeatherReporting = useFeatureFlag('weather_reporting')
   const showDailyBrief = useFeatureFlag('daily_brief')
+
+  const [openBlocks, setOpenBlocks] = useState<Set<'breakfast' | 'activities' | 'reservations'>>(
+    new Set()
+  )
+  const toggleBlock = (key: 'breakfast' | 'activities' | 'reservations') => {
+    setOpenBlocks((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
 
   const {
     activities,
@@ -337,11 +348,119 @@ function DayViewEditor({
         />
       )}
 
-      <DaySummaryCard
-        activities={activities}
-        reservations={reservations}
-        breakfastConfigs={breakfastConfigs}
-      />
+      {/* Expandable stat blocks — click to reveal item list with editor affordances */}
+      <div className="space-y-3">
+        <div
+          className={`grid gap-3 ${showBreakfast && showReservations ? 'grid-cols-3' : showBreakfast || showReservations ? 'grid-cols-2' : 'grid-cols-1'}`}
+        >
+          {showBreakfast && (
+            // eslint-disable-next-line no-restricted-syntax
+            <button
+              className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+              onClick={() => toggleBlock('breakfast')}
+              aria-expanded={openBlocks.has('breakfast')}
+            >
+              <p className="text-4xl leading-none font-bold tabular-nums">
+                {breakfastConfigs.reduce((s, b) => s + b.total_guests, 0)}
+              </p>
+              <p className="text-muted-foreground mt-2 text-xs leading-tight">
+                {tsummary('breakfast')}
+              </p>
+            </button>
+          )}
+          {/* eslint-disable-next-line no-restricted-syntax */}
+          <button
+            className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+            onClick={() => toggleBlock('activities')}
+            aria-expanded={openBlocks.has('activities')}
+          >
+            <p className="text-4xl leading-none font-bold tabular-nums">
+              {activities.reduce((s, a) => s + (a.expected_covers ?? 0), 0)}
+            </p>
+            <p className="text-muted-foreground mt-2 text-xs leading-tight">
+              {tsummary('activities')}
+            </p>
+          </button>
+          {showReservations && (
+            // eslint-disable-next-line no-restricted-syntax
+            <button
+              className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+              onClick={() => toggleBlock('reservations')}
+              aria-expanded={openBlocks.has('reservations')}
+            >
+              <p className="text-4xl leading-none font-bold tabular-nums">
+                {reservations.reduce((s, r) => s + (r.guest_count ?? 0), 0)}
+              </p>
+              <p className="text-muted-foreground mt-2 text-xs leading-tight">
+                {tsummary('reservations')}
+              </p>
+            </button>
+          )}
+        </div>
+
+        {openBlocks.has('breakfast') && showBreakfast && (
+          <section className="space-y-2">
+            {breakfastConfigs.length === 0 ? (
+              <p className="text-muted-foreground text-sm">{t('noBreakfasts')}</p>
+            ) : (
+              breakfastConfigs.map((item) => (
+                <BreakfastCard
+                  key={item.id}
+                  item={item}
+                  isEditor={authState.isEditor}
+                  onEdit={openEditBreakfast}
+                  onDeleted={handleBreakfastDeleted}
+                  onBeforeEdit={(el) => {
+                    returnFocusRef.current = el
+                  }}
+                />
+              ))
+            )}
+          </section>
+        )}
+
+        {openBlocks.has('activities') && (
+          <section className="space-y-2">
+            {activities.length === 0 ? (
+              <p className="text-muted-foreground text-sm">{t('noEntries')}</p>
+            ) : (
+              activities.map((item) => (
+                <ActivityCard
+                  key={item.id}
+                  item={item}
+                  isEditor={authState.isEditor}
+                  onEdit={openEditActivity}
+                  onDeleted={handleActivityDeleted}
+                  onBeforeEdit={(el) => {
+                    returnFocusRef.current = el
+                  }}
+                />
+              ))
+            )}
+          </section>
+        )}
+
+        {openBlocks.has('reservations') && showReservations && (
+          <section className="space-y-2">
+            {reservations.length === 0 ? (
+              <p className="text-muted-foreground text-sm">{t('noReservations')}</p>
+            ) : (
+              reservations.map((item) => (
+                <ReservationCard
+                  key={item.id}
+                  item={item}
+                  isEditor={authState.isEditor}
+                  onEdit={openEditReservation}
+                  onDeleted={handleReservationDeleted}
+                  onBeforeEdit={(el) => {
+                    returnFocusRef.current = el
+                  }}
+                />
+              ))
+            )}
+          </section>
+        )}
+      </div>
 
       {showStaffSchedule && (
         <StaffScheduleSection
@@ -354,76 +473,6 @@ function DayViewEditor({
           forecastBreakdown={forecastBreakdown}
           addTriggerRef={shiftAddTriggerRef}
         />
-      )}
-
-      {showBreakfast && (
-        <section className="space-y-3">
-          <h2 className="font-semibold">{t('breakfast')}</h2>
-          {breakfastConfigs.length === 0 ? (
-            <p className="text-muted-foreground text-sm">{t('noBreakfasts')}</p>
-          ) : (
-            <div className="space-y-2">
-              {breakfastConfigs.map((item) => (
-                <BreakfastCard
-                  key={item.id}
-                  item={item}
-                  isEditor={authState.isEditor}
-                  onEdit={openEditBreakfast}
-                  onDeleted={handleBreakfastDeleted}
-                  onBeforeEdit={(el) => {
-                    returnFocusRef.current = el
-                  }}
-                />
-              ))}
-            </div>
-          )}
-        </section>
-      )}
-
-      <section className="space-y-3">
-        <h2 className="font-semibold">{t('activities')}</h2>
-        {activities.length === 0 ? (
-          <p className="text-muted-foreground text-sm">{t('noEntries')}</p>
-        ) : (
-          <div className="space-y-2">
-            {activities.map((item) => (
-              <ActivityCard
-                key={item.id}
-                item={item}
-                isEditor={authState.isEditor}
-                onEdit={openEditActivity}
-                onDeleted={handleActivityDeleted}
-                onBeforeEdit={(el) => {
-                  returnFocusRef.current = el
-                }}
-              />
-            ))}
-          </div>
-        )}
-      </section>
-
-      {showReservations && (
-        <section className="space-y-3">
-          <h2 className="font-semibold">{t('reservations')}</h2>
-          {reservations.length === 0 ? (
-            <p className="text-muted-foreground text-sm">{t('noReservations')}</p>
-          ) : (
-            <div className="space-y-2">
-              {reservations.map((item) => (
-                <ReservationCard
-                  key={item.id}
-                  item={item}
-                  isEditor={authState.isEditor}
-                  onEdit={openEditReservation}
-                  onDeleted={handleReservationDeleted}
-                  onBeforeEdit={(el) => {
-                    returnFocusRef.current = el
-                  }}
-                />
-              ))}
-            </div>
-          )}
-        </section>
       )}
 
       <DayNotes

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -13,6 +13,7 @@ import { dailyBriefContentSchema } from '@/lib/daily-brief-schema'
 import type { DailyBriefContent, DailyBriefRecord, RegenerableSection } from '@/types/daily-brief'
 import { formatDailyBriefMarkdown } from '@/lib/daily-brief-format'
 import { regenerateBriefSection } from '@/app/actions/daily-brief'
+import type { WeatherData } from '@/app/actions/weather'
 
 const REGENERATE_DEBOUNCE_MS = 2000
 
@@ -31,6 +32,8 @@ type Props = {
   overrideAuthorName?: string | null
   /** Viewer mode: hides card chrome (title, copy button). Empty/not-generated state renders nothing. */
   chromeless?: boolean
+  /** Inline weather summary shown at top of card; only rendered when non-null. */
+  weather?: WeatherData | null
 }
 
 export function DailyBriefCard({
@@ -42,6 +45,7 @@ export function DailyBriefCard({
   briefIsEmpty = false,
   overrideAuthorName = null,
   chromeless = false,
+  weather = null,
 }: Props) {
   const t = useTranslations('Tenant.dailyBrief')
   const router = useRouter()
@@ -150,7 +154,6 @@ export function DailyBriefCard({
 
   const hasBrief = brief !== null
   const streaming = isLoading && !hasBrief
-  const covers = streamedObject?.covers
 
   // Chromeless + no brief = render nothing (viewer sees no placeholder)
   if (chromeless && !hasBrief && !streaming) return null
@@ -194,6 +197,23 @@ export function DailyBriefCard({
       )}
 
       <div className={`space-y-3 ${chromeless ? 'p-0' : 'p-4'}`}>
+        {weather && (
+          <div className="bg-muted/30 flex items-center gap-3 rounded-lg border px-4 py-3">
+            <span className="shrink-0 text-3xl leading-none" aria-hidden="true">
+              {weather.emoji}
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-medium">{weather.description}</p>
+              <p className="text-muted-foreground text-xs">
+                {weather.tempMax}° / {weather.tempMin}°C
+                {weather.precipitationProbability > 0 && (
+                  <> · {weather.precipitationProbability}% rain</>
+                )}
+              </p>
+            </div>
+          </div>
+        )}
+
         {stale && isEditor && !isLoading && (
           <div className="flex items-center justify-between gap-2 rounded-md border border-amber-200/60 bg-amber-50 px-2.5 py-2 dark:border-amber-900/50 dark:bg-amber-950/40">
             <p className="text-xs text-amber-800/90 dark:text-amber-200/90">{t('stale')}</p>
@@ -241,29 +261,6 @@ export function DailyBriefCard({
               </div>
             )}
 
-            {covers ? (
-              <div className="animate-in fade-in grid grid-cols-3 gap-2 text-center text-sm duration-300">
-                <div className="bg-muted/50 rounded-md py-2">
-                  <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
-                  <div className="font-semibold tabular-nums">{covers.breakfast ?? '—'}</div>
-                </div>
-                <div className="bg-muted/50 rounded-md py-2">
-                  <div className="text-muted-foreground text-xs">{t('coversActivities')}</div>
-                  <div className="font-semibold tabular-nums">{covers.activities ?? '—'}</div>
-                </div>
-                <div className="bg-muted/50 rounded-md py-2">
-                  <div className="text-muted-foreground text-xs">{t('coversReservations')}</div>
-                  <div className="font-semibold tabular-nums">{covers.reservations ?? '—'}</div>
-                </div>
-              </div>
-            ) : (
-              <div className="grid grid-cols-3 gap-2">
-                <Skeleton className="h-12 rounded-md" />
-                <Skeleton className="h-12 rounded-md" />
-                <Skeleton className="h-12 rounded-md" />
-              </div>
-            )}
-
             <div className="space-y-1.5 pt-1">
               <Skeleton className="h-3 w-1/3" />
               <Skeleton className="h-3 w-11/12" />
@@ -289,23 +286,6 @@ export function DailyBriefCard({
                   t={t}
                 />
               )}
-            </div>
-
-            <div className="grid grid-cols-3 gap-2 text-center text-sm">
-              <div className="bg-muted/50 rounded-md py-2">
-                <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
-                <div className="font-semibold tabular-nums">{brief.content.covers.breakfast}</div>
-              </div>
-              <div className="bg-muted/50 rounded-md py-2">
-                <div className="text-muted-foreground text-xs">{t('coversActivities')}</div>
-                <div className="font-semibold tabular-nums">{brief.content.covers.activities}</div>
-              </div>
-              <div className="bg-muted/50 rounded-md py-2">
-                <div className="text-muted-foreground text-xs">{t('coversReservations')}</div>
-                <div className="font-semibold tabular-nums">
-                  {brief.content.covers.reservations}
-                </div>
-              </div>
             </div>
 
             <details className="group text-sm">

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -1,5 +1,5 @@
 'use client'
-
+// fmt
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { useTranslations } from 'next-intl'

--- a/components/daily-brief-card.tsx
+++ b/components/daily-brief-card.tsx
@@ -1,5 +1,5 @@
 'use client'
-// fmt
+
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { useTranslations } from 'next-intl'

--- a/components/day-info-banner.tsx
+++ b/components/day-info-banner.tsx
@@ -1,5 +1,5 @@
 'use client'
-
+// fmt
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { ClipboardCopy, Loader2, Pencil, RefreshCw, Sparkles } from 'lucide-react'

--- a/components/day-info-banner.tsx
+++ b/components/day-info-banner.tsx
@@ -1,5 +1,5 @@
 'use client'
-// fmt
+
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { ClipboardCopy, Loader2, Pencil, RefreshCw, Sparkles } from 'lucide-react'

--- a/components/day-info-banner.tsx
+++ b/components/day-info-banner.tsx
@@ -81,12 +81,6 @@ function AllergenBlock({
   )
 }
 
-/** Fades in a section when it first receives content during streaming. */
-function StreamSection({ show, children }: { show: boolean; children: React.ReactNode }) {
-  if (!show) return null
-  return <div className="animate-in fade-in duration-300">{children}</div>
-}
-
 export function DayInfoBanner({
   weather,
   showWeather,
@@ -390,7 +384,6 @@ function StreamingBriefContent({
   object: StreamPartial
   t: ReturnType<typeof useTranslations<'Tenant.dailyBrief'>>
 }) {
-  const covers = object?.covers
   return (
     <div className="space-y-3">
       {object?.headline ? (
@@ -411,23 +404,6 @@ function StreamingBriefContent({
           <div className="bg-muted h-4 w-5/6 animate-pulse rounded" />
         </div>
       )}
-
-      <StreamSection show={Boolean(covers)}>
-        <div className="grid grid-cols-3 gap-2 text-center text-sm">
-          <div className="bg-muted/50 rounded-md py-2">
-            <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
-            <div className="font-semibold tabular-nums">{covers?.breakfast ?? '—'}</div>
-          </div>
-          <div className="bg-muted/50 rounded-md py-2">
-            <div className="text-muted-foreground text-xs">{t('coversActivities')}</div>
-            <div className="font-semibold tabular-nums">{covers?.activities ?? '—'}</div>
-          </div>
-          <div className="bg-muted/50 rounded-md py-2">
-            <div className="text-muted-foreground text-xs">{t('coversReservations')}</div>
-            <div className="font-semibold tabular-nums">{covers?.reservations ?? '—'}</div>
-          </div>
-        </div>
-      </StreamSection>
     </div>
   )
 }
@@ -477,21 +453,6 @@ function SettledBriefContent({
             t={t}
           />
         )}
-      </div>
-
-      <div className="grid grid-cols-3 gap-2 text-center text-sm">
-        <div className="bg-muted/50 rounded-md py-2">
-          <div className="text-muted-foreground text-xs">{t('coversBreakfast')}</div>
-          <div className="font-semibold tabular-nums">{brief.content.covers.breakfast}</div>
-        </div>
-        <div className="bg-muted/50 rounded-md py-2">
-          <div className="text-muted-foreground text-xs">{t('coversActivities')}</div>
-          <div className="font-semibold tabular-nums">{brief.content.covers.activities}</div>
-        </div>
-        <div className="bg-muted/50 rounded-md py-2">
-          <div className="text-muted-foreground text-xs">{t('coversReservations')}</div>
-          <div className="font-semibold tabular-nums">{brief.content.covers.reservations}</div>
-        </div>
       </div>
 
       <details className="group text-sm">

--- a/components/viewer-day-dashboard.tsx
+++ b/components/viewer-day-dashboard.tsx
@@ -1,5 +1,5 @@
 'use client'
-// temp
+
 import { useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { useTranslations } from 'next-intl'

--- a/components/viewer-day-dashboard.tsx
+++ b/components/viewer-day-dashboard.tsx
@@ -121,7 +121,7 @@ export function ViewerDayDashboard({
           {showBreakfast && (
             // eslint-disable-next-line no-restricted-syntax
             <button
-              className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+              className="bg-card hover:bg-muted/30 cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors"
               onClick={() => toggleBlock('breakfast')}
               aria-expanded={openBlocks.has('breakfast')}
             >
@@ -133,7 +133,7 @@ export function ViewerDayDashboard({
           )}
           {/* eslint-disable-next-line no-restricted-syntax */}
           <button
-            className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+            className="bg-card hover:bg-muted/30 cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors"
             onClick={() => toggleBlock('activities')}
             aria-expanded={openBlocks.has('activities')}
           >
@@ -145,7 +145,7 @@ export function ViewerDayDashboard({
           {showReservations && (
             // eslint-disable-next-line no-restricted-syntax
             <button
-              className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+              className="bg-card hover:bg-muted/30 cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors"
               onClick={() => toggleBlock('reservations')}
               aria-expanded={openBlocks.has('reservations')}
             >

--- a/components/viewer-day-dashboard.tsx
+++ b/components/viewer-day-dashboard.tsx
@@ -1,19 +1,13 @@
 'use client'
 
+import { useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { useTranslations } from 'next-intl'
 import { DayNav } from '@/components/day-nav'
 import { DayNotes } from '@/components/day-notes'
-import { WeatherCard } from '@/components/weather-card'
 import { TableBreakdownDisplay } from '@/components/table-breakdown-display'
 import { useFeatureFlag } from '@/lib/feature-flags-context'
-import { ShiftCard } from '@/components/shift-card'
-import type {
-  ActivityWithRelations,
-  Reservation,
-  BreakfastConfiguration,
-  ShiftWithAssignee,
-} from '@/types/index'
+import type { ActivityWithRelations, Reservation, BreakfastConfiguration } from '@/types/index'
 import type { DayNote } from '@/app/actions/day-notes'
 import type { WeatherData } from '@/app/actions/weather'
 import type { DailyBriefRecord } from '@/types/daily-brief'
@@ -38,7 +32,6 @@ type Props = {
   dailyBrief: DailyBriefRecord | null
   briefStale?: boolean
   briefIsEmpty?: boolean
-  shifts: ShiftWithAssignee[]
   briefOverrideAuthorName?: string | null
 }
 
@@ -59,7 +52,6 @@ export function ViewerDayDashboard({
   dailyBrief,
   briefStale,
   briefIsEmpty,
-  shifts,
   briefOverrideAuthorName = null,
 }: Props) {
   const { impersonationRole } = useAuth()
@@ -67,14 +59,12 @@ export function ViewerDayDashboard({
   useDayViewHotkeys({ date, today, impersonationRole })
 
   const td = useTranslations('Tenant.day')
-  const ts = useTranslations('Tenant.staff.section')
   const tsummary = useTranslations('Tenant.summary')
   const te = useTranslations('Tenant.entry')
   const tb = useTranslations('Tenant.breakfastCard')
   const showReservations = useFeatureFlag('reservations')
   const showBreakfast = useFeatureFlag('breakfast_config')
   const showWeatherReporting = useFeatureFlag('weather_reporting')
-  const showStaffSchedule = useFeatureFlag('staff_schedule')
   const showDailyBrief = useFeatureFlag('daily_brief')
 
   const visibleBreakfastConfigs = showBreakfast ? breakfastConfigs : []
@@ -83,6 +73,18 @@ export function ViewerDayDashboard({
   const totalBreakfastCovers = visibleBreakfastConfigs.reduce((s, b) => s + b.total_guests, 0)
   const totalActivityCovers = activities.reduce((s, a) => s + (a.expected_covers ?? 0), 0)
   const totalReservationCovers = visibleReservations.reduce((s, r) => s + (r.guest_count ?? 0), 0)
+
+  const [openBlocks, setOpenBlocks] = useState<Set<'breakfast' | 'activities' | 'reservations'>>(
+    new Set()
+  )
+  const toggleBlock = (key: 'breakfast' | 'activities' | 'reservations') => {
+    setOpenBlocks((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 px-4 py-6 sm:px-6">
@@ -97,11 +99,10 @@ export function ViewerDayDashboard({
           briefStale={briefStale ?? false}
           briefIsEmpty={briefIsEmpty ?? false}
           overrideAuthorName={briefOverrideAuthorName}
+          weather={showWeatherReporting ? weather : null}
           chromeless
         />
       )}
-
-      {showWeatherReporting && weather && <WeatherCard weather={weather} />}
 
       <DayNotes
         dayId={dayId}
@@ -112,57 +113,84 @@ export function ViewerDayDashboard({
         currentUserId={undefined}
       />
 
-      {/* Summary — large numbers for at-a-glance reading */}
-      <div
-        className={`grid gap-3 ${showBreakfast && showReservations ? 'grid-cols-3' : showBreakfast || showReservations ? 'grid-cols-2' : 'grid-cols-1'}`}
-      >
-        {showBreakfast && <StatBlock label={tsummary('breakfast')} value={totalBreakfastCovers} />}
-        <StatBlock label={tsummary('activities')} value={totalActivityCovers} />
-        {showReservations && (
-          <StatBlock label={tsummary('reservations')} value={totalReservationCovers} />
+      {/* Expandable stat blocks — click to reveal item list */}
+      <div className="space-y-3">
+        <div
+          className={`grid gap-3 ${showBreakfast && showReservations ? 'grid-cols-3' : showBreakfast || showReservations ? 'grid-cols-2' : 'grid-cols-1'}`}
+        >
+          {showBreakfast && (
+            // eslint-disable-next-line no-restricted-syntax
+            <button
+              className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+              onClick={() => toggleBlock('breakfast')}
+              aria-expanded={openBlocks.has('breakfast')}
+            >
+              <p className="text-4xl leading-none font-bold tabular-nums">{totalBreakfastCovers}</p>
+              <p className="text-muted-foreground mt-2 text-xs leading-tight">
+                {tsummary('breakfast')}
+              </p>
+            </button>
+          )}
+          {/* eslint-disable-next-line no-restricted-syntax */}
+          <button
+            className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+            onClick={() => toggleBlock('activities')}
+            aria-expanded={openBlocks.has('activities')}
+          >
+            <p className="text-4xl leading-none font-bold tabular-nums">{totalActivityCovers}</p>
+            <p className="text-muted-foreground mt-2 text-xs leading-tight">
+              {tsummary('activities')}
+            </p>
+          </button>
+          {showReservations && (
+            // eslint-disable-next-line no-restricted-syntax
+            <button
+              className="bg-card cursor-pointer rounded-lg border px-3 py-4 text-center transition-colors hover:bg-muted/30"
+              onClick={() => toggleBlock('reservations')}
+              aria-expanded={openBlocks.has('reservations')}
+            >
+              <p className="text-4xl leading-none font-bold tabular-nums">
+                {totalReservationCovers}
+              </p>
+              <p className="text-muted-foreground mt-2 text-xs leading-tight">
+                {tsummary('reservations')}
+              </p>
+            </button>
+          )}
+        </div>
+
+        {openBlocks.has('breakfast') && showBreakfast && (
+          <section className="space-y-2">
+            {visibleBreakfastConfigs.length === 0 ? (
+              <p className="text-muted-foreground text-sm">{td('noBreakfasts')}</p>
+            ) : (
+              visibleBreakfastConfigs.map((item) => (
+                <BreakfastRow key={item.id} item={item} t={tb} />
+              ))
+            )}
+          </section>
+        )}
+
+        {openBlocks.has('activities') && (
+          <section className="space-y-2">
+            {activities.length === 0 ? (
+              <p className="text-muted-foreground text-sm">{td('noEntries')}</p>
+            ) : (
+              activities.map((item) => <ActivityRow key={item.id} item={item} t={te} />)
+            )}
+          </section>
+        )}
+
+        {openBlocks.has('reservations') && showReservations && (
+          <section className="space-y-2">
+            {visibleReservations.length === 0 ? (
+              <p className="text-muted-foreground text-sm">{td('noReservations')}</p>
+            ) : (
+              visibleReservations.map((item) => <ReservationRow key={item.id} item={item} />)
+            )}
+          </section>
         )}
       </div>
-
-      {showStaffSchedule && (
-        <ViewerSection title={ts('title')} empty={shifts.length === 0} emptyLabel={ts('empty')}>
-          {shifts.map((item) => (
-            <ShiftCard key={item.id} dayId={dayId} item={item} isEditor={false} />
-          ))}
-        </ViewerSection>
-      )}
-
-      {/* Breakfast */}
-      <ViewerSection
-        title={td('breakfast')}
-        empty={visibleBreakfastConfigs.length === 0}
-        emptyLabel={td('noBreakfasts')}
-      >
-        {visibleBreakfastConfigs.map((item) => (
-          <BreakfastRow key={item.id} item={item} t={tb} />
-        ))}
-      </ViewerSection>
-
-      {/* Activities */}
-      <ViewerSection
-        title={td('activities')}
-        empty={activities.length === 0}
-        emptyLabel={td('noEntries')}
-      >
-        {activities.map((item) => (
-          <ActivityRow key={item.id} item={item} t={te} />
-        ))}
-      </ViewerSection>
-
-      {/* Reservations */}
-      <ViewerSection
-        title={td('reservations')}
-        empty={visibleReservations.length === 0}
-        emptyLabel={td('noReservations')}
-      >
-        {visibleReservations.map((item) => (
-          <ReservationRow key={item.id} item={item} />
-        ))}
-      </ViewerSection>
     </div>
   )
 }
@@ -170,40 +198,6 @@ export function ViewerDayDashboard({
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
-
-function StatBlock({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="bg-card rounded-lg border px-3 py-4 text-center">
-      <p className="text-4xl leading-none font-bold tabular-nums">{value}</p>
-      <p className="text-muted-foreground mt-2 text-xs leading-tight">{label}</p>
-    </div>
-  )
-}
-
-function ViewerSection({
-  title,
-  empty,
-  emptyLabel,
-  children,
-}: {
-  title: string
-  empty: boolean
-  emptyLabel: string
-  children?: React.ReactNode
-}) {
-  return (
-    <section className="space-y-3">
-      <h2 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
-        {title}
-      </h2>
-      {empty ? (
-        <p className="text-muted-foreground text-sm">{emptyLabel}</p>
-      ) : (
-        <div className="space-y-2">{children}</div>
-      )}
-    </section>
-  )
-}
 
 function BreakfastRow({
   item,
@@ -305,7 +299,7 @@ function formatTimeRange(
   if (start && end) {
     return t
       ? t('timeRange', { start: fmt(start), end: fmt(end) })
-      : `${fmt(start)} \u2013 ${fmt(end)}`
+      : `${fmt(start)} – ${fmt(end)}`
   }
   if (start) return t ? t('timeFrom', { time: fmt(start) }) : fmt(start)
   if (end) return t ? t('timeUntil', { time: fmt(end) }) : fmt(end)

--- a/components/viewer-day-dashboard.tsx
+++ b/components/viewer-day-dashboard.tsx
@@ -1,5 +1,5 @@
 'use client'
-
+// temp
 import { useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { useTranslations } from 'next-intl'
@@ -297,9 +297,7 @@ function formatTimeRange(
 ): string {
   const fmt = (s: string) => s.slice(0, 5)
   if (start && end) {
-    return t
-      ? t('timeRange', { start: fmt(start), end: fmt(end) })
-      : `${fmt(start)} – ${fmt(end)}`
+    return t ? t('timeRange', { start: fmt(start), end: fmt(end) }) : `${fmt(start)} – ${fmt(end)}`
   }
   if (start) return t ? t('timeFrom', { time: fmt(start) }) : fmt(start)
   if (end) return t ? t('timeUntil', { time: fmt(end) }) : fmt(end)


### PR DESCRIPTION
## Summary

- **DailyBriefCard**: adds optional `weather` prop; renders inline weather strip (emoji + temp + condition) at top of card when provided. Removes the covers grid (breakfast/activities/reservations counts) — those are now at page level.
- **ViewerDayDashboard**: removes standalone `WeatherCard` and shift `ViewerSection`. Passes `weather` to `DailyBriefCard`. Converts the 3 stat blocks to an accordion — clicking a block expands its item list inline beneath the grid; each block is independent.
- **DayInfoBanner**: removes the covers grid from both the streaming skeleton and the settled brief dialog.
- **DayViewClient (editor)**: removes `DaySummaryCard` and the separate breakfast/activities/reservations sections. Replaces them with the same expandable stat block pattern, showing `BreakfastCard` / `ActivityCard` / `ReservationCard` with full editor affordances when expanded. `StaffScheduleSection` is kept.

## Test plan

- [ ] Visit a day with activities + reservations + breakfasts as **viewer** — confirm: Daily Brief (with weather inline at top), then stat blocks; no standalone weather card, no shift section
- [ ] Click each stat block — confirm items expand beneath the grid independently; click again collapses
- [ ] Visit same day as **editor** — confirm same top structure (DayInfoBanner → expandable stat blocks); expand each block and verify edit/delete cards render; add buttons still work via the top add menu
- [ ] Toggle `weather_reporting` flag off — confirm weather disappears from inside the brief; no standalone card appears
- [ ] Toggle `daily_brief` flag off — confirm no brief card; stat blocks still render
- [ ] Toggle `staff_schedule` flag — confirm StaffScheduleSection still appears/disappears correctly in editor view

Closes #230

https://claude.ai/code/session_01KQpeCNBMo67bf7qYwZjaWw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQpeCNBMo67bf7qYwZjaWw)_