### PR TITLE
Move notification bell to mobile bottom nav + add notifications page

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -11,7 +11,7 @@ import { getTenantFromHeaders } from '@/lib/tenant'
 import { TenantProvider } from '@/lib/tenant-context'
 import { AuthProvider } from '@/lib/AuthProvider'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { isEditor } from '@/lib/membership'
+import { getUserRole } from '@/lib/membership'
 import { PwaRegister } from '@/components/pwa-register'
 import { PwaInstallPrompt } from '@/components/pwa-install-prompt'
 import { FeatureFlagProvider } from '@/lib/feature-flags-context'
@@ -91,12 +91,14 @@ export default async function TenantLayout({ children }: { children: React.React
   const palette = getTenantPalette(row?.theme_palette ?? null, row?.accent_color ?? null)
   const accentStyle = getTenantThemeCssVariables(palette) as React.CSSProperties
 
-  const [editor, superadminImpersonationRole, t, unreadCount] = await Promise.all([
-    isEditor(tenant.id),
+  const [role, superadminImpersonationRole, t, unreadCount] = await Promise.all([
+    getUserRole(tenant.id),
     user ? getSuperadminImpersonationRole(tenant.id, user.id) : Promise.resolve(null),
     getTranslations('Tenant.nav'),
     getUnreadCount(),
   ])
+  const editor = role === 'editor'
+  const isMember = role !== null
 
   // RTL locales — extend when adding Arabic, Hebrew, etc.
   const RTL_LOCALES = new Set<string>([])
@@ -175,14 +177,21 @@ export default async function TenantLayout({ children }: { children: React.React
                         </TooltipProvider>
                       </span>
                     )}
-                    <NotificationBell initialCount={unreadCount} />
+                    <span className="hidden sm:inline-flex">
+                      <NotificationBell initialCount={unreadCount} />
+                    </span>
                   </div>
                 </header>
                 <main id="main-content" className="flex-1 pb-16 sm:pb-0">
                   {children}
                 </main>
               </div>
-              <MobileNav today={today} isEditor={editor} />
+              <MobileNav
+                today={today}
+                isEditor={editor}
+                isMember={isMember}
+                initialUnreadCount={unreadCount}
+              />
               {superadminImpersonationRole && (
                 <SuperadminReturnPopup role={superadminImpersonationRole} />
               )}

--- a/app/[tenant]/notifications/notifications-client.tsx
+++ b/app/[tenant]/notifications/notifications-client.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/ui/button'
+import {
+  getNotificationsPage,
+  markNotificationRead,
+  markAllRead,
+} from '@/app/actions/notifications'
+import type { Notification } from '@/app/actions/notifications'
+import { cn } from '@/lib/utils'
+
+export const PAGE_SIZE = 30
+
+interface NotificationsClientProps {
+  initialNotifications: Notification[]
+  initialHasMore: boolean
+}
+
+export function NotificationsClient({
+  initialNotifications,
+  initialHasMore,
+}: NotificationsClientProps) {
+  const t = useTranslations('Tenant.notifications')
+  const [notifications, setNotifications] = useState<Notification[]>(initialNotifications)
+  const [hasMore, setHasMore] = useState(initialHasMore)
+  const [isLoadingMore, startLoadMoreTransition] = useTransition()
+  const [isMarkingAll, startMarkAllTransition] = useTransition()
+
+  const hasUnread = notifications.some((n) => !n.read)
+
+  function handleClickNotification(notification: Notification) {
+    if (!notification.read) {
+      markNotificationRead(notification.id)
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === notification.id ? { ...n, read: true } : n))
+      )
+    }
+  }
+
+  function handleMarkAllRead() {
+    startMarkAllTransition(async () => {
+      await markAllRead()
+      setNotifications((prev) => prev.map((n) => ({ ...n, read: true })))
+    })
+  }
+
+  function handleLoadMore() {
+    startLoadMoreTransition(async () => {
+      const result = await getNotificationsPage(notifications.length, PAGE_SIZE)
+      if (result.success) {
+        setNotifications((prev) => [...prev, ...result.data.notifications])
+        setHasMore(result.data.hasMore)
+      }
+    })
+  }
+
+  if (notifications.length === 0) {
+    return <p className="text-muted-foreground py-12 text-center text-sm">{t('empty')}</p>
+  }
+
+  return (
+    <div>
+      {hasUnread && (
+        <div className="mb-3 flex justify-end">
+          <Button
+            variant="link"
+            size="sm"
+            disabled={isMarkingAll}
+            onClick={handleMarkAllRead}
+            data-testid="notifications-mark-all-read"
+          >
+            {t('markAllRead')}
+          </Button>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-md border">
+        {notifications.map((n) => {
+          const rowClass = cn(
+            'border-b px-4 py-3 transition-colors last:border-0',
+            n.read ? 'bg-background' : 'bg-primary/5'
+          )
+          const rowContent = (
+            <div className="flex items-start gap-2">
+              {!n.read && <span className="bg-primary mt-1.5 h-2 w-2 shrink-0 rounded-full" />}
+              <div className={cn('flex-1', n.read && 'pl-4')}>
+                <p className="text-sm leading-snug font-medium">{n.title}</p>
+                {n.body && <p className="text-muted-foreground mt-0.5 text-xs">{n.body}</p>}
+                <p className="text-muted-foreground mt-1 text-[10px]">
+                  {new Date(n.created_at).toLocaleString()}
+                </p>
+              </div>
+            </div>
+          )
+
+          if (n.link) {
+            return (
+              <Link
+                key={n.id}
+                href={n.link}
+                className={cn(rowClass, 'hover:bg-accent block cursor-pointer')}
+                onClick={() => handleClickNotification(n)}
+              >
+                {rowContent}
+              </Link>
+            )
+          }
+          if (!n.read) {
+            return (
+              // Bespoke notification row — full-bleed block layout doesn't fit Button primitive.
+              // eslint-disable-next-line no-restricted-syntax
+              <button
+                key={n.id}
+                type="button"
+                className={cn(rowClass, 'hover:bg-accent w-full cursor-pointer text-left')}
+                onClick={() => handleClickNotification(n)}
+              >
+                {rowContent}
+              </button>
+            )
+          }
+          return (
+            <div key={n.id} className={rowClass}>
+              {rowContent}
+            </div>
+          )
+        })}
+      </div>
+
+      {hasMore && (
+        <div className="mt-4 flex justify-center">
+          <Button
+            variant="outline"
+            disabled={isLoadingMore}
+            onClick={handleLoadMore}
+            data-testid="notifications-load-more"
+          >
+            {isLoadingMore ? t('loading') : t('loadMore')}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/[tenant]/notifications/page.tsx
+++ b/app/[tenant]/notifications/page.tsx
@@ -1,0 +1,24 @@
+import { getTranslations } from 'next-intl/server'
+import { requireTenantMember } from '@/lib/guards'
+import { getNotificationsPage } from '@/app/actions/notifications'
+import { NotificationsClient, PAGE_SIZE } from './notifications-client'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export default async function NotificationsPage() {
+  await requireTenantMember()
+  const t = await getTranslations('Tenant.notifications')
+  const result = await getNotificationsPage(0, PAGE_SIZE)
+  const initial = result.success ? result.data : { notifications: [], hasMore: false }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-6">
+      <h1 className="mb-6 text-xl font-bold">{t('title')}</h1>
+      <NotificationsClient
+        initialNotifications={initial.notifications}
+        initialHasMore={initial.hasMore}
+      />
+    </div>
+  )
+}

--- a/app/actions/notifications.ts
+++ b/app/actions/notifications.ts
@@ -38,6 +38,40 @@ export async function getNotifications(): Promise<ActionResponse<Notification[]>
   return { success: true, data: (data ?? []) as Notification[] }
 }
 
+export interface NotificationsPage {
+  notifications: Notification[]
+  hasMore: boolean
+}
+
+export async function getNotificationsPage(
+  offset: number,
+  limit: number
+): Promise<ActionResponse<NotificationsPage>> {
+  const tenantId = await getTenantId()
+  const role = await getUserRole(tenantId)
+  if (!role) return { success: false, error: 'Not a member.' }
+
+  const user = await getUser()
+  if (!user) return { success: false, error: 'Not authenticated.' }
+
+  const { supabase } = await createTenantClient()
+  const { data, error } = await supabase
+    .from('notifications')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit)
+
+  if (error) return { success: false, error: error.message }
+  const rows = (data ?? []) as Notification[]
+  const hasMore = rows.length > limit
+  return {
+    success: true,
+    data: { notifications: hasMore ? rows.slice(0, limit) : rows, hasMore },
+  }
+}
+
 export async function markNotificationRead(id: string): Promise<ActionResponse> {
   const user = await getUser()
   if (!user) return { success: false, error: 'Not authenticated.' }

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Home, CalendarDays, Settings, Sparkles, CalendarCheck } from 'lucide-react'
+import { Home, CalendarDays, Settings, Sparkles, CalendarCheck, Bell } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import {
@@ -16,13 +17,18 @@ import {
 import { getVisibleSettingsRoutes } from '@/components/settings-dropdown'
 import { useFeatureFlag } from '@/lib/feature-flags-context'
 import { useKeyboardShortcuts } from '@/lib/keyboard-shortcuts'
+import { getUnreadCount } from '@/app/actions/notifications'
 
 interface MobileNavProps {
   today: string
   isEditor: boolean
+  isMember: boolean
+  initialUnreadCount: number
 }
 
-export function MobileNav({ today, isEditor }: MobileNavProps) {
+const POLL_INTERVAL_MS = 30_000
+
+export function MobileNav({ today, isEditor, isMember, initialUnreadCount }: MobileNavProps) {
   const pathname = usePathname()
   const navT = useTranslations('Tenant.nav')
   const settingsT = useTranslations('Tenant.settings')
@@ -34,6 +40,24 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
     checklists: showChecklists,
     staffSchedule: showStaffSchedule,
   })
+
+  const [unreadCount, setUnreadCount] = useState(initialUnreadCount)
+
+  useEffect(() => {
+    if (!isMember) return
+    let cancelled = false
+    async function refresh() {
+      const count = await getUnreadCount()
+      if (!cancelled) setUnreadCount(count)
+    }
+    const id = setInterval(refresh, POLL_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [isMember, pathname])
+
+  const notificationsActive = pathname.startsWith('/notifications')
 
   const navItems = [
     { href: '/', label: navT('home'), icon: Home, active: pathname === '/' },
@@ -77,6 +101,35 @@ export function MobileNav({ today, isEditor }: MobileNavProps) {
             {label}
           </Link>
         ))}
+
+        {isMember && (
+          <Link
+            href="/notifications"
+            aria-current={notificationsActive ? 'page' : undefined}
+            aria-label={
+              unreadCount > 0
+                ? `${navT('notifications')} (${unreadCount} ${navT('unread')})`
+                : navT('notifications')
+            }
+            className={cn(
+              'relative flex flex-1 flex-col items-center justify-center gap-1 text-xs font-medium transition-colors',
+              notificationsActive ? 'text-foreground' : 'text-muted-foreground'
+            )}
+          >
+            <span className="relative">
+              <Bell
+                className={cn('h-5 w-5', notificationsActive && 'stroke-[2.5]')}
+                aria-hidden="true"
+              />
+              {unreadCount > 0 && (
+                <span className="bg-primary text-primary-foreground absolute -top-1 -right-2 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold">
+                  {unreadCount > 9 ? '9+' : unreadCount}
+                </span>
+              )}
+            </span>
+            {navT('notifications')}
+          </Link>
+        )}
 
         {isEditor && (
           /* Quick-add center slot — tab nav trigger, bespoke surface. */

--- a/messages/de.json
+++ b/messages/de.json
@@ -79,7 +79,16 @@
       "skipToContent": "Zum Hauptinhalt springen",
       "today": "Heute",
       "mySchedule": "Mein Dienstplan",
-      "profile": "Mein Profil"
+      "profile": "Mein Profil",
+      "notifications": "Benachrichtigungen",
+      "unread": "ungelesen"
+    },
+    "notifications": {
+      "title": "Benachrichtigungen",
+      "empty": "Noch keine Benachrichtigungen.",
+      "markAllRead": "Alle als gelesen markieren",
+      "loadMore": "Mehr laden",
+      "loading": "Wird geladen…"
     },
     "join": {
       "homeAria": "Startseite",

--- a/messages/en.json
+++ b/messages/en.json
@@ -183,7 +183,16 @@
       "themeLight": "Light",
       "themeDark": "Dark",
       "mySchedule": "My schedule",
-      "profile": "My Profile"
+      "profile": "My Profile",
+      "notifications": "Notifications",
+      "unread": "unread"
+    },
+    "notifications": {
+      "title": "Notifications",
+      "empty": "No notifications yet.",
+      "markAllRead": "Mark all read",
+      "loadMore": "Load more",
+      "loading": "Loading…"
     },
     "join": {
       "homeAria": "Home",

--- a/messages/es.json
+++ b/messages/es.json
@@ -79,7 +79,16 @@
       "skipToContent": "Saltar al contenido principal",
       "today": "Hoy",
       "mySchedule": "Mi horario",
-      "profile": "Mi perfil"
+      "profile": "Mi perfil",
+      "notifications": "Notificaciones",
+      "unread": "sin leer"
+    },
+    "notifications": {
+      "title": "Notificaciones",
+      "empty": "Aún no hay notificaciones.",
+      "markAllRead": "Marcar todo como leído",
+      "loadMore": "Cargar más",
+      "loading": "Cargando…"
     },
     "join": {
       "homeAria": "Inicio",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -183,7 +183,16 @@
       "themeLight": "Clair",
       "themeDark": "Sombre",
       "mySchedule": "Mon planning",
-      "profile": "Mon profil"
+      "profile": "Mon profil",
+      "notifications": "Notifications",
+      "unread": "non lus"
+    },
+    "notifications": {
+      "title": "Notifications",
+      "empty": "Aucune notification pour l'instant.",
+      "markAllRead": "Tout marquer comme lu",
+      "loadMore": "Charger plus",
+      "loading": "Chargement…"
     },
     "join": {
       "homeAria": "Accueil",


### PR DESCRIPTION
## Summary
- On mobile (`< sm`), the top-navbar bell is now hidden; bottom nav gains a bell tab for every signed-in member with a polled unread badge (9+ capped). Desktop bell + popover are unchanged.
- Tapping the bell on mobile routes to a new `/[tenant]/notifications` page that lists all notifications paginated 30 at a time, with "Load more" and "Mark all read" reusing the existing actions.
- Added a paginated server action `getNotificationsPage(offset, limit)` (RLS-scoped, member-only). Notification rows reuse the unread blue dot + bg highlight from the popover.

## Test plan
- [ ] On a mobile viewport, top navbar no longer shows the bell; bottom nav shows the bell tab with badge.
- [ ] Tapping the bell tab navigates to `/notifications` and lists notifications, newest first.
- [ ] "Load more" appends the next page; disabled once exhausted.
- [ ] "Mark all read" clears the badge and unread highlights.
- [ ] Clicking a notification with a link marks it read and navigates.
- [ ] Desktop bell + popover behave as before.
- [ ] Non-members do not see the bell tab.

Closes #249

https://claude.ai/code/session_017evXf8eBfbVL8JA4AYRefy

---
_Generated by [Claude Code](https://claude.ai/code/session_017evXf8eBfbVL8JA4AYRefy)_