### PR TITLE
feat(quick-add): blank + auto-focus date when LLM cannot infer a date

### DIFF
--- a/components/quick-add-review.tsx
+++ b/components/quick-add-review.tsx
@@ -96,7 +96,7 @@ function initialState(data: QuickAddParseData): State {
       notes: data.defaults.notes,
       allergens: data.allergens,
       tableBreakdown: [],
-      date: data.contextDate,
+      date: data.resolvedDate,
     }
   }
   if (data.kind === 'reservation') {
@@ -109,7 +109,7 @@ function initialState(data: QuickAddParseData): State {
       notes: data.defaults.notes,
       allergens: data.allergens,
       tableBreakdown: data.tableBreakdown,
-      date: data.contextDate,
+      date: data.resolvedDate,
     }
   }
   return {
@@ -121,7 +121,7 @@ function initialState(data: QuickAddParseData): State {
     notes: data.defaults.notes,
     allergens: data.allergens,
     tableBreakdown: data.tableBreakdown,
-    date: data.contextDate,
+    date: data.resolvedDate,
   }
 }
 
@@ -144,6 +144,8 @@ export function QuickAddReview({
   // original parse's gap-field highlights.
   const [userChangedKind, setUserChangedKind] = useState(false)
 
+  const dateInputRef = useRef<HTMLInputElement>(null)
+
   const errId = useId()
   const dateId = useId()
   const primaryId = useId()
@@ -159,12 +161,19 @@ export function QuickAddReview({
   useEffect(() => {
     if (lastDataKey.current !== dataKey) {
       lastDataKey.current = dataKey
-
       setUserChangedKind(false)
-
       setState(initialState(data))
     }
   }, [dataKey, data])
+
+  // Auto-focus the date input when the resolved date is blank.
+  useEffect(() => {
+    if (state.date === '') {
+      dateInputRef.current?.focus()
+    }
+    // Only run on mount / when data changes (dataKey), not on every date keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataKey])
 
   const gapSet = useMemo<ReadonlySet<QuickAddGapId>>(() => {
     if (userChangedKind) return new Set()
@@ -277,7 +286,11 @@ export function QuickAddReview({
 
   const showEndTime = state.kind !== 'breakfast'
 
-  const canSave = !isPending && state.primary.trim().length > 0 && allowedKinds.includes(state.kind)
+  const canSave =
+    !isPending &&
+    state.primary.trim().length > 0 &&
+    state.date !== '' &&
+    allowedKinds.includes(state.kind)
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3" aria-label={t('reviewTitle')}>
@@ -303,15 +316,17 @@ export function QuickAddReview({
         </Select>
       </div>
 
-      {data.dateAmbiguous && (
+      {(data.dateAmbiguous || state.date === '') && (
         <div className="space-y-1.5">
           <Label htmlFor={dateId}>{t('dateLabel')}</Label>
           <Input
+            ref={dateInputRef}
             id={dateId}
             type="date"
             value={state.date}
             onChange={(e) => setState((s) => ({ ...s, date: e.target.value }))}
             disabled={isPending ?? false}
+            required
           />
         </div>
       )}

--- a/lib/quick-add-build.ts
+++ b/lib/quick-add-build.ts
@@ -15,6 +15,7 @@ const intNull = z.coerce.number().int().nullable()
 // OpenAI strict structured output requires root `type: object` AND every key
 // in `required`. To express "absent", use nullable fields instead of optional.
 const allFields = z.object({
+  date: z.string().date().nullable(),
   title: strNull,
   description: strNull,
   guestName: strNull,
@@ -410,6 +411,7 @@ export function buildDataFromLlm(
       kind: 'activity',
       dayId,
       contextDate,
+      resolvedDate: out.fields.date ?? '',
       dateAmbiguous: out.dateAmbiguous,
       defaults: defaultsRaw,
       allergens: filterAllergenCodes(a.codes) as AllergenCode[],
@@ -454,6 +456,7 @@ export function buildDataFromLlm(
       kind: 'reservation',
       dayId,
       contextDate,
+      resolvedDate: out.fields.date ?? '',
       dateAmbiguous: out.dateAmbiguous,
       defaults: {
         guestName: d.guestName,
@@ -496,6 +499,7 @@ export function buildDataFromLlm(
       kind: 'breakfast',
       dayId,
       contextDate,
+      resolvedDate: f.date ?? '',
       dateAmbiguous: out.dateAmbiguous,
       defaults: {
         groupName: d.groupName,

--- a/lib/quick-add-prompt.ts
+++ b/lib/quick-add-prompt.ts
@@ -9,8 +9,9 @@ Return JSON matching the required schema. The schema wraps an "items" array — 
 Rules:
 - kind: "activity" = programme item / event / class / tee time block; "reservation" = restaurant or table booking; "breakfast" = hotel breakfast service group.
 - Each item is classified independently — a single paste can mix kinds (e.g. a tee time, a dinner reservation, and a breakfast block).
+- date: return a YYYY-MM-DD string ONLY when the user's text explicitly mentions a date (absolute like "26 June" or relative like "next Monday", "tonight", "today"). Otherwise return null. Do NOT default to the context day — null means the user did not specify a date and the form will ask them to fill it in.
 - dateAmbiguous: set true (per item) if the user refers to a date or weekday in a way that is ambiguous (e.g. "Saturday" could mean the upcoming Saturday in a different week, or a Saturday not matching the given context day) OR you cannot place times/dates for this item relative to the context. When true, OMIT startTime, endTime (or startTime for breakfast) or leave time fields out — the staff will set them on the page for the day they are viewing.
-- The scheduled calendar day the user is viewing (context) is the anchor for "today", "this evening", etc. Use it to resolve "Saturday 8pm" to that Saturday if that Saturday IS the context day; if it clearly refers to a different day you cannot place on the context row, set dateAmbiguous: true and omit time fields.
+- The scheduled calendar day the user is viewing (context) is the anchor for resolving relative phrases: "today" and "tonight" → context day, "next Monday" → next Monday from context. Use context to resolve the final YYYY-MM-DD for date. If no date phrase is present, return date: null.
 - Times: 24h strings as HH:MM (e.g. 20:00) as used in HTML time inputs, no seconds unless the schema accepts them; prefer HH:MM.
 - Allergen hints: in allergenHints, list short tokens from the user text. Use EU-14 codes from this list when possible: ${CODES}. Also include natural phrases (e.g. "no nuts", "dairy free") for post-processing. Our system maps synonyms.
 - For reservations: guestName is the party or contact name. guestCount = party size.
@@ -19,22 +20,16 @@ Rules:
 - notes: any other free text not already captured for that item. Do not invent PII.
 
 Examples (illustrative; adapt to actual user text):
-1) Single item, "Member golf 8am, 24 players" → items: [{ kind:"activity", fields:{ title:"Member golf", startTime:"08:00", expectedCovers:24 } }]
-2) Multi-reservation list:
+1) No date phrase, "tee time 9am" with context 2026-05-11 → items: [{ kind:"activity", dateAmbiguous:false, fields:{ date:null, title:"Tee time", startTime:"09:00", expectedCovers:null } }]
+2) Relative date phrase, "tee time 9am next Monday" with context 2026-05-12 (Tuesday) → items: [{ kind:"activity", dateAmbiguous:false, fields:{ date:"2026-05-18", title:"Tee time", startTime:"09:00", expectedCovers:null } }]
+3) "today"/"tonight" anchor, "tee time tonight 9pm" with context 2026-05-11 → items: [{ kind:"activity", dateAmbiguous:false, fields:{ date:"2026-05-11", title:"Tee time", startTime:"21:00", expectedCovers:null } }]
+4) Absolute date, "tee time on 26 June" with context 2026-05-11 → items: [{ kind:"activity", dateAmbiguous:false, fields:{ date:"2026-06-26", title:"Tee time", startTime:null, expectedCovers:null } }]
+5) Multi-reservation list with no date phrases:
    "- Smith party of 6 at 7:30pm
-    - Lee, 2 guests, 8pm, no nuts
-    - Patel 4 at 8:15pm"
+    - Lee, 2 guests, 8pm, no nuts"
    → items: [
-       { kind:"reservation", fields:{ guestName:"Smith", guestCount:6, startTime:"19:30" } },
-       { kind:"reservation", fields:{ guestName:"Lee", guestCount:2, startTime:"20:00", allergenHints:["no nuts"] } },
-       { kind:"reservation", fields:{ guestName:"Patel", guestCount:4, startTime:"20:15" } }
-     ]
-3) Mixed kinds in one paste:
-   "Tee time 9am, 16 players. Breakfast for room block A, 30 guests at 7am. Reservation: Garcia, 4, 8pm."
-   → items: [
-       { kind:"activity", fields:{ title:"Tee time", startTime:"09:00", expectedCovers:16 } },
-       { kind:"breakfast", fields:{ groupName:"Room block A", guestCount:30, startTime:"07:00" } },
-       { kind:"reservation", fields:{ guestName:"Garcia", guestCount:4, startTime:"20:00" } }
+       { kind:"reservation", dateAmbiguous:false, fields:{ date:null, guestName:"Smith", guestCount:6, startTime:"19:30" } },
+       { kind:"reservation", dateAmbiguous:false, fields:{ date:null, guestName:"Lee", guestCount:2, startTime:"20:00", allergenHints:["no nuts"] } }
      ]`
 
 export function buildUserPrompt(userText: string, _dayId: string, contextDateYmd: string): string {

--- a/lib/quick-add-types.ts
+++ b/lib/quick-add-types.ts
@@ -38,6 +38,7 @@ export type QuickAddParseData =
       kind: 'activity'
       dayId: string
       contextDate: string
+      resolvedDate: string
       dateAmbiguous: boolean
       defaults: QuickAddActivityFormDefaults
       allergens: AllergenCode[]
@@ -48,6 +49,7 @@ export type QuickAddParseData =
       kind: 'reservation'
       dayId: string
       contextDate: string
+      resolvedDate: string
       dateAmbiguous: boolean
       defaults: QuickAddReservationFormDefaults
       tableBreakdown: number[]
@@ -59,6 +61,7 @@ export type QuickAddParseData =
       kind: 'breakfast'
       dayId: string
       contextDate: string
+      resolvedDate: string
       dateAmbiguous: boolean
       defaults: QuickAddBreakfastFormDefaults
       tableBreakdown: number[]

--- a/tests/components/quick-add-multi-review.test.tsx
+++ b/tests/components/quick-add-multi-review.test.tsx
@@ -79,6 +79,7 @@ function activity(title: string, startTime: string, covers: string): QuickAddPar
     kind: 'activity',
     dayId: DAY,
     contextDate: CTX,
+    resolvedDate: CTX,
     dateAmbiguous: false,
     defaults: {
       title,
@@ -99,6 +100,7 @@ function reservation(name: string, count: string, startTime: string): QuickAddPa
     kind: 'reservation',
     dayId: DAY,
     contextDate: CTX,
+    resolvedDate: CTX,
     dateAmbiguous: false,
     defaults: { guestName: name, guestCount: count, startTime, endTime: '', notes: '' },
     tableBreakdown: [],
@@ -113,6 +115,7 @@ function breakfast(group: string, count: string, startTime: string): QuickAddPar
     kind: 'breakfast',
     dayId: DAY,
     contextDate: CTX,
+    resolvedDate: CTX,
     dateAmbiguous: false,
     defaults: { groupName: group, guestCount: count, startTime, notes: '' },
     tableBreakdown: [],

--- a/tests/components/quick-add-review.test.tsx
+++ b/tests/components/quick-add-review.test.tsx
@@ -92,6 +92,7 @@ const baseActivity: QuickAddParseData = {
   kind: 'activity',
   dayId: '00000000-0000-0000-0000-000000000001',
   contextDate: '2026-05-10',
+  resolvedDate: '2026-05-10',
   dateAmbiguous: false,
   defaults: {
     title: 'Member golf',
@@ -110,6 +111,7 @@ const baseReservation: QuickAddParseData = {
   kind: 'reservation',
   dayId: '00000000-0000-0000-0000-000000000001',
   contextDate: '2026-05-10',
+  resolvedDate: '2026-05-10',
   dateAmbiguous: false,
   defaults: {
     guestName: 'Smith',

--- a/tests/lib/quick-add-build.test.ts
+++ b/tests/lib/quick-add-build.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { buildDataFromLlm } from '@/lib/quick-add-build'
+import type { QuickAddLlmItem } from '@/lib/quick-add-build'
+
+const DAY_ID = '00000000-0000-0000-0000-000000000001'
+const CTX = '2026-05-11'
+
+function llmActivity(
+  over: Partial<QuickAddLlmItem['fields']> & { dateAmbiguous?: boolean } = {}
+): QuickAddLlmItem {
+  const { dateAmbiguous = false, ...fieldOverrides } = over
+  return {
+    kind: 'activity',
+    dateAmbiguous,
+    fields: {
+      date: null,
+      title: 'Tee time',
+      description: null,
+      guestName: null,
+      groupName: null,
+      startTime: '09:00',
+      endTime: null,
+      expectedCovers: null,
+      guestCount: null,
+      notes: null,
+      tableBreakdown: null,
+      allergenHints: null,
+      ...fieldOverrides,
+    },
+  }
+}
+
+describe('buildDataFromLlm — resolvedDate', () => {
+  it('leaves resolvedDate empty when LLM returns date: null (no date phrase)', () => {
+    // "tee time 9am" — LLM cannot infer a date, returns date: null
+    const item = llmActivity({ date: null, startTime: '09:00' })
+    const result = buildDataFromLlm(item, DAY_ID, CTX)
+    expect(result.resolvedDate).toBe('')
+  })
+
+  it('uses explicit future date when LLM returns date (relative: next Monday)', () => {
+    // "tee time 9am next Monday" with context 2026-05-12 (Tue) → LLM resolves to 2026-05-18
+    const item = llmActivity({ date: '2026-05-18', startTime: '09:00' })
+    const result = buildDataFromLlm(item, DAY_ID, '2026-05-12')
+    expect(result.resolvedDate).toBe('2026-05-18')
+  })
+
+  it('uses context day when LLM resolves "tonight" to context date', () => {
+    // "tee time tonight 9pm" — LLM anchors to context day
+    const item = llmActivity({ date: CTX, startTime: '21:00' })
+    const result = buildDataFromLlm(item, DAY_ID, CTX)
+    expect(result.resolvedDate).toBe(CTX)
+  })
+
+  it('uses absolute date when LLM resolves "26 June"', () => {
+    // "tee time on 26 June" — LLM resolves to next 26 June
+    const item = llmActivity({ date: '2026-06-26', startTime: null })
+    const result = buildDataFromLlm(item, DAY_ID, CTX)
+    expect(result.resolvedDate).toBe('2026-06-26')
+  })
+})
+
+describe('buildDataFromLlm — resolvedDate for reservation and breakfast', () => {
+  it('reservation: empty resolvedDate when date is null', () => {
+    const item: QuickAddLlmItem = {
+      kind: 'reservation',
+      dateAmbiguous: false,
+      fields: {
+        date: null,
+        title: null,
+        description: null,
+        guestName: 'Smith',
+        groupName: null,
+        startTime: '19:30',
+        endTime: null,
+        expectedCovers: null,
+        guestCount: 6,
+        notes: null,
+        tableBreakdown: null,
+        allergenHints: null,
+      },
+    }
+    const result = buildDataFromLlm(item, DAY_ID, CTX)
+    expect(result.resolvedDate).toBe('')
+  })
+
+  it('breakfast: non-empty resolvedDate when date is provided', () => {
+    const item: QuickAddLlmItem = {
+      kind: 'breakfast',
+      dateAmbiguous: false,
+      fields: {
+        date: '2026-06-01',
+        title: null,
+        description: null,
+        guestName: null,
+        groupName: 'Room A',
+        startTime: '07:00',
+        endTime: null,
+        expectedCovers: null,
+        guestCount: 20,
+        notes: null,
+        tableBreakdown: null,
+        allergenHints: null,
+      },
+    }
+    const result = buildDataFromLlm(item, DAY_ID, CTX)
+    expect(result.resolvedDate).toBe('2026-06-01')
+  })
+})


### PR DESCRIPTION
Closes #253

## Summary

- **LLM schema** (`lib/quick-add-build.ts`): added `date: z.string().date().nullable()` to `allFields` — the model now returns an explicit `YYYY-MM-DD` or `null` per item.
- **System prompt** (`lib/quick-add-prompt.ts`): updated instructions to only return a date when the prompt explicitly mentions one (absolute or relative), with examples covering all four acceptance-criteria cases.
- **`buildDataFromLlm`**: maps `fields.date ?? ''` → new `resolvedDate: string` field on `QuickAddParseData` (empty string when LLM returned null). `contextDate` is preserved as the relative-date anchor passed to the LLM.
- **Review form** (`components/quick-add-review.tsx`): initialises date state from `resolvedDate` instead of `contextDate`; shows the date input when `state.date === ''` or `dateAmbiguous`; auto-focuses the input on mount when blank; blocks the Save button while date is empty.
- **Tests** (`tests/lib/quick-add-build.test.ts`): covers all four acceptance-criteria prompt cases for activity, plus reservation and breakfast variants.

## Test plan

- [ ] `pnpm test:run` — unit tests pass (quick-add-build suite)
- [ ] "tee time 9am" → form opens with date field empty and focused, Save blocked
- [ ] "tee time 9am next Monday" (context Tue 2026-05-12) → form opens with date = 2026-05-18
- [ ] "tee time tonight 9pm" → form opens with date = context day
- [ ] "tee time on 26 June" → form opens with date = 2026-06-26
- [ ] Typing a date into the blank field unblocks Save

https://claude.ai/code/session_01AEQ8Ykz3jfAn5XVHqMizyY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEQ8Ykz3jfAn5XVHqMizyY)_