### PR TITLE
Move Add menu from day view to global navbar

### DIFF
--- a/app/[tenant]/day/[date]/DayViewClient.tsx
+++ b/app/[tenant]/day/[date]/DayViewClient.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { DayAddMenu } from '@/components/day-add-menu'
 import dynamic from 'next/dynamic'
 import { useSearchParams, usePathname, useRouter } from 'next/navigation'
 import { useDayRealtime } from './useDayRealtime'
@@ -184,29 +183,21 @@ function DayViewEditor({
   const [editBreakfast, setEditBreakfast] = useState<BreakfastConfiguration | null>(null)
 
   const returnFocusRef = useRef<HTMLElement | null>(null)
-  const addMenuRef = useRef<HTMLButtonElement>(null)
   const shiftAddTriggerRef = useRef<(() => void) | null>(null)
 
   const openAddActivity = useCallback(() => {
-    returnFocusRef.current = addMenuRef.current
     setEditActivity(null)
     setActivityModalOpen(true)
   }, [])
 
   const openAddReservation = useCallback(() => {
-    returnFocusRef.current = addMenuRef.current
     setEditReservation(null)
     setReservationModalOpen(true)
   }, [])
 
   const openAddBreakfast = useCallback(() => {
-    returnFocusRef.current = addMenuRef.current
     setEditBreakfast(null)
     setBreakfastModalOpen(true)
-  }, [])
-
-  const openAddShift = useCallback(() => {
-    shiftAddTriggerRef.current?.()
   }, [])
 
   function openEditActivity(item: ActivityWithRelations) {
@@ -323,13 +314,6 @@ function DayViewEditor({
     <div className="mx-auto max-w-3xl space-y-6 px-3 py-4 sm:px-6 sm:py-8">
       <div className="flex items-center justify-between gap-2">
         <DayNav date={date} today={today} />
-        <DayAddMenu
-          ref={addMenuRef}
-          onAddActivity={openAddActivity}
-          onAddReservation={showReservations ? openAddReservation : undefined}
-          onAddBreakfast={showBreakfast ? openAddBreakfast : undefined}
-          onAddShift={showStaffSchedule && shiftAssignees.length > 0 ? openAddShift : undefined}
-        />
       </div>
 
       {(showDailyBrief || showWeatherReporting) && (
@@ -489,7 +473,7 @@ function DayViewEditor({
         onClose={() => {
           setActivityModalOpen(false)
         }}
-        date={date}
+        defaultDate={date}
         dayId={dayId}
         pocs={pocs}
         venueTypes={venueTypes}

--- a/app/[tenant]/layout.tsx
+++ b/app/[tenant]/layout.tsx
@@ -26,6 +26,7 @@ import { getSuperadminImpersonationRole } from '@/lib/superadmin'
 import { getTenantPalette, getTenantThemeCssVariables } from '@/lib/theme/palettes'
 import { TenantKeyboardShell } from '@/components/tenant-keyboard-shell'
 import { GlobalQuickAdd } from '@/components/global-quick-add'
+import { GlobalAddMenu } from '@/components/global-add-menu'
 import { StaffMobileSettings } from '@/components/staff-mobile-settings'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -128,6 +129,12 @@ export default async function TenantLayout({ children }: { children: React.React
                     <OfflineStatusPill />
                     {/* AI quick-add — editors only */}
                     {editor && <GlobalQuickAdd />}
+                    {/* Global add menu — editors only */}
+                    {editor && (
+                      <span className="hidden sm:inline-flex">
+                        <GlobalAddMenu />
+                      </span>
+                    )}
                     {/* Settings dropdown — editors only, desktop */}
                     {editor && (
                       <span className="hidden sm:inline-flex">

--- a/components/AgendaView.tsx
+++ b/components/AgendaView.tsx
@@ -347,7 +347,7 @@ function AgendaDayRow({
           <ActivityForm
             isOpen={activityOpen}
             onClose={() => setActivityOpen(false)}
-            date={summary.date}
+            defaultDate={summary.date}
             dayId={summary.dayId}
             pocs={expandedData.pocs}
             venueTypes={expandedData.venueTypes}

--- a/components/CalendarDaySidebar.tsx
+++ b/components/CalendarDaySidebar.tsx
@@ -248,7 +248,7 @@ export function CalendarDaySidebar({ date, onClose, onSummaryChanged }: Props) {
           <ActivityForm
             isOpen={activityModalOpen}
             onClose={() => setActivityModalOpen(false)}
-            date={date}
+            defaultDate={date}
             dayId={data.dayId}
             pocs={data.pocs}
             venueTypes={data.venueTypes}

--- a/components/activity-form.tsx
+++ b/components/activity-form.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from 'next-intl'
 import { createPOC } from '@/app/actions/poc'
 import { createVenueType } from '@/app/actions/venue-type'
 import { createActivityTag, getAllActivityTags } from '@/app/actions/activity-tags'
+import { ensureDayExists } from '@/app/actions/days'
 import { generateRecurrenceDates } from '@/lib/day-utils'
 import { filterAllergenCodes, type AllergenCode } from '@/lib/allergens'
 import type { QuickAddActivityFormDefaults, QuickAddGapId } from '@/lib/quick-add-types'
@@ -50,6 +51,7 @@ import {
 const formSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z.string().optional(),
+  date: z.string().optional(),
   startTime: z.string().optional(),
   endTime: z.string().optional(),
   expectedCovers: z.string().optional(),
@@ -93,10 +95,12 @@ export type ActivityQuickAddSeed = {
 type Props = {
   isOpen: boolean
   onClose: () => void
-  date: string
-  dayId: string
-  pocs: PointOfContact[]
-  venueTypes: VenueType[]
+  /** Pre-filled date (from day view). When absent, a date picker is shown. */
+  defaultDate?: string
+  /** If provided, skips the date field and ensureDayExists call. */
+  dayId?: string
+  pocs?: PointOfContact[]
+  venueTypes?: VenueType[]
   editItem?: ActivityWithRelations | null
   onSuccess: (item: Activity) => void
   returnFocusRef?: RefObject<HTMLElement | null>
@@ -111,10 +115,10 @@ type Props = {
 export function ActivityForm({
   isOpen,
   onClose,
-  date,
-  dayId,
-  pocs: initialPocs,
-  venueTypes: initialVenueTypes,
+  defaultDate,
+  dayId: dayIdProp,
+  pocs: initialPocs = [],
+  venueTypes: initialVenueTypes = [],
   editItem,
   onSuccess,
   returnFocusRef,
@@ -248,10 +252,13 @@ export function ActivityForm({
   const qaRing = (field: QuickAddGapId) =>
     qaGapFieldKeys?.has(field) ? 'rounded-md ring-2 ring-amber-500/40 p-0.5 -m-0.5' : ''
 
+  const watchDate = watch('date')
+  const effectiveDate = defaultDate ?? watchDate ?? ''
+
   const occurrenceCount = useMemo(() => {
-    if (!watchIsRecurring || !watchFrequency) return 0
-    return Math.min(52, 1 + generateRecurrenceDates(date, watchFrequency).length)
-  }, [date, watchIsRecurring, watchFrequency])
+    if (!watchIsRecurring || !watchFrequency || !effectiveDate) return 0
+    return Math.min(52, 1 + generateRecurrenceDates(effectiveDate, watchFrequency).length)
+  }, [effectiveDate, watchIsRecurring, watchFrequency])
 
   function handleSavePoc() {
     if (!newPocName.trim()) return
@@ -289,9 +296,24 @@ export function ActivityForm({
 
   function onSubmit(data: FormData) {
     startTransition(async () => {
+      let resolvedDayId = dayIdProp
+      if (!resolvedDayId) {
+        if (!data.date) {
+          toast.error(t('dateRequired'))
+          return
+        }
+        const dayResult = await ensureDayExists(data.date)
+        if (!dayResult.success) {
+          toast.error(dayResult.error)
+          return
+        }
+        resolvedDayId = dayResult.data.id
+      }
+      const finalDayId = resolvedDayId as string
+
       const payload = {
         title: data.title,
-        dayId,
+        dayId: finalDayId,
         description: data.description || undefined,
         startTime: data.startTime || undefined,
         endTime: data.endTime || undefined,
@@ -309,7 +331,7 @@ export function ActivityForm({
         entity: 'activities',
         operation: isEditing ? 'update' : 'create',
         tenantSlug,
-        dayId,
+        dayId: finalDayId,
         payload: isEditing ? { ...payload, id: editItem!.id } : payload,
       })
 
@@ -322,7 +344,7 @@ export function ActivityForm({
         onSuccess({
           id: `pending-${result.clientMutationId}`,
           tenant_id: '',
-          day_id: dayId,
+          day_id: finalDayId,
           title: payload.title,
           description: payload.description ?? null,
           start_time: payload.startTime ?? null,
@@ -362,6 +384,13 @@ export function ActivityForm({
 
   const formBody = (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-testid="activity-form">
+      {/* Date — only shown when no dayId is pre-resolved (global add mode) */}
+      {!dayIdProp && (
+        <div className="space-y-1">
+          <Label htmlFor="af-date">{t('dateLabel')} *</Label>
+          <Input id="af-date" type="date" {...register('date')} data-testid="activity-form-date" />
+        </div>
+      )}
       {/* Title */}
       <div className={cn('space-y-1', qaRing('title'))}>
         <Label htmlFor="af-title">{t('titleLabel')} *</Label>
@@ -803,6 +832,7 @@ function defaultValues(editItem?: ActivityWithRelations | null): FormData {
     return {
       title: '',
       description: '',
+      date: '',
       startTime: '',
       endTime: '',
       expectedCovers: '',
@@ -816,6 +846,7 @@ function defaultValues(editItem?: ActivityWithRelations | null): FormData {
   return {
     title: editItem.title,
     description: editItem.description ?? '',
+    date: '',
     startTime: editItem.start_time ?? '',
     endTime: editItem.end_time ?? '',
     expectedCovers: editItem.expected_covers != null ? String(editItem.expected_covers) : '',

--- a/components/breakfast-form.tsx
+++ b/components/breakfast-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useTransition, type RefObject } from 'react'
+import { ensureDayExists } from '@/app/actions/days'
 import { useForm } from 'react-hook-form'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { z } from 'zod'
@@ -29,6 +30,7 @@ import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/u
 const formSchema = z.object({
   groupName: z.string().optional(),
   guestCount: z.string().optional(),
+  date: z.string().optional(),
   startTime: z.string().optional(),
   notes: z.string().optional(),
 })
@@ -61,7 +63,8 @@ export type BreakfastQuickAdd = {
 type Props = {
   isOpen: boolean
   onClose: () => void
-  dayId: string
+  /** If provided, skips the date field and ensureDayExists call. */
+  dayId?: string
   editItem?: BreakfastConfiguration | null
   onSuccess: (config: BreakfastConfiguration) => void
   returnFocusRef?: RefObject<HTMLElement | null>
@@ -75,7 +78,7 @@ type Props = {
 export function BreakfastForm({
   isOpen,
   onClose,
-  dayId,
+  dayId: dayIdProp,
   editItem,
   onSuccess,
   returnFocusRef,
@@ -141,10 +144,25 @@ export function BreakfastForm({
 
   function onSubmit(data: FormData) {
     startTransition(async () => {
+      let resolvedDayId = dayIdProp
+      if (!resolvedDayId) {
+        if (!data.date) {
+          toast.error(t('dateRequired'))
+          return
+        }
+        const dayResult = await ensureDayExists(data.date)
+        if (!dayResult.success) {
+          toast.error(dayResult.error)
+          return
+        }
+        resolvedDayId = dayResult.data.id
+      }
+      const finalDayId = resolvedDayId as string
+
       const guestCount = data.guestCount ? parseInt(data.guestCount, 10) : undefined
 
       const payload = {
-        dayId,
+        dayId: finalDayId,
         groupName: data.groupName || undefined,
         guestCount,
         tableBreakdown: tableBreakdown.length > 0 ? tableBreakdown : undefined,
@@ -156,7 +174,7 @@ export function BreakfastForm({
         entity: 'breakfast',
         operation: isEditing ? 'update' : 'create',
         tenantSlug,
-        dayId,
+        dayId: finalDayId,
         payload: isEditing ? { ...payload, id: editItem!.id } : payload,
       })
 
@@ -169,7 +187,7 @@ export function BreakfastForm({
         onSuccess({
           id: `pending-${result.clientMutationId}`,
           tenant_id: '',
-          day_id: dayId,
+          day_id: finalDayId,
           breakfast_date: '',
           group_name: payload.groupName ?? null,
           table_breakdown: payload.tableBreakdown ?? null,
@@ -209,6 +227,12 @@ export function BreakfastForm({
 
   const formBody = (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-testid="breakfast-form">
+      {!dayIdProp && (
+        <div className="space-y-1">
+          <Label htmlFor="bf-date">{t('dateLabel')} *</Label>
+          <Input id="bf-date" type="date" {...register('date')} data-testid="breakfast-form-date" />
+        </div>
+      )}
       <div className={cn('space-y-1', qaRing('groupName'))}>
         <Label htmlFor="bf-group">{t('groupNameLabel')}</Label>
         <Input
@@ -316,10 +340,11 @@ export function BreakfastForm({
 // ---------------------------------------------------------------------------
 
 function defaultValues(editItem?: BreakfastConfiguration | null): FormData {
-  if (!editItem) return { groupName: '', guestCount: '', startTime: '', notes: '' }
+  if (!editItem) return { groupName: '', guestCount: '', date: '', startTime: '', notes: '' }
   return {
     groupName: editItem.group_name ?? '',
     guestCount: editItem.total_guests > 0 ? String(editItem.total_guests) : '',
+    date: '',
     startTime: editItem.start_time ?? '',
     notes: editItem.notes ?? '',
   }

--- a/components/day-add-menu.tsx
+++ b/components/day-add-menu.tsx
@@ -32,6 +32,7 @@ type Props = {
   onAddReservation?: (() => void) | undefined
   onAddBreakfast?: (() => void) | undefined
   onAddShift?: (() => void) | undefined
+  'data-testid'?: string
 }
 
 export function DayAddMenu({
@@ -40,6 +41,7 @@ export function DayAddMenu({
   onAddReservation,
   onAddBreakfast,
   onAddShift,
+  'data-testid': testId = 'day-add-menu',
 }: Props) {
   const tDay = useTranslations('Tenant.day')
   const tStaff = useTranslations('Tenant.staff.section')
@@ -83,7 +85,7 @@ export function DayAddMenu({
     return (
       <Drawer open={open} onOpenChange={setOpen}>
         <DrawerTrigger asChild>
-          <Button ref={ref} size="sm" data-testid="day-add-menu">
+          <Button ref={ref} size="sm" data-testid={testId}>
             <Plus className="mr-1 h-4 w-4" />
             {tPoc('add')}
           </Button>
@@ -101,7 +103,7 @@ export function DayAddMenu({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button ref={ref} size="sm" data-testid="day-add-menu">
+        <Button ref={ref} size="sm" data-testid={testId}>
           <Plus className="mr-1 h-4 w-4" />
           {tPoc('add')}
         </Button>

--- a/components/global-add-menu.tsx
+++ b/components/global-add-menu.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState } from 'react'
+import dynamic from 'next/dynamic'
+import { useFeatureFlag } from '@/lib/feature-flags-context'
+import { DayAddMenu } from '@/components/day-add-menu'
+import { getAllPOCs } from '@/app/actions/poc'
+import { getAllVenueTypes } from '@/app/actions/venue-type'
+import type { PointOfContact, VenueType } from '@/types/index'
+
+const ActivityForm = dynamic(() => import('@/components/activity-form').then((m) => m.ActivityForm))
+const ReservationForm = dynamic(() =>
+  import('@/components/reservation-form').then((m) => m.ReservationForm)
+)
+const BreakfastForm = dynamic(() =>
+  import('@/components/breakfast-form').then((m) => m.BreakfastForm)
+)
+
+export function GlobalAddMenu() {
+  const showReservations = useFeatureFlag('reservations')
+  const showBreakfast = useFeatureFlag('breakfast_config')
+
+  const [activityOpen, setActivityOpen] = useState(false)
+  const [reservationOpen, setReservationOpen] = useState(false)
+  const [breakfastOpen, setBreakfastOpen] = useState(false)
+
+  const [pocs, setPocs] = useState<PointOfContact[]>([])
+  const [venueTypes, setVenueTypes] = useState<VenueType[]>([])
+
+  async function openActivity() {
+    const [pocsResult, vtResult] = await Promise.all([getAllPOCs(), getAllVenueTypes()])
+    if (pocsResult.success) setPocs(pocsResult.data)
+    if (vtResult.success) setVenueTypes(vtResult.data)
+    setActivityOpen(true)
+  }
+
+  return (
+    <>
+      <DayAddMenu
+        data-testid="global-add"
+        onAddActivity={openActivity}
+        onAddReservation={showReservations ? () => setReservationOpen(true) : undefined}
+        onAddBreakfast={showBreakfast ? () => setBreakfastOpen(true) : undefined}
+      />
+      {activityOpen && (
+        <ActivityForm
+          isOpen={activityOpen}
+          onClose={() => setActivityOpen(false)}
+          pocs={pocs}
+          venueTypes={venueTypes}
+          onSuccess={() => {}}
+        />
+      )}
+      {reservationOpen && (
+        <ReservationForm
+          isOpen={reservationOpen}
+          onClose={() => setReservationOpen(false)}
+          onSuccess={() => {}}
+        />
+      )}
+      {breakfastOpen && (
+        <BreakfastForm
+          isOpen={breakfastOpen}
+          onClose={() => setBreakfastOpen(false)}
+          onSuccess={() => {}}
+        />
+      )}
+    </>
+  )
+}

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -18,6 +18,7 @@ import { getVisibleSettingsRoutes } from '@/components/settings-dropdown'
 import { useFeatureFlag } from '@/lib/feature-flags-context'
 import { useKeyboardShortcuts } from '@/lib/keyboard-shortcuts'
 import { getUnreadCount } from '@/app/actions/notifications'
+import { GlobalAddMenu } from '@/components/global-add-menu'
 
 interface MobileNavProps {
   today: string
@@ -142,6 +143,11 @@ export function MobileNav({ today, isEditor, isMember, initialUnreadCount }: Mob
             <Sparkles className="h-5 w-5" aria-hidden="true" />
             {qaT('openButton')}
           </button>
+        )}
+        {isEditor && (
+          <div className="flex flex-1 items-center justify-center">
+            <GlobalAddMenu />
+          </div>
         )}
 
         {isEditor && (

--- a/components/reservation-form.tsx
+++ b/components/reservation-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useTransition, type RefObject } from 'react'
+import { ensureDayExists } from '@/app/actions/days'
 import { useForm } from 'react-hook-form'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { z } from 'zod'
@@ -29,6 +30,7 @@ import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/u
 const formSchema = z.object({
   guestName: z.string().optional(),
   guestCount: z.string().optional(),
+  date: z.string().optional(),
   startTime: z.string().optional(),
   endTime: z.string().optional(),
   notes: z.string().optional(),
@@ -65,7 +67,8 @@ export type ReservationQuickAdd =
 type Props = {
   isOpen: boolean
   onClose: () => void
-  dayId: string
+  /** If provided, skips the date field and ensureDayExists call. */
+  dayId?: string
   editItem?: Reservation | null
   onSuccess: (item: Reservation) => void
   returnFocusRef?: RefObject<HTMLElement | null>
@@ -79,7 +82,7 @@ type Props = {
 export function ReservationForm({
   isOpen,
   onClose,
-  dayId,
+  dayId: dayIdProp,
   editItem,
   onSuccess,
   returnFocusRef,
@@ -159,8 +162,23 @@ export function ReservationForm({
 
   function onSubmit(data: FormData) {
     startTransition(async () => {
+      let resolvedDayId = dayIdProp
+      if (!resolvedDayId) {
+        if (!data.date) {
+          toast.error(t('dateRequired'))
+          return
+        }
+        const dayResult = await ensureDayExists(data.date)
+        if (!dayResult.success) {
+          toast.error(dayResult.error)
+          return
+        }
+        resolvedDayId = dayResult.data.id
+      }
+      const finalDayId = resolvedDayId as string
+
       const payload = {
-        dayId,
+        dayId: finalDayId,
         guestName: data.guestName || undefined,
         guestCount: data.guestCount ? parseInt(data.guestCount, 10) : undefined,
         startTime: data.startTime || undefined,
@@ -174,7 +192,7 @@ export function ReservationForm({
         entity: 'reservations',
         operation: isEditing ? 'update' : 'create',
         tenantSlug,
-        dayId,
+        dayId: finalDayId,
         payload: isEditing ? { ...payload, id: editItem!.id } : payload,
       })
 
@@ -187,7 +205,7 @@ export function ReservationForm({
         const optimistic: Reservation = {
           id: `pending-${result.clientMutationId}`,
           tenant_id: '',
-          day_id: dayId,
+          day_id: finalDayId,
           guest_name: payload.guestName ?? null,
           guest_count: payload.guestCount ?? null,
           start_time: payload.startTime ?? null,
@@ -221,6 +239,17 @@ export function ReservationForm({
 
   const formBody = (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-testid="reservation-form">
+      {!dayIdProp && (
+        <div className="space-y-1">
+          <Label htmlFor="rf-date">{t('dateLabel')} *</Label>
+          <Input
+            id="rf-date"
+            type="date"
+            {...register('date')}
+            data-testid="reservation-form-date"
+          />
+        </div>
+      )}
       <div className={cn('space-y-1', qaRing('guestName'))}>
         <Label htmlFor="rf-name">{t('guestNameLabel')}</Label>
         <Input id="rf-name" {...register('guestName')} data-testid="reservation-form-guest-name" />
@@ -325,10 +354,12 @@ export function ReservationForm({
 // ---------------------------------------------------------------------------
 
 function defaultValues(editItem?: Reservation | null): FormData {
-  if (!editItem) return { guestName: '', guestCount: '', startTime: '', endTime: '', notes: '' }
+  if (!editItem)
+    return { guestName: '', guestCount: '', date: '', startTime: '', endTime: '', notes: '' }
   return {
     guestName: editItem.guest_name ?? '',
     guestCount: editItem.guest_count != null ? String(editItem.guest_count) : '',
+    date: '',
     startTime: editItem.start_time ?? '',
     endTime: editItem.end_time ?? '',
     notes: editItem.notes ?? '',

--- a/messages/en.json
+++ b/messages/en.json
@@ -465,7 +465,9 @@
       "venueTypeAdded": "Venue type added.",
       "namePlaceholder": "Name *",
       "emailPlaceholder": "Email (optional)",
-      "phonePlaceholder": "Phone (optional)"
+      "phonePlaceholder": "Phone (optional)",
+      "dateLabel": "Date",
+      "dateRequired": "Date is required"
     },
     "reservationForm": {
       "addTitle": "Add reservation",
@@ -480,7 +482,9 @@
       "save": "Save",
       "saving": "Saving…",
       "saved": "Reservation added.",
-      "updated": "Reservation updated."
+      "updated": "Reservation updated.",
+      "dateLabel": "Date",
+      "dateRequired": "Date is required"
     },
     "breakfastForm": {
       "addTitle": "Add breakfast",
@@ -496,7 +500,9 @@
       "save": "Save",
       "saving": "Saving…",
       "saved": "Breakfast added.",
-      "updated": "Breakfast updated."
+      "updated": "Breakfast updated.",
+      "dateLabel": "Date",
+      "dateRequired": "Date is required"
     },
     "tableBreakdown": {
       "emptyLabel": "Add tables to define the seating layout",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -439,7 +439,9 @@
       "venueTypeAdded": "Type de lieu ajouté.",
       "namePlaceholder": "Nom *",
       "emailPlaceholder": "E-mail (optionnel)",
-      "phonePlaceholder": "Téléphone (optionnel)"
+      "phonePlaceholder": "Téléphone (optionnel)",
+      "dateLabel": "Date",
+      "dateRequired": "La date est requise"
     },
     "reservationForm": {
       "addTitle": "Ajouter une réservation",
@@ -454,7 +456,9 @@
       "save": "Enregistrer",
       "saving": "Enregistrement…",
       "saved": "Réservation ajoutée.",
-      "updated": "Réservation mise à jour."
+      "updated": "Réservation mise à jour.",
+      "dateLabel": "Date",
+      "dateRequired": "La date est requise"
     },
     "breakfastForm": {
       "addTitle": "Ajouter un petit-déjeuner",
@@ -470,7 +474,9 @@
       "save": "Enregistrer",
       "saving": "Enregistrement…",
       "saved": "Petit-déjeuner ajouté.",
-      "updated": "Petit-déjeuner mis à jour."
+      "updated": "Petit-déjeuner mis à jour.",
+      "dateLabel": "Date",
+      "dateRequired": "La date est requise"
     },
     "tableBreakdown": {
       "emptyLabel": "Ajoutez des tables pour définir la disposition des places",

--- a/tests/components/activity-form.test.tsx
+++ b/tests/components/activity-form.test.tsx
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+
+vi.mock('@/lib/tenant-context', () => ({
+  useTenant: () => ({ tenantSlug: 'test-tenant', tenantId: 'tid' }),
+}))
+
+vi.mock('@/app/actions/activity-tags', () => ({
+  getAllActivityTags: vi.fn().mockResolvedValue({ success: true, data: [] }),
+  createActivityTag: vi.fn(),
+}))
+
+vi.mock('@/app/actions/poc', () => ({
+  createPOC: vi.fn(),
+}))
+
+vi.mock('@/app/actions/venue-type', () => ({
+  createVenueType: vi.fn(),
+}))
+
+vi.mock('@/app/actions/days', () => ({
+  ensureDayExists: vi.fn().mockResolvedValue({
+    success: true,
+    data: { id: 'resolved-day-id', date_iso: '2026-06-01', tenant_id: 'tid', weekday: 'monday' },
+  }),
+}))
+
+vi.mock('@/lib/day-mutation-client', () => ({
+  mutateWithOfflineQueue: vi.fn().mockResolvedValue({ success: true, data: { id: 'act-1' } }),
+}))
+
+const toastError = vi.fn()
+const toastSuccess = vi.fn()
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}))
+
+// Stub Radix Select to a native <select> for jsdom
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string
+    onValueChange?: (v: string) => void
+    children?: React.ReactNode
+  }) => (
+    <select value={value} onChange={(e) => onValueChange?.(e.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectItem: ({ value, children }: { value: string; children?: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}))
+
+// Stub Dialog/Drawer to render children directly
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children?: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DrawerContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DrawerHeader: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children?: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/allergen-multi-select', () => ({
+  AllergenMultiSelect: () => null,
+}))
+
+vi.mock('@/components/more-options-section', () => ({
+  MoreOptionsSection: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/switch', () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+  }: {
+    checked?: boolean
+    onCheckedChange?: (v: boolean) => void
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+    />
+  ),
+}))
+
+import { ActivityForm } from '@/components/activity-form'
+import { ensureDayExists } from '@/app/actions/days'
+import { mutateWithOfflineQueue } from '@/lib/day-mutation-client'
+
+const messages = {
+  Tenant: {
+    activityForm: {
+      addTitle: 'Add activity',
+      editTitle: 'Edit activity',
+      titleLabel: 'Title',
+      tagsLabel: 'Tags',
+      tagsPlaceholder: 'Select tags…',
+      addNewTag: 'Add new tag',
+      tagNamePlaceholder: 'Tag name',
+      dateLabel: 'Date',
+      dateRequired: 'Date is required',
+      startTimeLabel: 'Start time',
+      endTimeLabel: 'End time',
+      expectedCoversLabel: 'Expected covers',
+      venueTypeLabel: 'Venue type',
+      selectVenueType: 'Select venue type',
+      pocLabel: 'Point of contact',
+      selectPoc: 'Select point of contact',
+      addNew: 'Add new…',
+      newVenueType: 'New venue type',
+      newPoc: 'New point of contact',
+      notesLabel: 'Notes',
+      recurringLabel: 'Recurring',
+      selectFrequency: 'Select frequency',
+      weekly: 'Weekly',
+      biweekly: 'Bi-weekly',
+      monthly: 'Monthly',
+      yearly: 'Yearly',
+      occurrences: 'This will create {count} occurrences.',
+      cancel: 'Cancel',
+      save: 'Save',
+      saving: 'Saving…',
+      saved: 'Activity added.',
+      updated: 'Activity updated.',
+      pocAdded: 'Point of contact added.',
+      venueTypeAdded: 'Venue type added.',
+      namePlaceholder: 'Name *',
+      emailPlaceholder: 'Email (optional)',
+      phonePlaceholder: 'Phone (optional)',
+    },
+    allergens: {
+      label: 'Allergens',
+      moreOptions: 'More options',
+      placeholder: 'None',
+    },
+  },
+}
+
+function renderForm(props: Partial<React.ComponentProps<typeof ActivityForm>> = {}) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ActivityForm
+        isOpen
+        onClose={() => {}}
+        pocs={[]}
+        venueTypes={[]}
+        onSuccess={() => {}}
+        {...props}
+      />
+    </NextIntlClientProvider>
+  )
+}
+
+describe('ActivityForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a date field when no dayId is provided', () => {
+    renderForm()
+    expect(screen.getByTestId('activity-form-date')).toBeInTheDocument()
+  })
+
+  it('does not show a date field when dayId is provided', () => {
+    renderForm({ dayId: 'some-day-id', defaultDate: '2026-05-11' })
+    expect(screen.queryByTestId('activity-form-date')).not.toBeInTheDocument()
+  })
+
+  it('rejects submission without a date when no dayId is provided', async () => {
+    renderForm()
+    const titleInput = screen.getByTestId('activity-form-title')
+    fireEvent.change(titleInput, { target: { value: 'Morning Golf' } })
+
+    fireEvent.submit(screen.getByTestId('activity-form'))
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith('Date is required')
+    })
+    expect(ensureDayExists).not.toHaveBeenCalled()
+    expect(mutateWithOfflineQueue).not.toHaveBeenCalled()
+  })
+
+  it('calls ensureDayExists and submits when date is provided', async () => {
+    renderForm()
+    const titleInput = screen.getByTestId('activity-form-title')
+    fireEvent.change(titleInput, { target: { value: 'Morning Golf' } })
+
+    const dateInput = screen.getByTestId('activity-form-date')
+    fireEvent.change(dateInput, { target: { value: '2026-06-01' } })
+
+    fireEvent.submit(screen.getByTestId('activity-form'))
+
+    await waitFor(() => {
+      expect(ensureDayExists).toHaveBeenCalledWith('2026-06-01')
+    })
+    await waitFor(() => {
+      expect(mutateWithOfflineQueue).toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/components/activity-form.test.tsx
+++ b/tests/components/activity-form.test.tsx
@@ -2,6 +2,21 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { NextIntlClientProvider } from 'next-intl'
 
+// jsdom doesn't implement matchMedia; stub it so useIsMobile doesn't throw
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
 vi.mock('@/lib/tenant-context', () => ({
   useTenant: () => ({ tenantSlug: 'test-tenant', tenantId: 'tid' }),
 }))


### PR DESCRIPTION
## Summary

- Removes `DayAddMenu` from the day view header — the "+" no longer lives on individual day pages
- Adds `GlobalAddMenu` component (wraps `DayAddMenu` dropdown UI) mounted in the desktop navbar and mobile nav, gated on `isEditor`
- `ActivityForm`, `ReservationForm`, `BreakfastForm` now accept an optional `dayId`; when absent (global add mode) a required date picker is shown and `ensureDayExists` is called on submit to resolve the day row
- Day view forms continue to work exactly as before — `dayId` + `defaultDate` are passed from the page, date field is hidden
- `data-testid="global-add"` on the new navbar trigger; existing `add-activity`, `add-reservation`, `add-breakfast` testids preserved on dropdown items
- i18n: `dateLabel` + `dateRequired` keys added to `activityForm`, `reservationForm`, `breakfastForm` in `en.json` and `fr.json`
- Unit test verifying `ActivityForm` rejects submission without a date when no `dayId` is provided

## Test plan

- [ ] Sign in as an editor and verify the "+" button appears in desktop navbar and mobile nav
- [ ] Click "+", pick "Activity" — date field appears; submit without date shows error toast
- [ ] Pick a date, fill title, save — activity appears on that day
- [ ] Open a day view — no "+" button in the day header, day-level forms still open from card edit / hotkeys
- [ ] CI unit tests pass

Closes #269

https://claude.ai/code/session_01T26AzShceEkjxCQVvafWrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T26AzShceEkjxCQVvafWrJ)_