### PR TITLE
Mobile: add top-bar settings entry for staff (theme, profile, sign out)

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -26,6 +26,7 @@ import { getSuperadminImpersonationRole } from '@/lib/superadmin'
 import { getTenantPalette, getTenantThemeCssVariables } from '@/lib/theme/palettes'
 import { TenantKeyboardShell } from '@/components/tenant-keyboard-shell'
 import { GlobalQuickAdd } from '@/components/global-quick-add'
+import { StaffMobileSettings } from '@/components/staff-mobile-settings'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { CalendarDays, User } from 'lucide-react'
@@ -175,6 +176,8 @@ export default async function TenantLayout({ children }: { children: React.React
                         </TooltipProvider>
                       </span>
                     )}
+                    {/* Staff settings — mobile only, non-editors */}
+                    {!editor && user && <StaffMobileSettings />}
                     <NotificationBell initialCount={unreadCount} />
                   </div>
                 </header>

--- a/components/staff-mobile-settings.tsx
+++ b/components/staff-mobile-settings.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { LogOut, Monitor, Moon, Settings, Sun, User } from 'lucide-react'
+import Link from 'next/link'
+import { useTheme } from 'next-themes'
+import { useTranslations } from 'next-intl'
+import { signOut } from '@/app/actions/auth'
+import { Button } from '@/components/ui/button'
+import { MenuItem } from '@/components/ui/menu-item'
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer'
+
+const THEMES = ['system', 'light', 'dark'] as const
+type ThemeValue = (typeof THEMES)[number]
+
+const THEME_ICON: Record<ThemeValue, React.ReactNode> = {
+  system: <Monitor className="h-4 w-4" />,
+  light: <Sun className="h-4 w-4" />,
+  dark: <Moon className="h-4 w-4" />,
+}
+
+export function StaffMobileSettings() {
+  const { theme, setTheme } = useTheme()
+  const t = useTranslations('Tenant.nav')
+
+  const themeLabel: Record<ThemeValue, string> = {
+    system: t('themeSystem'),
+    light: t('themeLight'),
+    dark: t('themeDark'),
+  }
+
+  return (
+    <span className="sm:hidden">
+      <Drawer>
+        <DrawerTrigger asChild>
+          <Button variant="ghost" size="iconSm" aria-label={t('settings')}>
+            <Settings />
+          </Button>
+        </DrawerTrigger>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>{t('settings')}</DrawerTitle>
+          </DrawerHeader>
+          <div className="flex flex-col gap-1 px-4 pb-8">
+            {THEMES.map((value) => (
+              <MenuItem
+                key={value}
+                onClick={() => setTheme(value)}
+                className={theme === value ? 'font-medium' : undefined}
+              >
+                {THEME_ICON[value]}
+                {themeLabel[value]}
+              </MenuItem>
+            ))}
+            <div className="my-1 border-t" />
+            <DrawerClose asChild>
+              <MenuItem asChild>
+                <Link href="/profile">
+                  <User />
+                  {t('profile')}
+                </Link>
+              </MenuItem>
+            </DrawerClose>
+            <form action={signOut}>
+              <MenuItem type="submit" variant="destructive" className="w-full">
+                <LogOut />
+                {t('signOut')}
+              </MenuItem>
+            </form>
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `StaffMobileSettings` component — a bottom-sheet drawer triggered by a Settings icon in the top navbar
- Icon is mobile-only (`sm:hidden`) and renders only for non-editor signed-in users
- Drawer contains: 3 theme options (system/light/dark) as `MenuItem` rows, an Edit Profile link, and a Sign-out action
- Reuses `useTheme` + existing `Tenant.nav.themeSystem/Light/Dark` translation keys — no new i18n keys required
- Desktop layout and editor experience are unchanged

## Test plan

- [ ] Sign in as staff on mobile → Settings icon visible top-right in navbar
- [ ] Sign in as editor on mobile → no new icon (editor keeps bottom-nav drawer)
- [ ] Tapping icon opens bottom-sheet drawer with theme rows, profile link, sign-out
- [ ] Selecting a theme persists across reload
- [ ] Tapping Edit Profile navigates to `/[tenant]/profile`
- [ ] Tapping Sign out redirects to `/[tenant]/auth/sign-in`

Closes #248

https://claude.ai/code/session_01Pi2xw1rQhfSB2Zdsukpc4E

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pi2xw1rQhfSB2Zdsukpc4E)_