### PR TITLE
Remove standalone Profile button from tenant top navbar

### DIFF
--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -29,7 +29,7 @@ import { GlobalQuickAdd } from '@/components/global-quick-add'
 import { StaffMobileSettings } from '@/components/staff-mobile-settings'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { CalendarDays, User } from 'lucide-react'
+import { CalendarDays } from 'lucide-react'
 
 const getTenantRow = cache(async (tenantId: string) => {
   const supabase = await createSupabaseServerClient()
@@ -156,29 +156,7 @@ export default async function TenantLayout({ children }: { children: React.React
                         </TooltipProvider>
                       </span>
                     )}
-                    {/* Profile link — all signed-in members, desktop */}
-                    {user && (
-                      <span className="hidden sm:inline-flex">
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="iconSm"
-                                aria-label={t('profile')}
-                                asChild
-                              >
-                                <Link href="/profile">
-                                  <User />
-                                </Link>
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>{t('profile')}</TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      </span>
-                    )}
-                    {/* Staff settings — mobile only, non-editors */}
+                    {/* Staff settings drawer — non-editors, all breakpoints */}
                     {!editor && user && <StaffMobileSettings />}
                     <span className="hidden sm:inline-flex">
                       <NotificationBell initialCount={unreadCount} />

--- a/components/staff-mobile-settings.tsx
+++ b/components/staff-mobile-settings.tsx
@@ -36,7 +36,7 @@ export function StaffMobileSettings() {
   }
 
   return (
-    <span className="sm:hidden">
+    <span>
       <Drawer>
         <DrawerTrigger asChild>
           <Button variant="ghost" size="iconSm" aria-label={t('settings')}>


### PR DESCRIPTION
## Summary
- Removes the standalone Profile icon button from the top navbar (was shown to all signed-in members on desktop)
- Extends `StaffMobileSettings` drawer to render on all breakpoints (removes `sm:hidden`) so staff on desktop can still reach `/profile` via the settings drawer
- Editors continue to access profile via `SettingsDropdown` (unchanged)
- Drops unused `User` icon import from `layout.tsx`

## Test plan
- [ ] Top navbar no longer shows a Profile button on any breakpoint
- [ ] Editor on desktop: Settings dropdown still contains My Profile link
- [ ] Staff on desktop: Settings gear icon opens drawer with Profile entry
- [ ] Staff on mobile: same drawer still works as before

Closes #252

https://claude.ai/code/session_01W5kWLN7SZz4yetFRnx5bea

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5kWLN7SZz4yetFRnx5bea)_