### PR TITLE
fix(stats): show item count as primary, covers as secondary (#266)

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -361,11 +361,18 @@ function DayViewEditor({
               aria-expanded={openBlocks.has('breakfast')}
             >
               <p className="text-4xl leading-none font-bold tabular-nums">
-                {breakfastConfigs.reduce((s, b) => s + b.total_guests, 0)}
+                {breakfastConfigs.length}
               </p>
               <p className="text-muted-foreground mt-2 text-xs leading-tight">
                 {tsummary('breakfast')}
               </p>
+              {breakfastConfigs.reduce((s, b) => s + b.total_guests, 0) > 0 && (
+                <p className="text-muted-foreground mt-0.5 text-xs leading-tight">
+                  {tsummary('coversShort', {
+                    count: breakfastConfigs.reduce((s, b) => s + b.total_guests, 0),
+                  })}
+                </p>
+              )}
             </button>
           )}
           {/* eslint-disable-next-line no-restricted-syntax */}
@@ -374,9 +381,7 @@ function DayViewEditor({
             onClick={() => toggleBlock('activities')}
             aria-expanded={openBlocks.has('activities')}
           >
-            <p className="text-4xl leading-none font-bold tabular-nums">
-              {activities.reduce((s, a) => s + (a.expected_covers ?? 0), 0)}
-            </p>
+            <p className="text-4xl leading-none font-bold tabular-nums">{activities.length}</p>
             <p className="text-muted-foreground mt-2 text-xs leading-tight">
               {tsummary('activities')}
             </p>
@@ -388,12 +393,17 @@ function DayViewEditor({
               onClick={() => toggleBlock('reservations')}
               aria-expanded={openBlocks.has('reservations')}
             >
-              <p className="text-4xl leading-none font-bold tabular-nums">
-                {reservations.reduce((s, r) => s + (r.guest_count ?? 0), 0)}
-              </p>
+              <p className="text-4xl leading-none font-bold tabular-nums">{reservations.length}</p>
               <p className="text-muted-foreground mt-2 text-xs leading-tight">
                 {tsummary('reservations')}
               </p>
+              {reservations.reduce((s, r) => s + (r.guest_count ?? 0), 0) > 0 && (
+                <p className="text-muted-foreground mt-0.5 text-xs leading-tight">
+                  {tsummary('coversShort', {
+                    count: reservations.reduce((s, r) => s + (r.guest_count ?? 0), 0),
+                  })}
+                </p>
+              )}
             </button>
           )}
         </div>

--- a/app/actions/agenda.ts
+++ b/app/actions/agenda.ts
@@ -44,7 +44,7 @@ export async function getDaySummaries(
     supabase.from('reservation').select('day_id').eq('tenant_id', tenantId).in('day_id', dayIds),
     supabase
       .from('breakfast_configuration')
-      .select('breakfast_date,total_guests')
+      .select('breakfast_date')
       .eq('tenant_id', tenantId)
       .gte('breakfast_date', start)
       .lte('breakfast_date', end),
@@ -78,7 +78,7 @@ export async function getDaySummaries(
 
   for (const item of breakfastRes.data ?? []) {
     const s = summaryMap.get((item as { breakfast_date: string }).breakfast_date)
-    if (s) s.breakfastCount += (item as { total_guests: number }).total_guests
+    if (s) s.breakfastCount++
   }
 
   const summaries = [...summaryMap.values()].sort((a, b) => a.date.localeCompare(b.date))

--- a/components/AgendaView.tsx
+++ b/components/AgendaView.tsx
@@ -213,7 +213,7 @@ function AgendaDayRow({
   if (showReservations && summary.reservationCount > 0)
     countParts.push(ts('reservationCount', { count: summary.reservationCount }))
   if (showBreakfast && summary.breakfastCount > 0)
-    countParts.push(ts('breakfastCoverCount', { count: summary.breakfastCount }))
+    countParts.push(ts('breakfastCount', { count: summary.breakfastCount }))
 
   return (
     <>
@@ -396,7 +396,7 @@ function AgendaDayRow({
                     : prev
                 )
                 onSummaryChanged({
-                  breakfastCount: summary.breakfastCount + item.total_guests,
+                  breakfastCount: summary.breakfastCount + 1,
                 })
               }}
             />

--- a/components/CalendarDaySidebar.tsx
+++ b/components/CalendarDaySidebar.tsx
@@ -123,8 +123,7 @@ export function CalendarDaySidebar({ date, onClose, onSummaryChanged }: Props) {
         ? data.breakfastConfigs.map((c) => (c.id === config.id ? config : c))
         : [...data.breakfastConfigs, config]
     setData({ ...data, breakfastConfigs: updated })
-    const totalGuests = updated.reduce((s, c) => s + c.total_guests, 0)
-    onSummaryChanged(date, { breakfastCount: totalGuests })
+    onSummaryChanged(date, { breakfastCount: updated.length })
   }
 
   const formattedDate = format(parseISO(date), 'EEEE d MMMM')

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -313,7 +313,7 @@ const CalendarDayCell = memo(function CalendarDayCell({
             ? `${summary.reservationCount} reservations`
             : '',
           showBreakfast && summary.breakfastCount > 0
-            ? `${summary.breakfastCount} breakfast covers`
+            ? `${summary.breakfastCount} ${summary.breakfastCount === 1 ? 'breakfast' : 'breakfasts'}`
             : '',
         ].filter(Boolean)
       : []),

--- a/messages/de.json
+++ b/messages/de.json
@@ -235,7 +235,8 @@
     "summary": {
       "breakfast": "Frühstücke",
       "activities": "Aktivitäten",
-      "reservations": "Reservierungen"
+      "reservations": "Reservierungen",
+      "coversShort": "{count} Covers"
     },
     "sidebar": {
       "selectedDay": "Ausgewählter Tag",
@@ -252,7 +253,8 @@
       "reservationCount": "{count, plural, one {# Reservierung} other {# Reservierungen}}",
       "breakfastCoverCount": "{count, plural, one {# Frühstücksgedeck} other {# Frühstücksgedecke}}",
       "loading": "Laden…",
-      "close": "Schließen"
+      "close": "Schließen",
+      "breakfastCount": "{count, plural, one {# Frühstück} other {# Frühstücke}}"
     },
     "entry": {
       "deleteTitle": "Aktivität löschen?",

--- a/messages/en.json
+++ b/messages/en.json
@@ -366,7 +366,8 @@
     "summary": {
       "breakfast": "Breakfasts",
       "activities": "Activities",
-      "reservations": "Reservations"
+      "reservations": "Reservations",
+      "coversShort": "{count} covers"
     },
     "sidebar": {
       "selectedDay": "Selected day",
@@ -382,6 +383,7 @@
       "activityCount": "{count, plural, one {# activity} other {# activities}}",
       "reservationCount": "{count, plural, one {# reservation} other {# reservations}}",
       "breakfastCoverCount": "{count, plural, one {# breakfast cover} other {# breakfast covers}}",
+      "breakfastCount": "{count, plural, one {# breakfast} other {# breakfasts}}",
       "loading": "Loading…",
       "close": "Close"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -235,7 +235,8 @@
     "summary": {
       "breakfast": "Desayunos",
       "activities": "Actividades",
-      "reservations": "Reservas"
+      "reservations": "Reservas",
+      "coversShort": "{count} cubiertos"
     },
     "sidebar": {
       "selectedDay": "Día seleccionado",
@@ -252,7 +253,8 @@
       "reservationCount": "{count, plural, one {# reserva} other {# reservas}}",
       "breakfastCoverCount": "{count, plural, one {# cubierto de desayuno} other {# cubiertos de desayuno}}",
       "loading": "Cargando…",
-      "close": "Cerrar"
+      "close": "Cerrar",
+      "breakfastCount": "{count, plural, one {# desayuno} other {# desayunos}}"
     },
     "entry": {
       "deleteTitle": "¿Eliminar actividad?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -340,7 +340,8 @@
     "summary": {
       "breakfast": "Petits-déjeuners",
       "activities": "Activités",
-      "reservations": "Réservations"
+      "reservations": "Réservations",
+      "coversShort": "{count} couverts"
     },
     "sidebar": {
       "selectedDay": "Jour sélectionné",
@@ -357,7 +358,8 @@
       "reservationCount": "{count, plural, one {# réservation} other {# réservations}}",
       "breakfastCoverCount": "{count, plural, one {# couvert petit-déjeuner} other {# couverts petit-déjeuner}}",
       "loading": "Chargement…",
-      "close": "Fermer"
+      "close": "Fermer",
+      "breakfastCount": "{count, plural, one {# petit-déjeuner} other {# petits-déjeuners}}"
     },
     "entry": {
       "deleteTitle": "Supprimer l'activité ?",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Day-view stat cards now show item count as the big number (activities.length, reservations.length, breakfastConfigs.length) with a small "X covers" secondary line under reservations and breakfasts; activities drop the expected_covers sum entirely
- `breakfastCount` in `DaySummary` fixed to count configs (not sum `total_guests`) in the server action, `CalendarDaySidebar` mutation callbacks, and `AgendaView` optimistic increment
- `AgendaView` summary label changed from `breakfastCoverCount` → `breakfastCount`; `HomeClient` aria-label updated to say "N breakfasts" instead of "N breakfast covers"
- Added `Tenant.summary.coversShort` and `Tenant.sidebar.breakfastCount` translation keys to en/fr/de/es

## Test plan

- [ ] Open a day view with reservations and breakfasts — stat cards show count as large number, "X covers" beneath
- [ ] Activities stat card shows plain count (no covers number)
- [ ] Agenda view summary text shows "N breakfasts" (not "N breakfast covers")
- [ ] Calendar pips still display correctly
- [ ] Add a breakfast from the sidebar — breakfastCount increments by 1, not by guest count

Closes #266

https://claude.ai/code/session_01UxyD7bWKmg7qQ1fW3Zm74Q
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxyD7bWKmg7qQ1fW3Zm74Q)_