### PR TITLE
Move theme toggle and sign-out to profile Account section

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -5,8 +5,6 @@ import { getLocale, getMessages, getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { Toaster } from 'sonner'
 import { Logo } from '@/components/logo'
-import { UserMenu } from '@/components/user-menu'
-import { ThemeToggle } from '@/components/theme-toggle'
 import { SettingsDropdown } from '@/components/settings-dropdown'
 import { getUser } from '@/app/actions/auth'
 import { getTenantFromHeaders } from '@/lib/tenant'
@@ -125,8 +123,6 @@ export default async function TenantLayout({ children }: { children: React.React
                   <Logo logoUrl={row?.logo_url ?? null} tenantName={row?.name ?? null} />
                   <div className="flex items-center gap-1">
                     <OfflineStatusPill />
-                    {/* Theme toggle — visible to all signed-in users */}
-                    {user && <ThemeToggle />}
                     {/* AI quick-add — editors only */}
                     {editor && <GlobalQuickAdd />}
                     {/* Settings dropdown — editors only, desktop */}
@@ -180,11 +176,6 @@ export default async function TenantLayout({ children }: { children: React.React
                       </span>
                     )}
                     <NotificationBell initialCount={unreadCount} />
-                    {user && (
-                      <span className={editor ? undefined : 'hidden sm:inline-flex'}>
-                        <UserMenu user={user} signOutLabel={t('signOut')} />
-                      </span>
-                    )}
                   </div>
                 </header>
                 <main id="main-content" className="flex-1 pb-16 sm:pb-0">

--- a/app/[tenant]/profile/page.tsx
+++ b/app/[tenant]/profile/page.tsx
@@ -1,6 +1,9 @@
 import { getTranslations } from 'next-intl/server'
 import { requireTenantMember } from '@/lib/guards'
 import { getMemberProfile } from '@/app/actions/memberships'
+import { signOut } from '@/app/actions/auth'
+import { Button } from '@/components/ui/button'
+import { ThemeToggle } from '@/components/theme-toggle'
 import { ProfileForm } from './profile-form'
 
 export const dynamic = 'force-dynamic'
@@ -20,6 +23,21 @@ export default async function ProfilePage() {
         initialLastName={profile?.last_name ?? ''}
         initialJobTitle={profile?.job_title ?? ''}
       />
+
+      <div className="mt-10">
+        <h2 className="mb-4 text-lg font-semibold">{t('accountSection')}</h2>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">{t('theme')}</span>
+            <ThemeToggle />
+          </div>
+          <form action={signOut}>
+            <Button type="submit" variant="destructive" className="w-full" data-testid="sign-out">
+              {t('signOut')}
+            </Button>
+          </form>
+        </div>
+      </div>
     </div>
   )
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -624,7 +624,10 @@
       "jobTitlePlaceholder": "z.B. Chefkoch, Barkeeper, Manager",
       "save": "Speichern",
       "saving": "Speichern…",
-      "saved": "Profil aktualisiert."
+      "saved": "Profil aktualisiert.",
+      "accountSection": "Konto",
+      "theme": "Darstellung",
+      "signOut": "Abmelden"
     }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -832,7 +832,10 @@
       "jobTitlePlaceholder": "e.g. Head chef, Barman, Manager",
       "save": "Save",
       "saving": "Saving…",
-      "saved": "Profile updated."
+      "saved": "Profile updated.",
+      "accountSection": "Account",
+      "theme": "Theme",
+      "signOut": "Sign out"
     },
     "venueType": {
       "title": "Venue Types",

--- a/messages/es.json
+++ b/messages/es.json
@@ -624,7 +624,10 @@
       "jobTitlePlaceholder": "p.ej. Jefe de cocina, Camarero, Gerente",
       "save": "Guardar",
       "saving": "Guardando…",
-      "saved": "Perfil actualizado."
+      "saved": "Perfil actualizado.",
+      "accountSection": "Cuenta",
+      "theme": "Tema",
+      "signOut": "Cerrar sesión"
     }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -752,7 +752,10 @@
       "jobTitlePlaceholder": "ex. Chef de rang, Barman, Directeur",
       "save": "Enregistrer",
       "saving": "Enregistrement…",
-      "saved": "Profil mis à jour."
+      "saved": "Profil mis à jour.",
+      "accountSection": "Compte",
+      "theme": "Thème",
+      "signOut": "Se déconnecter"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Removes `ThemeToggle` and `UserMenu` (sign-out) from the tenant navbar (desktop)
- Adds an **Account** section at the bottom of the profile page with a theme toggle row and a destructive sign-out button
- Adds `Tenant.profile.accountSection`, `Tenant.profile.theme`, `Tenant.profile.signOut` keys to all four locales (en, fr, de, es)
- Mobile nav had no theme/sign-out entries — no changes needed there

Closes #233

## Test plan

- [ ] Sign in, confirm theme toggle and sign-out icon are gone from desktop navbar
- [ ] Visit `/[tenant]/profile` — Account section visible with working theme toggle and sign-out button
- [ ] Sign out via profile page redirects to sign-in (existing behavior)
- [ ] Test at mobile width — mobile nav unaffected

https://claude.ai/code/session_01LauNkGfu1pk7kCsqpoCzF6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LauNkGfu1pk7kCsqpoCzF6)_